### PR TITLE
refactor: Rewrite `NoiseAdapter` to consume `open_stream`

### DIFF
--- a/docs/user-guide/reproducibility.md
+++ b/docs/user-guide/reproducibility.md
@@ -59,9 +59,12 @@ Consumers must reject unknown major versions.
 ```
 
 `config` stores the resolved configuration snapshot for that run.
-`segment_seeds` stores the deterministic per-segment seeds derived from the
-top-level `seed`. The subpackage `metadata` objects are preserved as JSON
-objects without gwmock rewriting their internal structure.
+`segment_seeds` stores the deterministic per-segment seeds that `gwmock` derives
+locally. Adapter-backed noise now consumes one shared
+`gwmock_noise.open_stream(...)` iterator per run, so the top-level `seed` is
+recorded once and noise continuation no longer appears as one derived seed per
+batch. The subpackage `metadata` objects are preserved as JSON objects without
+gwmock rewriting their internal structure.
 
 ## Reproducing a run
 

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -99,6 +100,9 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         self._active_noise_output_directory = Path("noise")
         self._active_noise_output_arguments: dict[str, Any] = {}
         self._active_overwrite = False
+        self._noise_stream: Iterator[dict[str, Any]] | None = None
+        self._noise_stream_position = 0
+        self._pending_noise_chunk: dict[str, Any] | None = None
 
         super().__init__(
             max_samples=max_samples,
@@ -208,7 +212,6 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
     def metadata(self) -> dict[str, Any]:
         """Return orchestration metadata for reproducibility."""
         signal_segment_seed = self._signal_segment_seed()
-        noise_segment_seed = self._noise_segment_seed()
         return {
             **super().metadata,
             "orchestration": {
@@ -229,7 +232,8 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                 },
                 "noise": {
                     "arguments": self.noise_arguments,
-                    "segment_seed": noise_segment_seed,
+                    "stream_seed": self._root_seed(),
+                    "state_model": "gwmock consumes one shared gwmock_noise.open_stream() iterator across batches.",
                 },
                 "segment_seeds": self.segment_seeds(),
             },
@@ -285,6 +289,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         """Advance to the next segment."""
         self.counter = cast(int, self.counter) + 1
         self.start_time += self.duration
+        self._pending_noise_chunk = None
 
     def signal_output_directory(self) -> Path:
         """Return the active signal output directory."""
@@ -301,16 +306,17 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
     def _run_noise_batch(self) -> SimulationResult:
         output_format = self._infer_noise_output_format(self.orchestration_config.noise.output.file_name)
         output_prefix = self._derive_noise_output_prefix(self.orchestration_config.noise.output.file_name)
-        channel_prefix = str(self._active_noise_output_arguments.pop("channel_prefix", "MOCK"))
-        gps_start = float(self._active_noise_output_arguments.pop("gps_start", float(self.start_time.value)))
-        if self._active_noise_output_arguments:
-            unsupported = ", ".join(sorted(self._active_noise_output_arguments))
+        output_arguments = dict(self._active_noise_output_arguments)
+        channel_prefix = str(output_arguments.pop("channel_prefix", "MOCK"))
+        gps_start = float(output_arguments.pop("gps_start", float(self.start_time.value)))
+        if output_arguments:
+            unsupported = ", ".join(sorted(output_arguments))
             raise ValueError(
                 "Noise orchestration output arguments only support channel_prefix and gps_start. "
                 f"Unsupported keys: {unsupported}."
             )
 
-        return self.noise_adapter.run(
+        config = self.noise_adapter.build_config(
             detectors=list(self.noise_arguments["detectors"]),
             duration=float(self.duration.value),
             sampling_frequency=float(self.sampling_frequency.value),
@@ -319,7 +325,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             output_format=output_format,
             gps_start=gps_start,
             channel_prefix=channel_prefix,
-            seed=self._noise_segment_seed(),
+            seed=self._root_seed(),
             psd_file=self.noise_arguments.get("psd_file"),
             psd_schedule=self.noise_arguments.get("psd_schedule"),
             psd_files=self.noise_arguments.get("psd_files"),
@@ -329,10 +335,20 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             spectral_lines=self.noise_arguments.get("spectral_lines"),
             glitches=self.noise_arguments.get("glitches"),
         )
+        if not self._active_overwrite:
+            existing = [path for path in self.noise_adapter.expected_output_paths(config=config) if path.exists()]
+            if existing:
+                raise FileExistsError(
+                    f"Noise adapter output(s) already exist: {', '.join(str(path) for path in existing)}. "
+                    "Use overwrite=True to overwrite them."
+                )
+
+        chunk = self._next_noise_chunk()
+        return self.noise_adapter.write_chunk(config=config, chunk=chunk)
 
     def segment_seeds(self) -> list[int]:
-        """Return the deterministic per-segment seeds used in the current batch."""
-        return [seed for seed in (self._signal_segment_seed(), self._noise_segment_seed()) if seed is not None]
+        """Return the deterministic per-segment seeds derived locally by gwmock."""
+        return [seed for seed in (self._signal_segment_seed(),) if seed is not None]
 
     def _root_seed(self) -> int | None:
         base_seed = self.noise_arguments.get("seed")
@@ -345,12 +361,6 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         if root_seed is None:
             return None
         return derive_seed(root_seed, "signal", int(self.counter))
-
-    def _noise_segment_seed(self) -> int | None:
-        root_seed = self._root_seed()
-        if root_seed is None:
-            return None
-        return derive_seed(root_seed, "noise", int(self.counter))
 
     def _infer_noise_output_format(self, file_name_template: str) -> Literal["npy", "gwf"]:
         suffix = Path(file_name_template).suffix.lower().lstrip(".")
@@ -372,3 +382,47 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             return base_output_directory / fallback_subdir
         configured_path = Path(configured_directory)
         return configured_path if configured_path.is_absolute() else base_output_directory / configured_path
+
+    def _next_noise_chunk(self) -> dict[str, Any]:
+        """Return the chunk for the current batch, reusing it across retries."""
+        if self._pending_noise_chunk is not None:
+            return self._pending_noise_chunk
+
+        self._ensure_noise_stream()
+        if self._noise_stream is None:
+            raise RuntimeError("Noise stream was not initialized.")
+        try:
+            self._pending_noise_chunk = next(self._noise_stream)
+        except StopIteration as error:
+            raise ValueError("Noise stream ended before all orchestration batches were generated.") from error
+        self._noise_stream_position += 1
+        return self._pending_noise_chunk
+
+    def _ensure_noise_stream(self) -> None:
+        """Open or realign the shared upstream noise stream to the current batch index."""
+        if self._noise_stream is not None and self._noise_stream_position == int(self.counter):
+            return
+
+        self._noise_stream = self.noise_adapter.open_stream(
+            chunk_duration=float(self.duration.value),
+            sampling_frequency=float(self.sampling_frequency.value),
+            detectors=list(self.noise_arguments["detectors"]),
+            seed=self._root_seed(),
+            psd_file=self.noise_arguments.get("psd_file"),
+            psd_schedule=self.noise_arguments.get("psd_schedule"),
+            psd_files=self.noise_arguments.get("psd_files"),
+            csd_files=self.noise_arguments.get("csd_files"),
+            low_frequency_cutoff=self.noise_arguments.get("low_frequency_cutoff", 2.0),
+            high_frequency_cutoff=self.noise_arguments.get("high_frequency_cutoff"),
+            spectral_lines=self.noise_arguments.get("spectral_lines"),
+            glitches=self.noise_arguments.get("glitches"),
+        )
+        self._noise_stream_position = 0
+        for _ in range(int(self.counter)):
+            try:
+                next(self._noise_stream)
+            except StopIteration as error:
+                raise ValueError(
+                    "Noise stream ended before the saved orchestration state could be restored."
+                ) from error
+            self._noise_stream_position += 1

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -53,6 +53,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
     """Compose population, signal, and noise adapters inside gwmock."""
 
     population_index = StateAttribute(0)
+    noise_stream_committed_count = StateAttribute(0)
 
     def __init__(  # noqa: PLR0913
         self,
@@ -287,6 +288,9 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
 
     def update_state(self) -> None:
         """Advance to the next segment."""
+        self.noise_stream_committed_count = max(
+            int(self.noise_stream_committed_count), int(self._noise_stream_position)
+        )
         self.counter = cast(int, self.counter) + 1
         self.start_time += self.duration
         self._pending_noise_chunk = None
@@ -344,7 +348,11 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                 )
 
         chunk = self._next_noise_chunk()
-        return self.noise_adapter.write_chunk(config=config, chunk=chunk)
+        result = self.noise_adapter.write_chunk(config=config, chunk=chunk)
+        self.noise_stream_committed_count = max(
+            int(self.noise_stream_committed_count), int(self._noise_stream_position)
+        )
+        return result
 
     def segment_seeds(self) -> list[int]:
         """Return the deterministic per-segment seeds derived locally by gwmock."""
@@ -400,7 +408,8 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
 
     def _ensure_noise_stream(self) -> None:
         """Open or realign the shared upstream noise stream to the current batch index."""
-        if self._noise_stream is not None and self._noise_stream_position == int(self.counter):
+        target_position = max(int(self.counter), int(self.noise_stream_committed_count))
+        if self._noise_stream is not None and self._noise_stream_position == target_position:
             return
 
         self._noise_stream = self.noise_adapter.open_stream(
@@ -418,7 +427,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             glitches=self.noise_arguments.get("glitches"),
         )
         self._noise_stream_position = 0
-        for _ in range(int(self.counter)):
+        for _ in range(target_position):
             try:
                 next(self._noise_stream)
             except StopIteration as error:

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -412,6 +412,13 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         if self._noise_stream is not None and self._noise_stream_position == target_position:
             return
 
+        if int(self.counter) > 0 and self._root_seed() is None:
+            raise ValueError(
+                "Cannot resume an unseeded noise stream from a non-zero batch index; "
+                "the upstream stream is non-deterministic without a seed."
+            )
+        self._pending_noise_chunk = None
+
         self._noise_stream = self.noise_adapter.open_stream(
             chunk_duration=float(self.duration.value),
             sampling_frequency=float(self.sampling_frequency.value),

--- a/src/gwmock/noise/__init__.py
+++ b/src/gwmock/noise/__init__.py
@@ -4,7 +4,7 @@ Noise models for gravitational wave detector simulations.
 
 from __future__ import annotations
 
-from gwmock.noise.adapter import NoiseAdapter, UpstreamNoiseSimulator
+from gwmock.noise.adapter import NoiseAdapter
 from gwmock.noise.base import NoiseSimulator
 from gwmock.noise.colored_noise import ColoredNoiseSimulator
 from gwmock.noise.correlated_noise import CorrelatedNoiseSimulator
@@ -14,5 +14,4 @@ __all__ = [
     "CorrelatedNoiseSimulator",
     "NoiseAdapter",
     "NoiseSimulator",
-    "UpstreamNoiseSimulator",
 ]

--- a/src/gwmock/noise/adapter.py
+++ b/src/gwmock/noise/adapter.py
@@ -2,27 +2,31 @@
 
 from __future__ import annotations
 
-import re
+from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 import numpy as np
 from gwmock_noise import (
+    AddLines,
     BaseNoiseSimulator,
+    ColoredNoiseSimulator,
+    CorrelatedNoiseSimulator,
     DefaultNoiseSimulator,
     FrameWriter,
+    InjectGlitches,
     NoiseConfig,
+    NoiseSimulator,
     OutputConfig,
     SimulationResult,
+    SpectralLineSimulator,
 )
-from gwmock_noise.simulators.protocol import NoiseSimulator
-
-from gwmock.cli.utils.template import expand_template_variables
-from gwmock.simulator.base import Simulator
-from gwmock.simulator.state import StateAttribute
+from gwmock_noise import (
+    open_stream as upstream_open_stream,
+)
 
 _SUPPORTED_OUTPUT_FORMATS = {"npy", "gwf"}
-_DETECTOR_PLACEHOLDER = re.compile(r"\{\{\s*detectors?\s*\}\}")
+_DETECTOR_PAIR_SIZE = 2
 
 
 def _coerce_path(value: str | Path | None) -> Path | None:
@@ -46,13 +50,26 @@ def _coerce_path_schedule(values: list[tuple[float, str | Path]] | None) -> list
     return [(offset, Path(path)) for offset, path in values]
 
 
-def _flatten_first(value: str | list[str] | list[list[str]]) -> str:
-    """Return the first scalar string from an expanded template value."""
-    while isinstance(value, list):
-        if not value:
-            raise ValueError("Template expansion produced an empty list; cannot derive a scalar string.")
-        value = value[0]
-    return value
+def _parse_csd_file_map(csd_files: dict[str, Path] | None) -> dict[tuple[str, str], Path]:
+    """Convert ``DET1-DET2`` mapping keys into detector-pair tuples."""
+    if not csd_files:
+        return {}
+
+    parsed: dict[tuple[str, str], Path] = {}
+    for pair_key, file_path in csd_files.items():
+        detectors = pair_key.split("-")
+        if len(detectors) != _DETECTOR_PAIR_SIZE or not all(detectors):
+            raise ValueError("csd_files keys must use the 'DET1-DET2' format.")
+
+        detector_a, detector_b = tuple(sorted(detectors))
+        if detector_a == detector_b:
+            raise ValueError("csd_files keys must reference two distinct detectors.")
+
+        normalized_key = (detector_a, detector_b)
+        if normalized_key in parsed:
+            raise ValueError(f"Duplicate CSD file mapping for detector pair {detector_a}-{detector_b}.")
+        parsed[normalized_key] = Path(file_path)
+    return parsed
 
 
 class NoiseAdapter:
@@ -67,11 +84,7 @@ class NoiseAdapter:
         """Build an adapter from a public gwmock-noise backend."""
         if backend is None:
             resolved_backend = DefaultNoiseSimulator()
-        elif isinstance(backend, BaseNoiseSimulator):
-            resolved_backend = backend
-        elif isinstance(backend, NoiseSimulator):
-            resolved_backend = _ProtocolNoiseBackendRunner(backend=backend)
-        elif callable(getattr(backend, "run", None)):
+        elif isinstance(backend, (BaseNoiseSimulator, NoiseSimulator)) or callable(getattr(backend, "run", None)):
             resolved_backend = backend
         else:
             raise TypeError("backend must satisfy BaseNoiseSimulator or NoiseSimulator.")
@@ -104,7 +117,101 @@ class NoiseAdapter:
         glitches: list[Any] | None = None,
     ) -> SimulationResult:
         """Run one noise batch through the public gwmock-noise boundary."""
-        config = NoiseConfig(
+        config = self.build_config(
+            detectors=detectors,
+            duration=duration,
+            sampling_frequency=sampling_frequency,
+            output_directory=output_directory,
+            output_prefix=output_prefix,
+            output_format=output_format,
+            gps_start=gps_start,
+            channel_prefix=channel_prefix,
+            seed=seed,
+            psd_file=psd_file,
+            psd_schedule=psd_schedule,
+            psd_files=psd_files,
+            csd_files=csd_files,
+            low_frequency_cutoff=low_frequency_cutoff,
+            high_frequency_cutoff=high_frequency_cutoff,
+            spectral_lines=spectral_lines,
+            glitches=glitches,
+        )
+        if callable(getattr(self._backend, "run", None)):
+            return self._backend.run(config)
+
+        if not isinstance(self._backend, NoiseSimulator):
+            raise TypeError("Noise backend must expose run() or satisfy the gwmock_noise NoiseSimulator protocol.")
+
+        chunk = self._backend.generate(
+            duration=duration,
+            sampling_frequency=sampling_frequency,
+            detectors=list(detectors),
+            seed=seed,
+        )
+        return self.write_chunk(config=config, chunk=chunk)
+
+    def open_stream(  # noqa: PLR0913
+        self,
+        *,
+        chunk_duration: float,
+        sampling_frequency: float,
+        detectors: Sequence[str],
+        seed: int | None = None,
+        psd_file: str | Path | None = None,
+        psd_schedule: list[tuple[float, str | Path]] | None = None,
+        psd_files: dict[str, str | Path] | None = None,
+        csd_files: dict[str, str | Path] | None = None,
+        low_frequency_cutoff: float = 2.0,
+        high_frequency_cutoff: float | None = None,
+        spectral_lines: list[Any] | None = None,
+        glitches: list[Any] | None = None,
+    ) -> Iterator[dict[str, np.ndarray]]:
+        """Open one stateful upstream stream and consume it chunk-by-chunk."""
+        simulator = self._resolve_stream_backend(
+            chunk_duration=chunk_duration,
+            sampling_frequency=sampling_frequency,
+            detectors=list(detectors),
+            seed=seed,
+            psd_file=psd_file,
+            psd_schedule=psd_schedule,
+            psd_files=psd_files,
+            csd_files=csd_files,
+            low_frequency_cutoff=low_frequency_cutoff,
+            high_frequency_cutoff=high_frequency_cutoff,
+            spectral_lines=spectral_lines,
+            glitches=glitches,
+        )
+        return upstream_open_stream(
+            simulator,
+            chunk_duration=chunk_duration,
+            sampling_frequency=sampling_frequency,
+            detectors=list(detectors),
+            seed=seed,
+        )
+
+    def build_config(  # noqa: PLR0913
+        self,
+        *,
+        detectors: Sequence[str],
+        duration: float,
+        sampling_frequency: float,
+        output_directory: str | Path,
+        output_prefix: str,
+        output_format: Literal["npy", "gwf"],
+        gps_start: float,
+        channel_prefix: str,
+        seed: int | None = None,
+        psd_file: str | Path | None = None,
+        psd_schedule: list[tuple[float, str | Path]] | None = None,
+        psd_files: dict[str, str | Path] | None = None,
+        csd_files: dict[str, str | Path] | None = None,
+        low_frequency_cutoff: float = 2.0,
+        high_frequency_cutoff: float | None = None,
+        spectral_lines: list[Any] | None = None,
+        glitches: list[Any] | None = None,
+    ) -> NoiseConfig:
+        """Construct the public gwmock-noise config model for one output chunk."""
+        return NoiseConfig(
             detectors=list(detectors),
             duration=duration,
             sampling_frequency=sampling_frequency,
@@ -125,257 +232,35 @@ class NoiseAdapter:
             spectral_lines=spectral_lines,
             glitches=glitches,
         )
-        return self._backend.run(config)
 
+    def expected_output_paths(self, *, config: NoiseConfig) -> list[Path]:
+        """Return the artifact paths gwmock will write for one chunk."""
+        if config.output.format == "npy":
+            return [
+                config.output.directory
+                / (f"{config.output.prefix}_{detector}.npy" if config.output.prefix else f"{detector}.npy")
+                for detector in config.detectors
+            ]
 
-class UpstreamNoiseSimulator(Simulator):
-    """Stateful gwmock wrapper around the public ``gwmock_noise`` run boundary."""
-
-    start_time = StateAttribute(0.0)
-
-    def __init__(  # noqa: PLR0913
-        self,
-        *,
-        duration: float = 4.0,
-        sampling_frequency: float = 4096.0,
-        detectors: list[str] | None = None,
-        start_time: float = 0.0,
-        max_samples: int | None = None,
-        seed: int | None = None,
-        psd_file: str | Path | None = None,
-        psd_schedule: list[tuple[float, str | Path]] | None = None,
-        psd_files: dict[str, str | Path] | None = None,
-        csd_files: dict[str, str | Path] | None = None,
-        low_frequency_cutoff: float = 2.0,
-        high_frequency_cutoff: float | None = None,
-        spectral_lines: list[Any] | None = None,
-        glitches: list[Any] | None = None,
-        output_directory: str | Path | None = None,
-        output_prefix: str | None = None,
-        output_format: Literal["npy", "gwf"] = "npy",
-        channel_prefix: str = "MOCK",
-        noise_adapter: NoiseAdapter | None = None,
-        noise_backend: BaseNoiseSimulator | None = None,
-        **kwargs,
-    ) -> None:
-        """Initialize the gwmock orchestration wrapper."""
-        if noise_adapter is not None and noise_backend is not None:
-            raise ValueError("Pass either noise_adapter or noise_backend, not both.")
-        if duration <= 0:
-            raise ValueError("duration must be positive.")
-        if sampling_frequency <= 0:
-            raise ValueError("sampling_frequency must be positive.")
-
-        super().__init__(max_samples=max_samples, **kwargs)
-
-        self.duration = duration
-        self.sampling_frequency = sampling_frequency
-        self.detectors = list(detectors) if detectors is not None else ["H1", "L1"]
-        self.start_time = float(start_time)
-        self.base_seed = seed
-        self.psd_file = _coerce_path(psd_file)
-        self.psd_schedule = _coerce_path_schedule(psd_schedule)
-        self.psd_files = _coerce_path_mapping(psd_files)
-        self.csd_files = _coerce_path_mapping(csd_files)
-        self.low_frequency_cutoff = low_frequency_cutoff
-        self.high_frequency_cutoff = high_frequency_cutoff
-        self.spectral_lines = spectral_lines
-        self.glitches = glitches
-        self.output_directory = _coerce_path(output_directory)
-        self.output_prefix = output_prefix
-        self.output_format = output_format
-        self.channel_prefix = channel_prefix
-        self.noise_adapter = noise_adapter if noise_adapter is not None else NoiseAdapter.from_backend(noise_backend)
-
-        self._active_output_directory = self.output_directory
-        self._active_output_prefix = output_prefix
-        self._active_output_format = output_format
-        self._active_channel_prefix = channel_prefix
-        self._active_overwrite = False
-        self._last_result: SimulationResult | None = None
-
-    @property
-    def metadata(self) -> dict[str, Any]:
-        """Return metadata describing the adapter-backed orchestration state."""
-        metadata = {
-            **super().metadata,
-            "noise": {
-                "arguments": {
-                    "duration": self.duration,
-                    "sampling_frequency": self.sampling_frequency,
-                    "detectors": self.detectors,
-                    "seed": self.base_seed,
-                    "psd_file": None if self.psd_file is None else str(self.psd_file),
-                    "psd_schedule": (
-                        None
-                        if self.psd_schedule is None
-                        else [(offset, str(path)) for offset, path in self.psd_schedule]
-                    ),
-                    "psd_files": None if self.psd_files is None else {k: str(v) for k, v in self.psd_files.items()},
-                    "csd_files": None if self.csd_files is None else {k: str(v) for k, v in self.csd_files.items()},
-                    "low_frequency_cutoff": self.low_frequency_cutoff,
-                    "high_frequency_cutoff": self.high_frequency_cutoff,
-                    "spectral_lines": self.spectral_lines,
-                    "glitches": self.glitches,
-                },
-                "output": {
-                    "directory": None if self._active_output_directory is None else str(self._active_output_directory),
-                    "prefix": self._active_output_prefix,
-                    "format": self._active_output_format,
-                    "channel_prefix": self._active_channel_prefix,
-                },
-                "state_model": (
-                    "gwmock tracks counter and gps_start locally; each batch reseeds gwmock_noise "
-                    "deterministically as base_seed + counter because BaseNoiseSimulator.run() is stateless."
-                ),
-            },
-        }
-        if self._last_result is not None:
-            metadata["noise"]["last_output_paths"] = {
-                detector: str(path) for detector, path in self._last_result.output_paths.items()
-            }
-        return metadata
-
-    def set_batch_context(self, *, batch: Any, output_directory: Path, overwrite: bool) -> None:
-        """Attach per-batch output settings before ``simulate()`` runs."""
-        output_config = batch.simulator_config.output
-        expanded_output_args = expand_template_variables(output_config.arguments or {}, self)
-
-        prefix = expanded_output_args.pop("prefix", None) or self.output_prefix
-        if prefix is None:
-            prefix = self._derive_output_prefix(output_config.file_name)
-
-        output_format = expanded_output_args.pop("format", None) or self._infer_output_format(output_config.file_name)
-        channel_prefix = expanded_output_args.pop("channel_prefix", self.channel_prefix)
-        gps_start = expanded_output_args.pop("gps_start", self.start_time)
-        if expanded_output_args:
-            unsupported = ", ".join(sorted(expanded_output_args))
-            raise ValueError(
-                "Noise adapter output arguments only support prefix, format, gps_start, and channel_prefix. "
-                f"Unsupported keys: {unsupported}."
-            )
-
-        self._active_output_directory = Path(output_directory)
-        self._active_output_prefix = str(prefix)
-        self._active_output_format = cast(Literal["npy", "gwf"], str(output_format))
-        self._active_channel_prefix = str(channel_prefix)
-        self._active_overwrite = overwrite
-        self.start_time = float(gps_start)
-
-    def simulate(self) -> SimulationResult:
-        """Generate one batch by delegating to the public gwmock-noise run API."""
-        if self._active_output_directory is None:
-            raise ValueError("Noise adapter batch context is missing an output directory.")
-        if self._active_output_prefix is None:
-            raise ValueError("Noise adapter batch context is missing an output prefix.")
-
-        expected_paths = self._expected_artifact_paths()
-        if not self._active_overwrite:
-            existing = [path for path in expected_paths if path.exists()]
-            if existing:
-                raise FileExistsError(
-                    f"Noise adapter output(s) already exist: {', '.join(str(path) for path in existing)}. "
-                    "Use overwrite=True to overwrite them."
-                )
-
-        result = self.noise_adapter.run(
-            detectors=self.detectors,
-            duration=self.duration,
-            sampling_frequency=self.sampling_frequency,
-            output_directory=self._active_output_directory,
-            output_prefix=self._active_output_prefix,
-            output_format=self._active_output_format,
-            gps_start=float(self.start_time),
-            channel_prefix=self._active_channel_prefix,
-            seed=self._segment_seed(),
-            psd_file=self.psd_file,
-            psd_schedule=self.psd_schedule,
-            psd_files=self.psd_files,
-            csd_files=self.csd_files,
-            low_frequency_cutoff=self.low_frequency_cutoff,
-            high_frequency_cutoff=self.high_frequency_cutoff,
-            spectral_lines=self.spectral_lines,
-            glitches=self.glitches,
+        writer = FrameWriter(
+            _ChunkNoiseSimulator({detector: np.zeros(1) for detector in config.detectors}),
+            gps_start=config.output.gps_start,
+            output_dir=config.output.directory,
+            channel_prefix=config.output.channel_prefix,
+            prefix=config.output.prefix,
         )
-        self._last_result = result
-        return result
+        return [
+            writer._frame_path(detector, writer._channel_name(detector), config.output.gps_start, config.duration)
+            for detector in config.detectors
+        ]
 
-    def update_state(self) -> None:
-        """Advance the gwmock-owned orchestration state to the next segment."""
-        self.counter = cast(int, self.counter) + 1
-        self.start_time += self.duration
-
-    def _save_data(self, data: Any, file_name: str | Path, **kwargs) -> None:
-        """The upstream adapter writes data itself; gwmock must not rewrite it."""
-        raise TypeError("UpstreamNoiseSimulator writes outputs through gwmock_noise and does not support save_data().")
-
-    def _segment_seed(self) -> int | None:
-        """Return the deterministic seed for the current batch."""
-        if self.base_seed is None:
-            return None
-        return int(self.base_seed) + int(self.counter)
-
-    def _infer_output_format(self, file_name_template: str) -> Literal["npy", "gwf"]:
-        """Infer the upstream output format from the template suffix or constructor default."""
-        suffix = Path(file_name_template).suffix.lower().lstrip(".")
-        if suffix in _SUPPORTED_OUTPUT_FORMATS:
-            return cast(Literal["npy", "gwf"], suffix)
-        if suffix and suffix not in _SUPPORTED_OUTPUT_FORMATS:
-            raise ValueError(
-                "Noise adapter output templates must use a .npy or .gwf suffix, or specify "
-                "`output.arguments.format` explicitly."
-            )
-        return self.output_format
-
-    def _derive_output_prefix(self, file_name_template: str) -> str:
-        """Derive an upstream prefix from the configured gwmock output template."""
-        template_without_detector = _DETECTOR_PLACEHOLDER.sub("", file_name_template)
-        expanded = expand_template_variables(str(Path(template_without_detector).with_suffix("")), self)
-        prefix = _flatten_first(expanded).strip("-_ ")
-        return prefix or f"noise-{self.counter}"
-
-    def _expected_artifact_paths(self) -> list[Path]:
-        """Return the detector artifacts and sidecars the upstream run will create."""
-        if self._active_output_directory is None or self._active_output_prefix is None:
-            return []
-
-        output_paths: list[Path] = []
-        start_token = self._format_time_token(float(self.start_time))
-        duration_token = self._format_time_token(self.duration)
-        for detector in self.detectors:
-            if self._active_output_format == "npy":
-                artifact = self._active_output_directory / f"{self._active_output_prefix}_{detector}.npy"
-            else:
-                # Match ``gwmock_noise.output.frame.FrameWriter._frame_path`` (GWF naming).
-                channel = f"{detector}:{self._active_channel_prefix}_NOISE"
-                artifact_name = f"{detector[0]}-{channel}_{start_token}-{duration_token}.gwf"
-                prefix = self._active_output_prefix
-                if prefix:
-                    artifact = self._active_output_directory / f"{prefix}_{artifact_name}"
-                else:
-                    artifact = self._active_output_directory / artifact_name
-            output_paths.append(artifact)
-            output_paths.append(self._active_output_directory / f"{self._active_output_prefix}_{detector}.json")
-        return output_paths
-
-    @staticmethod
-    def _format_time_token(value: float) -> str:
-        """Return the filename token used by the upstream frame writer."""
-        if float(value).is_integer():
-            return str(int(value))
-        return f"{value:.6f}".rstrip("0").rstrip(".").replace(".", "p")
-
-
-class _ProtocolNoiseBackendRunner(BaseNoiseSimulator):
-    """Adapt a protocol-style ``NoiseSimulator`` to ``BaseNoiseSimulator.run()``."""
-
-    def __init__(self, *, backend: NoiseSimulator) -> None:
-        self._backend = backend
-
-    def run(self, config: NoiseConfig) -> SimulationResult:
+    def write_chunk(self, *, config: NoiseConfig, chunk: Mapping[str, np.ndarray]) -> SimulationResult:
+        """Write one chunk returned by ``open_stream`` to gwmock-owned outputs."""
+        chunk_by_detector = self._normalize_chunk(chunk=chunk, detectors=config.detectors)
+        config.output.directory.mkdir(parents=True, exist_ok=True)
         if config.output.format == "gwf":
             output_paths = FrameWriter(
-                self._backend,
+                _ChunkNoiseSimulator(chunk_by_detector),
                 gps_start=config.output.gps_start,
                 output_dir=config.output.directory,
                 channel_prefix=config.output.channel_prefix,
@@ -384,27 +269,237 @@ class _ProtocolNoiseBackendRunner(BaseNoiseSimulator):
                 duration=config.duration,
                 sampling_frequency=config.sampling_frequency,
                 detectors=config.detectors,
-                seed=config.seed,
+                seed=None,
             )
         else:
-            output_paths = self._write_npy_outputs(config)
+            output_paths = {}
+            for detector, strain in chunk_by_detector.items():
+                file_name = f"{config.output.prefix}_{detector}.npy" if config.output.prefix else f"{detector}.npy"
+                output_path = config.output.directory / file_name
+                np.save(output_path, strain)
+                output_paths[detector] = output_path
         return SimulationResult(output_paths=output_paths, config=config)
 
-    def _write_npy_outputs(self, config: NoiseConfig) -> dict[str, Path]:
-        generated = self._backend.generate(
-            duration=config.duration,
-            sampling_frequency=config.sampling_frequency,
-            detectors=config.detectors,
-            seed=config.seed,
-        )
-        config.output.directory.mkdir(parents=True, exist_ok=True)
+    def _normalize_chunk(self, *, chunk: Mapping[str, np.ndarray], detectors: Sequence[str]) -> dict[str, np.ndarray]:
+        """Validate and normalize one upstream chunk."""
+        normalized: dict[str, np.ndarray] = {}
+        for detector in detectors:
+            if detector not in chunk:
+                raise ValueError(f"Noise stream did not produce detector '{detector}'.")
+            normalized[detector] = np.asarray(chunk[detector])
+        return normalized
 
-        output_paths: dict[str, Path] = {}
-        for detector in config.detectors:
-            if detector not in generated:
-                raise ValueError(f"Noise backend did not produce detector '{detector}'.")
-            file_name = f"{config.output.prefix}_{detector}.npy" if config.output.prefix else f"{detector}.npy"
-            output_path = config.output.directory / file_name
-            np.save(output_path, generated[detector])
-            output_paths[detector] = output_path
-        return output_paths
+    def _resolve_stream_backend(  # noqa: PLR0913
+        self,
+        *,
+        chunk_duration: float,
+        sampling_frequency: float,
+        detectors: list[str],
+        seed: int | None,
+        psd_file: str | Path | None,
+        psd_schedule: list[tuple[float, str | Path]] | None,
+        psd_files: dict[str, str | Path] | None,
+        csd_files: dict[str, str | Path] | None,
+        low_frequency_cutoff: float,
+        high_frequency_cutoff: float | None,
+        spectral_lines: list[Any] | None,
+        glitches: list[Any] | None,
+    ) -> NoiseSimulator:
+        """Return the protocol-compatible backend for ``open_stream``."""
+        if isinstance(self._backend, DefaultNoiseSimulator):
+            protocol_backend = self._configure_default_stream_backend(
+                chunk_duration=chunk_duration,
+                sampling_frequency=sampling_frequency,
+                detectors=detectors,
+                seed=seed,
+                psd_file=psd_file,
+                psd_schedule=psd_schedule,
+                psd_files=psd_files,
+                csd_files=csd_files,
+                low_frequency_cutoff=low_frequency_cutoff,
+                high_frequency_cutoff=high_frequency_cutoff,
+                spectral_lines=spectral_lines,
+                glitches=glitches,
+            )
+            if protocol_backend is not None:
+                return protocol_backend
+
+        if isinstance(self._backend, NoiseSimulator):
+            return self._backend
+
+        raise TypeError("Noise backend must satisfy the gwmock_noise NoiseSimulator protocol to open a stream.")
+
+    def _configure_default_stream_backend(  # noqa: PLR0913
+        self,
+        *,
+        chunk_duration: float,
+        sampling_frequency: float,
+        detectors: list[str],
+        seed: int | None,
+        psd_file: str | Path | None,
+        psd_schedule: list[tuple[float, str | Path]] | None,
+        psd_files: dict[str, str | Path] | None,
+        csd_files: dict[str, str | Path] | None,
+        low_frequency_cutoff: float,
+        high_frequency_cutoff: float | None,
+        spectral_lines: list[Any] | None,
+        glitches: list[Any] | None,
+    ) -> NoiseSimulator | None:
+        """Mirror the default gwmock-noise backend selection with protocol simulators."""
+        normalized_psd_files = _coerce_path_mapping(psd_files)
+        normalized_csd_files = _coerce_path_mapping(csd_files)
+        normalized_psd_schedule = _coerce_path_schedule(psd_schedule)
+        normalized_psd_file = _coerce_path(psd_file)
+
+        simulator: NoiseSimulator | None = None
+        if normalized_psd_files is not None or normalized_csd_files is not None:
+            simulator = CorrelatedNoiseSimulator(
+                psd_files=normalized_psd_files or {},
+                csd_files=_parse_csd_file_map(normalized_csd_files),
+                detectors=detectors,
+                duration=chunk_duration,
+                sampling_frequency=sampling_frequency,
+                seed=seed,
+                low_frequency_cutoff=low_frequency_cutoff,
+                high_frequency_cutoff=high_frequency_cutoff,
+            )
+        elif normalized_psd_file is not None or normalized_psd_schedule is not None:
+            simulator = ColoredNoiseSimulator(
+                psd_file=normalized_psd_file,
+                psd_schedule=normalized_psd_schedule,
+                detectors=detectors,
+                duration=chunk_duration,
+                sampling_frequency=sampling_frequency,
+                seed=seed,
+                low_frequency_cutoff=low_frequency_cutoff,
+                high_frequency_cutoff=high_frequency_cutoff,
+            )
+
+        if spectral_lines is not None:
+            if not spectral_lines:
+                raise ValueError("spectral_lines must contain at least one spectral line.")
+            simulator = (
+                SpectralLineSimulator(
+                    lines=spectral_lines,
+                    detectors=detectors,
+                    duration=chunk_duration,
+                    sampling_frequency=sampling_frequency,
+                    seed=seed,
+                )
+                if simulator is None
+                else AddLines(simulator, spectral_lines)
+            )
+
+        if glitches is not None:
+            if not glitches:
+                raise ValueError("glitches must contain at least one glitch model.")
+            if simulator is None:
+                simulator = _ZeroNoiseSimulator(
+                    detectors=detectors,
+                    duration=chunk_duration,
+                    sampling_frequency=sampling_frequency,
+                    seed=seed,
+                )
+            simulator = InjectGlitches(simulator, glitches)
+
+        return simulator
+
+
+class _ChunkNoiseSimulator:
+    """Protocol adapter that replays one already-generated chunk."""
+
+    def __init__(self, chunk: Mapping[str, np.ndarray]) -> None:
+        self._chunk = {detector: np.asarray(strain) for detector, strain in chunk.items()}
+        self.detectors = list(self._chunk)
+        self.duration = 0.0
+        self.sampling_frequency = 0.0
+        self.seed = None
+
+    def generate(
+        self,
+        duration: float,
+        sampling_frequency: float,
+        detectors: list[str],
+        seed: int | None = None,
+    ) -> dict[str, np.ndarray]:
+        """Return the stored chunk after validating the requested shape."""
+        _ = seed
+        expected_samples = round(duration * sampling_frequency)
+        generated: dict[str, np.ndarray] = {}
+        for detector in detectors:
+            if detector not in self._chunk:
+                raise ValueError(f"Noise stream did not produce detector '{detector}'.")
+            strain = self._chunk[detector]
+            if strain.shape[0] != expected_samples:
+                raise ValueError(
+                    f"Noise chunk for detector '{detector}' has {strain.shape[0]} samples; expected {expected_samples}."
+                )
+            generated[detector] = strain
+        self.detectors = list(detectors)
+        self.duration = duration
+        self.sampling_frequency = sampling_frequency
+        return generated
+
+    def generate_stream(
+        self,
+        chunk_duration: float,
+        sampling_frequency: float,
+        detectors: list[str],
+        seed: int | None = None,
+    ) -> Iterator[dict[str, np.ndarray]]:
+        """Yield the stored chunk once."""
+        yield self.generate(chunk_duration, sampling_frequency, detectors, seed)
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Return adapter metadata layered on the chunk replay backend."""
+        return {"adapter": "chunk-replay"}
+
+
+class _ZeroNoiseSimulator:
+    """Protocol-compatible zero-noise backend used for glitches-only streams."""
+
+    def __init__(
+        self,
+        *,
+        detectors: list[str],
+        duration: float,
+        sampling_frequency: float,
+        seed: int | None,
+    ) -> None:
+        self.detectors = list(detectors)
+        self.duration = duration
+        self.sampling_frequency = sampling_frequency
+        self.seed = seed
+
+    def generate(
+        self,
+        duration: float,
+        sampling_frequency: float,
+        detectors: list[str],
+        seed: int | None = None,
+    ) -> dict[str, np.ndarray]:
+        """Return zeros with the requested runtime shape."""
+        _ = seed
+        n_samples = round(duration * sampling_frequency)
+        self.detectors = list(detectors)
+        self.duration = duration
+        self.sampling_frequency = sampling_frequency
+        return {detector: np.zeros(n_samples, dtype=float) for detector in detectors}
+
+    def generate_stream(
+        self,
+        chunk_duration: float,
+        sampling_frequency: float,
+        detectors: list[str],
+        seed: int | None = None,
+    ) -> Iterator[dict[str, np.ndarray]]:
+        """Yield zero-noise chunks lazily."""
+        while True:
+            yield self.generate(chunk_duration, sampling_frequency, detectors, seed)
+            seed = None
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Return metadata for the zero-noise helper backend."""
+        return {"kind": "zero-noise"}

--- a/src/gwmock/noise/adapter.py
+++ b/src/gwmock/noise/adapter.py
@@ -29,6 +29,34 @@ _SUPPORTED_OUTPUT_FORMATS = {"npy", "gwf"}
 _DETECTOR_PAIR_SIZE = 2
 
 
+def _format_frame_time_token(value: float) -> str:
+    """Match gwmock-noise frame filename token formatting."""
+    if float(value).is_integer():
+        return str(int(value))
+    return f"{value:.6f}".rstrip("0").rstrip(".").replace(".", "p")
+
+
+def _frame_channel_name(detector: str, channel_prefix: str) -> str:
+    """Return detector channel name used by gwmock-noise frame outputs."""
+    return f"{detector}:{channel_prefix}_NOISE"
+
+
+def _frame_artifact_name(
+    *,
+    detector: str,
+    channel_prefix: str,
+    prefix: str,
+    gps_start: float,
+    duration: float,
+) -> str:
+    """Return the GWF filename used by gwmock-noise ``FrameWriter``."""
+    channel = _frame_channel_name(detector, channel_prefix)
+    start_token = _format_frame_time_token(gps_start)
+    duration_token = _format_frame_time_token(duration)
+    name = f"{detector[0]}-{channel}_{start_token}-{duration_token}.gwf"
+    return f"{prefix}_{name}" if prefix else name
+
+
 def _coerce_path(value: str | Path | None) -> Path | None:
     """Normalize a path-like input."""
     if value is None:
@@ -241,16 +269,15 @@ class NoiseAdapter:
                 / (f"{config.output.prefix}_{detector}.npy" if config.output.prefix else f"{detector}.npy")
                 for detector in config.detectors
             ]
-
-        writer = FrameWriter(
-            _ChunkNoiseSimulator({detector: np.zeros(1) for detector in config.detectors}),
-            gps_start=config.output.gps_start,
-            output_dir=config.output.directory,
-            channel_prefix=config.output.channel_prefix,
-            prefix=config.output.prefix,
-        )
         return [
-            writer._frame_path(detector, writer._channel_name(detector), config.output.gps_start, config.duration)
+            config.output.directory
+            / _frame_artifact_name(
+                detector=detector,
+                channel_prefix=config.output.channel_prefix,
+                prefix=config.output.prefix,
+                gps_start=config.output.gps_start,
+                duration=config.duration,
+            )
             for detector in config.detectors
         ]
 

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -87,6 +87,8 @@ class FakeSignalAdapter:
 class FakeNoiseAdapter:
     """Minimal noise protocol backend that materializes deterministic arrays."""
 
+    stream_open_calls: ClassVar[list[dict[str, object]]] = []
+
     def __init__(
         self,
         duration: float = 4.0,
@@ -98,6 +100,7 @@ class FakeNoiseAdapter:
         self.sampling_frequency = sampling_frequency
         self.detectors = ["H1"] if detectors is None else detectors
         self.seed = seed
+        self._chunk_index = 0
 
     def generate(
         self,
@@ -116,12 +119,20 @@ class FakeNoiseAdapter:
         detectors: list[str],
         seed: int | None = None,
     ):
-        yield self.generate(
-            duration=chunk_duration,
-            sampling_frequency=sampling_frequency,
-            detectors=detectors,
-            seed=seed,
+        type(self).stream_open_calls.append(
+            {
+                "chunk_duration": chunk_duration,
+                "sampling_frequency": sampling_frequency,
+                "detectors": list(detectors),
+                "seed": seed,
+            }
         )
+        while True:
+            yield {
+                detector: np.full(round(chunk_duration * sampling_frequency), self._chunk_index, dtype=float)
+                for detector in detectors
+            }
+            self._chunk_index += 1
 
     @property
     def metadata(self) -> dict[str, object]:
@@ -252,6 +263,7 @@ def test_create_plan_from_orchestration_config(tmp_path: Path):
 
 def test_simulate_command_runs_adapter_orchestration(monkeypatch, tmp_path: Path):
     """The CLI should execute the adapter-backed orchestration path end to end."""
+    FakeNoiseAdapter.stream_open_calls.clear()
     config = _orchestration_config(tmp_path)
     config_file = tmp_path / "config.yaml"
     config_file.write_text(yaml.safe_dump(config.model_dump(by_alias=True, exclude_none=True), sort_keys=False))
@@ -272,7 +284,7 @@ def test_simulate_command_runs_adapter_orchestration(monkeypatch, tmp_path: Path
     assert metadata["population"]["source_type"] == "bbh"
     assert metadata["signal"]["detector_network"] == ["H1"]
     assert {output["kind"] for output in metadata["outputs"]} == {"signal", "noise"}
-    assert metadata["segment_seeds"] == [derive_seed(7, "signal", 0), derive_seed(7, "noise", 0)]
+    assert metadata["segment_seeds"] == [derive_seed(7, "signal", 0)]
     assert (
         metadata["simulator_config"]["population"]["backend"]
         == "tests.cli.test_cli_orchestration:FakePopulationBackend"
@@ -281,7 +293,15 @@ def test_simulate_command_runs_adapter_orchestration(monkeypatch, tmp_path: Path
     assert metadata["simulator_metadata"]["orchestration"]["population"]["metadata"] == FakePopulationBackend.metadata
     assert metadata["simulator_metadata"]["orchestration"]["population"]["seed"] == derive_seed(7, "population")
     assert metadata["simulator_metadata"]["orchestration"]["signal"]["segment_seed"] == derive_seed(7, "signal", 0)
-    assert metadata["simulator_metadata"]["orchestration"]["noise"]["segment_seed"] == derive_seed(7, "noise", 0)
+    assert metadata["simulator_metadata"]["orchestration"]["noise"]["stream_seed"] == 7
+    assert FakeNoiseAdapter.stream_open_calls == [
+        {
+            "chunk_duration": 4.0,
+            "sampling_frequency": 4.0,
+            "detectors": ["H1"],
+            "seed": 7,
+        }
+    ]
 
 
 def test_simulate_command_runs_real_public_subpackages(monkeypatch, tmp_path: Path):

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -12,6 +12,7 @@ import yaml
 from gwmock_signal import DetectorStrainStack
 from gwpy.timeseries import TimeSeries as GWpyTimeSeries
 
+from gwmock.cli.adapter_orchestration import AdapterOrchestrator
 from gwmock.cli.simulate import _simulate_impl
 from gwmock.cli.utils.config import (
     Config,
@@ -302,6 +303,22 @@ def test_simulate_command_runs_adapter_orchestration(monkeypatch, tmp_path: Path
             "seed": 7,
         }
     ]
+
+
+def test_orchestrator_restores_noise_stream_from_committed_cursor(tmp_path: Path):
+    """Restart should fast-forward noise stream from persisted committed cursor."""
+    config = _orchestration_config(tmp_path)
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+
+    # Simulate restored state where one chunk was already committed.
+    orchestrator.noise_stream_committed_count = 1
+    orchestrator.counter = 0
+    orchestrator._noise_stream = None
+    orchestrator._noise_stream_position = 0
+    orchestrator._pending_noise_chunk = None
+
+    chunk = orchestrator._next_noise_chunk()
+    assert chunk["H1"][0] == 1.0
 
 
 def test_simulate_command_runs_real_public_subpackages(monkeypatch, tmp_path: Path):

--- a/tests/noise/test_adapter.py
+++ b/tests/noise/test_adapter.py
@@ -179,6 +179,26 @@ class TestNoiseAdapter:
         assert np.array_equal(np.load(result.output_paths["H1"]), np.arange(32, dtype=float))
         assert np.array_equal(np.load(result.output_paths["L1"]), np.arange(32, dtype=float) + 1.0)
 
+    def test_expected_output_paths_for_gwf(self, tmp_path: Path):
+        """GWF expected paths should match gwmock-noise FrameWriter naming."""
+        adapter = NoiseAdapter.from_backend(FakeStreamNoiseBackend())
+        config = adapter.build_config(
+            detectors=["H1", "L1"],
+            duration=4.0,
+            sampling_frequency=8.0,
+            output_directory=tmp_path,
+            output_prefix="noise-0",
+            output_format="gwf",
+            gps_start=100.5,
+            channel_prefix="MOCK",
+            seed=7,
+        )
+
+        assert adapter.expected_output_paths(config=config) == [
+            tmp_path / "noise-0_H-H1:MOCK_NOISE_100p5-4.gwf",
+            tmp_path / "noise-0_L-L1:MOCK_NOISE_100p5-4.gwf",
+        ]
+
     def test_multisegment_outputs_match_single_long_run_with_stateful_backend(self, tmp_path: Path):
         """Concatenated chunk outputs should match one long protocol run for the same stream."""
         backend = FakeStreamNoiseBackend()

--- a/tests/noise/test_adapter.py
+++ b/tests/noise/test_adapter.py
@@ -4,44 +4,21 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
+import numpy as np
 
-from gwmock.cli.utils.config import SimulatorConfig, SimulatorOutputConfig
-from gwmock.cli.utils.simulation_plan import SimulationBatch
-from gwmock.noise import NoiseAdapter, UpstreamNoiseSimulator
+from gwmock.noise import NoiseAdapter
 
 TEST_DURATION = 8.0
 TEST_SAMPLING_FREQUENCY = 256.0
 TEST_GPS_START = 1234.5
 TEST_SEED = 11
-SEGMENT_DURATION = 4.0
-BASE_SEED = 7
 
 
 class FakeNoiseBackend:
-    """Minimal public gwmock-noise backend for adapter tests."""
+    """Minimal run-style gwmock-noise backend for direct adapter tests."""
 
     def __init__(self) -> None:
         self.run_calls = []
-
-    @staticmethod
-    def _format_time_token(value: float) -> str:
-        """Same rules as ``gwmock_noise.output.frame.FrameWriter._format_time_token``."""
-        if float(value).is_integer():
-            return str(int(value))
-        return f"{value:.6f}".rstrip("0").rstrip(".").replace(".", "p")
-
-    def _artifact_path(self, config, detector: str) -> Path:
-        """Match ``DefaultNoiseSimulator`` output paths (NumPy vs GWF frame writer)."""
-        if config.output.format == "npy":
-            return config.output.directory / f"{config.output.prefix}_{detector}.npy"
-        start_token = self._format_time_token(float(config.output.gps_start))
-        duration_token = self._format_time_token(config.duration)
-        channel = f"{detector}:{config.output.channel_prefix}_NOISE"
-        artifact_name = f"{detector[0]}-{channel}_{start_token}-{duration_token}.gwf"
-        prefix = config.output.prefix or ""
-        name = f"{prefix}_{artifact_name}" if prefix else artifact_name
-        return config.output.directory / name
 
     def run(self, config):
         """Record the config and materialize the declared outputs."""
@@ -49,11 +26,64 @@ class FakeNoiseBackend:
         config.output.directory.mkdir(parents=True, exist_ok=True)
         output_paths = {}
         for detector in config.detectors:
-            artifact_path = self._artifact_path(config, detector)
+            artifact_path = config.output.directory / f"{config.output.prefix}_{detector}.npy"
             artifact_path.write_text(f"{detector}:{config.output.format}")
-            (config.output.directory / f"{config.output.prefix}_{detector}.json").write_text("{}")
             output_paths[detector] = artifact_path
         return type("SimulationResultStub", (), {"output_paths": output_paths, "config": config})()
+
+
+class FakeStreamNoiseBackend:
+    """Protocol-style backend that exposes one stateful chunk iterator."""
+
+    def __init__(self) -> None:
+        self.duration = 0.0
+        self.sampling_frequency = 0.0
+        self.detectors = ["H1", "L1"]
+        self.seed = None
+        self.stream_open_calls = []
+        self.chunk_index = 0
+
+    def generate(self, duration: float, sampling_frequency: float, detectors: list[str], seed: int | None = None):
+        """Return one deterministic chunk."""
+        _ = seed
+        n_samples = round(duration * sampling_frequency)
+        return {detector: np.full(n_samples, self.chunk_index, dtype=float) for detector in detectors}
+
+    def generate_stream(
+        self,
+        chunk_duration: float,
+        sampling_frequency: float,
+        detectors: list[str],
+        seed: int | None = None,
+    ):
+        """Yield deterministic chunks while recording one stream-open event."""
+        self.stream_open_calls.append(
+            {
+                "chunk_duration": chunk_duration,
+                "sampling_frequency": sampling_frequency,
+                "detectors": list(detectors),
+                "seed": seed,
+            }
+        )
+        while True:
+            n_samples = round(chunk_duration * sampling_frequency)
+            value = self.chunk_index
+            self.chunk_index += 1
+            yield {detector: np.full(n_samples, value, dtype=float) for detector in detectors}
+
+    @property
+    def metadata(self) -> dict[str, object]:
+        """Return fake backend metadata."""
+        return {"kind": "fake-stream-noise"}
+
+
+def _psd_file(tmp_path: Path) -> Path:
+    """Create a simple PSD file for reproducibility tests."""
+    freqs = np.linspace(1, 64, 64)
+    psd_values = np.ones_like(freqs)
+    psd_path = tmp_path / "psd.txt"
+    np.savetxt(psd_path, np.column_stack([freqs, psd_values]))
+    return psd_path
 
 
 class TestNoiseAdapter:
@@ -63,8 +93,7 @@ class TestNoiseAdapter:
         """The adapter should pass gwmock orchestration inputs through NoiseConfig."""
         backend = FakeNoiseBackend()
         adapter = NoiseAdapter.from_backend(backend)
-        psd_path = tmp_path / "psd.txt"
-        psd_path.write_text("0 1\n1 1\n")
+        psd_path = _psd_file(tmp_path)
 
         result = adapter.run(
             detectors=["H1", "L1"],
@@ -94,86 +123,89 @@ class TestNoiseAdapter:
         assert config.psd_file == psd_path
         assert result.output_paths["H1"] == tmp_path / "segment-0_H1.npy"
 
+    def test_open_stream_uses_one_upstream_iterator(self):
+        """The adapter should open one shared stream and consume it chunk by chunk."""
+        backend = FakeStreamNoiseBackend()
+        adapter = NoiseAdapter.from_backend(backend)
 
-class TestUpstreamNoiseSimulator:
-    """Tests for the gwmock orchestration wrapper."""
-
-    @staticmethod
-    def _batch(file_name: str, arguments: dict | None = None) -> SimulationBatch:
-        return SimulationBatch(
-            simulator_name="noise",
-            simulator_config=SimulatorConfig(
-                class_="gwmock.noise.UpstreamNoiseSimulator",
-                arguments={},
-                output=SimulatorOutputConfig(file_name=file_name, arguments=arguments or {}),
-            ),
-            globals_config=type(
-                "GlobalsStub",
-                (),
-                {
-                    "working_directory": ".",
-                    "output_directory": None,
-                    "metadata_directory": None,
-                    "simulator_arguments": {},
-                    "output_arguments": {},
-                },
-            )(),
-            batch_index=0,
-        )
-
-    def test_simulate_uses_batch_context_and_deterministic_segment_seed(self, tmp_path: Path):
-        """Each batch should map to one deterministic public run(config) call."""
-        backend = FakeNoiseBackend()
-        simulator = UpstreamNoiseSimulator(
-            duration=SEGMENT_DURATION,
-            sampling_frequency=128.0,
+        stream = adapter.open_stream(
+            chunk_duration=4.0,
+            sampling_frequency=8.0,
             detectors=["H1", "L1"],
-            seed=BASE_SEED,
-            psd_file=tmp_path / "psd.npy",
-            noise_adapter=NoiseAdapter.from_backend(backend),
+            seed=7,
         )
 
-        batch0 = self._batch("noise-{{counter}}.npy")
-        batch1 = self._batch("noise-{{counter}}.npy")
+        first_chunk = next(stream)
+        second_chunk = next(stream)
 
-        simulator.set_batch_context(batch=batch0, output_directory=tmp_path, overwrite=False)
-        result0 = simulator.simulate()
-        simulator.update_state()
+        assert backend.stream_open_calls == [
+            {
+                "chunk_duration": 4.0,
+                "sampling_frequency": 8.0,
+                "detectors": ["H1", "L1"],
+                "seed": 7,
+            }
+        ]
+        assert np.all(first_chunk["H1"] == 0.0)
+        assert np.all(second_chunk["L1"] == 1.0)
 
-        simulator.set_batch_context(batch=batch1, output_directory=tmp_path, overwrite=False)
-        result1 = simulator.simulate()
-
-        config0, config1 = backend.run_calls
-        assert config0.seed == BASE_SEED
-        assert config1.seed == BASE_SEED + 1
-        assert config0.output.prefix == "noise-0"
-        assert config1.output.prefix == "noise-1"
-        assert config0.output.gps_start == 0.0
-        assert config1.output.gps_start == SEGMENT_DURATION
-        assert result0.output_paths["H1"] == tmp_path / "noise-0_H1.npy"
-        assert result1.output_paths["L1"] == tmp_path / "noise-1_L1.npy"
-
-    def test_set_batch_context_rejects_unsupported_output_arguments(self, tmp_path: Path):
-        """Unsupported gwmock-only output arguments should fail loudly for the adapter path."""
-        simulator = UpstreamNoiseSimulator(noise_adapter=NoiseAdapter.from_backend(FakeNoiseBackend()))
-        batch = self._batch("noise.npy", {"channel": "H1:STRAIN"})
-
-        with pytest.raises(ValueError, match="Unsupported keys: channel"):
-            simulator.set_batch_context(batch=batch, output_directory=tmp_path, overwrite=False)
-
-    def test_simulate_gwf_overwrite_false_raises_when_outputs_exist(self, tmp_path: Path):
-        """GWF pre-run existence checks should see the same paths the backend writes."""
-        backend = FakeNoiseBackend()
-        simulator = UpstreamNoiseSimulator(
-            duration=SEGMENT_DURATION,
-            sampling_frequency=128.0,
-            detectors=["H1"],
+    def test_write_chunk_persists_numpy_outputs(self, tmp_path: Path):
+        """The adapter should let gwmock own NumPy chunk output writing."""
+        adapter = NoiseAdapter.from_backend(FakeStreamNoiseBackend())
+        config = adapter.build_config(
+            detectors=["H1", "L1"],
+            duration=4.0,
+            sampling_frequency=8.0,
+            output_directory=tmp_path,
+            output_prefix="noise-0",
+            output_format="npy",
+            gps_start=100.0,
             channel_prefix="MOCK",
-            noise_adapter=NoiseAdapter.from_backend(backend),
+            seed=7,
         )
-        batch = self._batch("noise-{{counter}}.gwf", {"prefix": "seg", "gps_start": 100.0})
 
-        simulator.set_batch_context(batch=batch, output_directory=tmp_path, overwrite=False)
-        simulator.simulate()
-        with pytest.raises(FileExistsError, match="Noise adapter output"):
-            simulator.simulate()
+        result = adapter.write_chunk(
+            config=config,
+            chunk={
+                "H1": np.arange(32, dtype=float),
+                "L1": np.arange(32, dtype=float) + 1.0,
+            },
+        )
+
+        assert adapter.expected_output_paths(config=config) == [
+            tmp_path / "noise-0_H1.npy",
+            tmp_path / "noise-0_L1.npy",
+        ]
+        assert np.array_equal(np.load(result.output_paths["H1"]), np.arange(32, dtype=float))
+        assert np.array_equal(np.load(result.output_paths["L1"]), np.arange(32, dtype=float) + 1.0)
+
+    def test_multisegment_outputs_match_single_long_run_with_stateful_backend(self, tmp_path: Path):
+        """Concatenated chunk outputs should match one long protocol run for the same stream."""
+        backend = FakeStreamNoiseBackend()
+        adapter = NoiseAdapter.from_backend(backend)
+        stream = adapter.open_stream(
+            chunk_duration=2.0,
+            sampling_frequency=4.0,
+            detectors=["H1"],
+            seed=13,
+        )
+
+        segments = []
+        for index in range(5):
+            config = adapter.build_config(
+                detectors=["H1"],
+                duration=2.0,
+                sampling_frequency=4.0,
+                output_directory=tmp_path,
+                output_prefix=f"noise-{index}",
+                output_format="npy",
+                gps_start=100.0 + index * 2.0,
+                channel_prefix="MOCK",
+                seed=13,
+            )
+            result = adapter.write_chunk(config=config, chunk=next(stream))
+            segments.append(np.load(result.output_paths["H1"]))
+
+        concatenated = np.concatenate(segments)
+        expected = np.concatenate([np.full(8, value, dtype=float) for value in range(5)])
+        assert concatenated.tobytes() == expected.tobytes()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated reproducibility guide to clarify seed behavior: segment_seeds are now stored locally per run, and adapter-backed noise uses a single shared stream per run with the root seed recorded once.

* **Breaking Changes**
  * Removed `UpstreamNoiseSimulator` from public API exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->