### PR TITLE
refactor: Rewrite `SignalAdapter` to use only public APIs

### DIFF
--- a/src/gwmock/signal/adapter.py
+++ b/src/gwmock/signal/adapter.py
@@ -6,14 +6,10 @@ from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
-from gwmock_signal import DetectorStrainStack, Network, resolve_simulator_backend
-from gwmock_signal.projection import project_polarizations_to_network
+from gwmock_signal import Network, resolve_simulator_backend
 
 from gwmock.data.time_series.time_series import TimeSeries
-from gwmock.detector.utils import (
-    DEFAULT_DETECTOR_BASE_PATH,
-    interferometer_config_to_custom_detector,
-)
+from gwmock.detector.utils import DEFAULT_DETECTOR_BASE_PATH
 
 _DEFAULT_WAVEFORM_MODEL = "IMRPhenomXPHM"
 
@@ -26,19 +22,21 @@ def _callable_waveform_registry_key(func: Callable[..., Any]) -> str:
 
 
 def _register_callable_waveform(backend: Any, registry_key: str, factory: Callable[..., Any]) -> None:
-    """Register *factory* under *registry_key* on the backend's internal ``WaveformFactory``."""
-    if hasattr(backend, "register_waveform_model"):
-        backend.register_waveform_model(registry_key, factory)
-        return
-    try:
-        waveform_factory = backend._waveform_factory
-    except AttributeError as exc:
-        msg = (
-            "Callable waveform_model is only supported when the resolved gwmock_signal "
-            "backend exposes _waveform_factory (e.g. CBCSimulator)."
-        )
-        raise TypeError(msg) from exc
-    waveform_factory.register_model(registry_key, factory)
+    """Register *factory* under *registry_key* through the public backend API."""
+    backend.register_waveform_model(registry_key, factory)
+
+
+def _resolve_detector_path(detector_spec: str) -> Path | None:
+    """Resolve a detector spec to an on-disk network file when one exists."""
+    detector_path = Path(detector_spec)
+    if detector_path.is_file():
+        return detector_path
+
+    bundled_path = DEFAULT_DETECTOR_BASE_PATH / detector_path
+    if bundled_path.is_file():
+        return bundled_path
+
+    return None
 
 
 class SignalAdapter:
@@ -57,7 +55,7 @@ class SignalAdapter:
 
         self._source_type = source_type
         self._backend = backend
-        self._network = Network.from_detectors(self._normalize_detector_specs(detector_specs))
+        self._network = self._resolve_detector_network(detector_specs)
         self._detector_names = tuple(
             detector if isinstance(detector, str) else detector.name for detector in self._network.detector_names
         )
@@ -116,15 +114,20 @@ class SignalAdapter:
         return backend_class(waveform_model=waveform_model)
 
     @staticmethod
-    def _normalize_detector_specs(detector_specs: Sequence[str]) -> tuple[str | Any, ...]:
-        normalized_specs: list[str | Any] = []
+    def _resolve_detector_network(detector_specs: Sequence[str]) -> Network:
+        resolved_detectors: list[str | Any] = []
         for detector_spec in detector_specs:
-            detector_path = Path(detector_spec)
-            if detector_path.is_file() or (DEFAULT_DETECTOR_BASE_PATH / detector_path).is_file():
-                normalized_specs.append(interferometer_config_to_custom_detector(detector_spec))
-            else:
-                normalized_specs.append(str(detector_spec))
-        return tuple(normalized_specs)
+            detector_path = _resolve_detector_path(str(detector_spec))
+            if detector_path is not None:
+                resolved_detectors.extend(Network.from_file(detector_path).detector_names)
+                continue
+
+            try:
+                resolved_detectors.extend(Network.from_name(str(detector_spec)).detector_names)
+            except ValueError:
+                resolved_detectors.append(str(detector_spec))
+
+        return Network.from_detectors(tuple(resolved_detectors))
 
     @property
     def source_type(self) -> str:
@@ -145,36 +148,16 @@ class SignalAdapter:
         waveform_arguments: Mapping[str, Any] | None = None,
         earth_rotation: bool = True,
     ) -> TimeSeries:
-        """Generate and project one signal chunk via public gwmock-signal APIs."""
+        """Generate one signal chunk via the public gwmock-signal ``simulate`` API."""
         backend_parameters = {**(waveform_arguments or {}), **dict(parameters)}
-        if hasattr(self._backend, "simulate"):
-            strain_stack = self._backend.simulate(
-                backend_parameters,
-                self._network.detector_names,
-                sampling_frequency=sampling_frequency,
-                minimum_frequency=minimum_frequency,
-                earth_rotation=earth_rotation,
-            )
-        elif hasattr(self._backend, "generate_polarizations"):
-            polarizations = self._backend.generate_polarizations(  # type: ignore[attr-defined]
-                backend_parameters,
-                sampling_frequency=sampling_frequency,
-                minimum_frequency=minimum_frequency,
-            )
-
-            projected = project_polarizations_to_network(
-                {"plus": polarizations[0], "cross": polarizations[1]},
-                self._network.detector_names,
-                right_ascension=backend_parameters["right_ascension"],
-                declination=backend_parameters["declination"],
-                polarization_angle=backend_parameters["polarization_angle"],
-                earth_rotation=earth_rotation,
-            )
-            strain_stack = DetectorStrainStack.from_mapping(self.detector_names, projected)
-        else:
-            raise TypeError(
-                "Resolved gwmock_signal backend does not expose simulate(...) or generate_polarizations(...)."
-            )
+        strain_stack = self._backend.simulate(
+            backend_parameters,
+            self._network.detector_names,
+            background=None,
+            sampling_frequency=sampling_frequency,
+            minimum_frequency=minimum_frequency,
+            earth_rotation=earth_rotation,
+        )
 
         return TimeSeries(
             data=strain_stack.data,

--- a/tests/signal/test_adapter.py
+++ b/tests/signal/test_adapter.py
@@ -19,7 +19,7 @@ class FakeBackend:
     def __init__(self, *, waveform_model: str) -> None:
         self.waveform_model = waveform_model
         self.required_params = frozenset({"coa_time"})
-        self.simulate_calls: list[tuple[dict, tuple[str, ...], float, float]] = []
+        self.simulate_calls: list[dict[str, object]] = []
 
     def register_waveform_model(self, name: str, factory) -> None:
         self.waveform_model = name
@@ -28,7 +28,7 @@ class FakeBackend:
     def simulate(
         self,
         params: dict,
-        detector_names: tuple[str, ...],
+        detector_names,
         background=None,
         *,
         sampling_frequency: float,
@@ -37,15 +37,25 @@ class FakeBackend:
         interpolate_if_offset: bool = True,
     ) -> DetectorStrainStack:
         """Record the call and return simple per-detector strains."""
-        _ = background, earth_rotation, interpolate_if_offset
-        self.simulate_calls.append((params, detector_names, sampling_frequency, minimum_frequency))
-        return DetectorStrainStack.from_mapping(
-            detector_names,
+        names = tuple(detector if isinstance(detector, str) else detector.name for detector in detector_names)
+        self.simulate_calls.append(
             {
-                detector: GWpyTimeSeries(
+                "params": params,
+                "detector_names": tuple(detector_names),
+                "background": background,
+                "sampling_frequency": sampling_frequency,
+                "minimum_frequency": minimum_frequency,
+                "earth_rotation": earth_rotation,
+                "interpolate_if_offset": interpolate_if_offset,
+            }
+        )
+        return DetectorStrainStack.from_mapping(
+            names,
+            {
+                name: GWpyTimeSeries(
                     [10.0 + index, 20.0 + index, 30.0 + index, 40.0 + index], t0=8.0, sample_rate=sampling_frequency
                 )
-                for index, detector in enumerate(detector_names)
+                for index, name in enumerate(names)
             },
         )
 
@@ -61,10 +71,10 @@ class TestSignalAdapter:
     """Test the gwmock-side signal adapter."""
 
     def test_from_source_type_merges_fixed_waveform_arguments(self):
-        """The adapter should resolve the backend via source_type and merge fixed waveform args into params."""
+        """The adapter should merge waveform args and call the public backend ``simulate``."""
         reference_frequency = 50.0
         detector_frame_mass_1 = 30.0
-        projected = {
+        expected = {
             "H1": [10.0, 20.0, 30.0, 40.0],
             "L1": [11.0, 21.0, 31.0, 41.0],
         }
@@ -96,24 +106,32 @@ class TestSignalAdapter:
 
         backend = adapter._backend
         assert adapter.detector_names == ("H1", "L1")
-        assert backend.simulate_calls[0][0]["reference_frequency"] == reference_frequency
-        assert backend.simulate_calls[0][0]["detector_frame_mass_1"] == detector_frame_mass_1
+        assert backend.simulate_calls[0]["params"]["reference_frequency"] == reference_frequency
+        assert backend.simulate_calls[0]["params"]["detector_frame_mass_1"] == detector_frame_mass_1
+        assert backend.simulate_calls[0]["detector_names"] == ("H1", "L1")
+        assert backend.simulate_calls[0]["background"] is None
+        assert backend.simulate_calls[0]["sampling_frequency"] == 4.0
+        assert backend.simulate_calls[0]["minimum_frequency"] == 5.0
+        assert backend.simulate_calls[0]["earth_rotation"] is True
         assert strain.shape == (2, 4)
-        np.testing.assert_allclose(strain[0].value, projected["H1"])
+        np.testing.assert_allclose(strain[0].value, expected["H1"])
 
-    def test_from_source_type_converts_detector_config_files(self, tmp_path):
-        """Detector config paths should be converted into public gwmock_signal detector specs."""
+    def test_from_source_type_loads_detector_config_files_via_network_from_file(self, tmp_path):
+        """Detector config paths should be loaded through ``Network.from_file``."""
         config_path = tmp_path / "custom.interferometer"
         config_path.write_text("# dummy\n")
         sentinel_detector = SimpleNamespace(name="custom")
 
         with (
             patch("gwmock.signal.adapter.resolve_simulator_backend", return_value=FakeBackend),
-            patch("gwmock.signal.adapter.interferometer_config_to_custom_detector", return_value=sentinel_detector),
+            patch(
+                "gwmock.signal.adapter.Network.from_file",
+                return_value=SimpleNamespace(detector_names=(sentinel_detector,)),
+            ) as mock_from_file,
             patch(
                 "gwmock.signal.adapter.Network.from_detectors",
                 return_value=SimpleNamespace(detector_names=(sentinel_detector,)),
-            ) as mock_network,
+            ) as mock_from_detectors,
         ):
             adapter = SignalAdapter.from_source_type(
                 source_type="bbh",
@@ -122,17 +140,43 @@ class TestSignalAdapter:
             )
 
         assert adapter.detector_names == ("custom",)
-        mock_network.assert_called_once_with((sentinel_detector,))
+        mock_from_file.assert_called_once_with(config_path)
+        mock_from_detectors.assert_called_once_with((sentinel_detector,))
 
-    def test_from_source_type_callable_requires_waveform_factory(self):
-        """Backends without ``_waveform_factory`` cannot host a callable ``waveform_model``."""
+    def test_from_source_type_resolves_named_networks_via_public_network_api(self):
+        """Named detector presets should be resolved through ``Network.from_name``."""
+        sentinel_detector = SimpleNamespace(name="ET1_SARD")
+
+        with (
+            patch("gwmock.signal.adapter.resolve_simulator_backend", return_value=FakeBackend),
+            patch(
+                "gwmock.signal.adapter.Network.from_name",
+                return_value=SimpleNamespace(detector_names=(sentinel_detector,)),
+            ) as mock_from_name,
+            patch(
+                "gwmock.signal.adapter.Network.from_detectors",
+                return_value=SimpleNamespace(detector_names=(sentinel_detector,)),
+            ) as mock_from_detectors,
+        ):
+            adapter = SignalAdapter.from_source_type(
+                source_type="bbh",
+                waveform_model="IMRPhenomD",
+                detectors=["ET-Triangle-Sardinia"],
+            )
+
+        assert adapter.detector_names == ("ET1_SARD",)
+        mock_from_name.assert_called_once_with("ET-Triangle-Sardinia")
+        mock_from_detectors.assert_called_once_with((sentinel_detector,))
+
+    def test_from_source_type_callable_requires_public_waveform_registration(self):
+        """Backends without ``register_waveform_model`` cannot host a callable ``waveform_model``."""
 
         def _dummy(**_kwargs):
             return {"plus": None, "cross": None}
 
         with (
             patch("gwmock.signal.adapter.resolve_simulator_backend", return_value=NoRegistrationBackend),
-            pytest.raises(TypeError, match="Callable waveform_model"),
+            pytest.raises(AttributeError, match="register_waveform_model"),
         ):
             SignalAdapter.from_source_type(
                 source_type="bbh",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified detector resolution and network construction to use a unified public API and file-based detector loading.
  * Streamlined the simulation workflow to rely on a single backend interface.
  * Removed deprecated polarization branching and detector projection functionality.

* **Tests**
  * Expanded test coverage for detector configuration loading, network resolution, and callable waveform integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->