### PR TITLE
refactor: Tighten `PopulationAdapter` to the public Protocol only

### DIFF
--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -18,7 +18,7 @@ from gwmock.data.time_series.time_series import TimeSeries
 from gwmock.data.time_series.time_series_list import TimeSeriesList
 from gwmock.mixin.time_series import TimeSeriesMixin
 from gwmock.noise import NoiseAdapter
-from gwmock.population import PopulationAdapter
+from gwmock.population import PopulationAdapter, instantiate_population_backend
 from gwmock.signal import SignalAdapter
 from gwmock.simulator.base import Simulator
 from gwmock.simulator.seeds import derive_seed
@@ -177,8 +177,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         if population_config.source_type is not None:
             backend_arguments.setdefault("source_type", population_config.source_type)
 
-        return instantiate_backend(
-            "population",
+        return instantiate_population_backend(
             population_config.backend,
             init_kwargs=backend_arguments,
         )

--- a/src/gwmock/cli/utils/backend_resolver.py
+++ b/src/gwmock/cli/utils/backend_resolver.py
@@ -210,19 +210,7 @@ def _validate_population_backend(backend_name: str, backend_instance: Any) -> No
     if isinstance(backend_instance, GWPopSimulator):
         return
 
-    issues = _collect_protocol_issues(
-        backend_instance,
-        required_attributes={
-            "parameter_names": _is_non_string_sequence,
-            "source_type": lambda value: isinstance(value, str) and bool(value.strip()),
-        },
-        required_callables=("simulate",),
-    )
-    if not issues:
-        return
-    raise TypeError(
-        f"Resolved population backend '{backend_name}' does not satisfy GWPopSimulator: {', '.join(issues)}."
-    )
+    raise TypeError(f"Resolved population backend '{backend_name}' does not satisfy GWPopSimulator.")
 
 
 def _validate_signal_backend(backend_name: str, backend_class: type[Any], backend_instance: Any) -> None:
@@ -283,7 +271,3 @@ def _collect_protocol_issues(
             issues.append(f"member '{method_name}' is not callable")
 
     return issues
-
-
-def _is_non_string_sequence(value: Any) -> bool:
-    return isinstance(value, Sequence) and not isinstance(value, str) and bool(value)

--- a/src/gwmock/population/__init__.py
+++ b/src/gwmock/population/__init__.py
@@ -2,6 +2,26 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Any, cast
+
+from gwmock_pop import GWPopSimulator
+
+from gwmock.cli.utils.backend_resolver import instantiate_backend
+
 from .adapter import PopulationAdapter
 
-__all__ = ["PopulationAdapter"]
+
+def instantiate_population_backend(
+    backend_name: str,
+    *,
+    init_kwargs: Mapping[str, Any] | None = None,
+) -> GWPopSimulator:
+    """Resolve, instantiate, and validate a population backend."""
+    return cast(
+        "GWPopSimulator",
+        instantiate_backend("population", backend_name, init_kwargs=init_kwargs),
+    )
+
+
+__all__ = ["PopulationAdapter", "instantiate_population_backend"]

--- a/tests/cli/utils/test_backend_resolver.py
+++ b/tests/cli/utils/test_backend_resolver.py
@@ -104,6 +104,7 @@ def test_resolve_population_builtin_alias():
 
 def test_resolve_backend_entry_point_from_installed_package(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Entry-point discovery should work for an installed third-party package."""
+    alias = "tiny_alias_backend_resolver_test"
     package_dir = tmp_path / "plugin-src"
     site_packages = tmp_path / "site-packages"
     (package_dir / "tiny_backend_pkg").mkdir(parents=True)
@@ -134,9 +135,9 @@ def test_resolve_backend_entry_point_from_installed_package(tmp_path: Path, monk
             version = "0.0.1"
 
             [project.entry-points."gwmock.population"]
-            tiny_alias = "tiny_backend_pkg.population:EntryPointPopulationBackend"
+            {alias} = "tiny_backend_pkg.population:EntryPointPopulationBackend"
             """
-        )
+        ).format(alias=alias)
     )
 
     uv_path = shutil.which("uv")
@@ -159,7 +160,7 @@ def test_resolve_backend_entry_point_from_installed_package(tmp_path: Path, monk
     )
     monkeypatch.syspath_prepend(str(site_packages))
 
-    backend = instantiate_backend("population", "tiny_alias")
+    backend = instantiate_backend("population", alias)
 
     assert backend.__class__.__name__ == "EntryPointPopulationBackend"
     assert backend.simulate(1)["mass_1"][0] == pytest.approx(7.0)
@@ -189,8 +190,8 @@ def test_resolve_legacy_dotted_path_warns_once(monkeypatch):
 
 
 def test_invalid_population_backend_names_missing_member():
-    """Validation failures should name the missing or mismatched protocol member."""
-    with pytest.raises(TypeError, match="source_type"):
+    """Validation failures should be reported at the GWPopSimulator boundary."""
+    with pytest.raises(TypeError, match="does not satisfy GWPopSimulator"):
         instantiate_backend("population", "tests.cli.utils.test_backend_resolver:InvalidPopulationBackend")
 
 

--- a/tests/population/test_adapter.py
+++ b/tests/population/test_adapter.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import shutil
+import subprocess
+import sys
 import tempfile
+import textwrap
 from pathlib import Path
 from typing import ClassVar
 
@@ -10,7 +14,8 @@ import numpy as np
 import pytest
 from gwmock_pop import CBC_PARAMETER_NAMES, ExternalPopulationLoader, GWPopSimulator
 
-from gwmock.population import PopulationAdapter
+from gwmock.cli.utils.backend_resolver import resolve_backend_class
+from gwmock.population import PopulationAdapter, instantiate_population_backend
 
 EXPECTED_SAMPLE_COUNT = 2
 
@@ -37,6 +42,10 @@ class MockGWPopBackend:
         }
 
 
+class ModulePopulationBackend(MockGWPopBackend):
+    """Protocol-compatible backend for module:Class resolver tests."""
+
+
 class MockExternalPopulationLoader:
     """Protocol-compatible file loader backend for adapter tests."""
 
@@ -60,12 +69,76 @@ class MockExternalPopulationLoader:
         }
 
 
+def _install_entry_point_backend(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    alias: str,
+    package_name: str,
+) -> None:
+    package_dir = tmp_path / "plugin-src"
+    site_packages = tmp_path / "site-packages"
+    (package_dir / package_name).mkdir(parents=True)
+    (package_dir / package_name / "__init__.py").write_text("")
+    (package_dir / package_name / "population.py").write_text(
+        textwrap.dedent(
+            """
+            import numpy as np
+
+            class EntryPointPopulationBackend:
+                parameter_names = ("detector_frame_mass_1",)
+                source_type = "bbh"
+
+                def simulate(self, n_samples: int, **_kwargs):
+                    return {"detector_frame_mass_1": np.full(n_samples, 7.0)}
+            """
+        )
+    )
+    (package_dir / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """
+            [build-system]
+            requires = ["setuptools>=61"]
+            build-backend = "setuptools.build_meta"
+
+            [project]
+            name = "{package_name}"
+            version = "0.0.1"
+
+            [project.entry-points."gwmock.population"]
+            """
+        ).format(package_name=package_name)
+        + f'{alias} = "{package_name}.population:EntryPointPopulationBackend"\n'
+    )
+
+    uv_path = shutil.which("uv")
+    if uv_path is None:  # pragma: no cover - repository tests run with uv available
+        raise AssertionError("uv executable is required for entry-point installation tests.")
+
+    subprocess.run(  # noqa: S603
+        [
+            uv_path,
+            "pip",
+            "install",
+            "--python",
+            sys.executable,
+            "--quiet",
+            "--no-deps",
+            "--target",
+            str(site_packages),
+            str(package_dir),
+        ],
+        check=True,
+    )
+    monkeypatch.syspath_prepend(str(site_packages))
+
+
 class TestPopulationAdapter:
     """Test suite for population adapter behavior."""
 
     def test_from_backend_accepts_gwpop_simulator(self):
         """Simulator-backed batches are sliced into per-event dictionaries."""
-        backend = MockGWPopBackend()
+        backend = instantiate_population_backend("tests.population.test_adapter:MockGWPopBackend")
 
         assert isinstance(backend, GWPopSimulator)
 
@@ -95,7 +168,7 @@ class TestPopulationAdapter:
 
     def test_from_backend_accepts_external_population_loader(self):
         """Loader-backed batches use the same adapter boundary."""
-        loader = MockExternalPopulationLoader()
+        loader = instantiate_population_backend("tests.population.test_adapter:MockExternalPopulationLoader")
 
         assert isinstance(loader, GWPopSimulator)
         assert isinstance(loader, ExternalPopulationLoader)
@@ -159,3 +232,50 @@ class TestPopulationAdapter:
                 source_type="bbh",
                 parameter_names=("detector_frame_mass_2", "detector_frame_mass_1"),
             )
+
+    @pytest.mark.parametrize(
+        ("backend_name", "expected_class_name"),
+        [
+            ("bbh", "BBHSimulator"),
+            ("cbc_prior", "CBCPriorSimulator"),
+            ("bns_prior", "BNSPriorSimulator"),
+            ("nsbh_prior", "NSBHPriorSimulator"),
+            ("file", "FilePopulationLoader"),
+        ],
+    )
+    def test_instantiate_population_backend_resolves_builtin_aliases(
+        self,
+        backend_name: str,
+        expected_class_name: str,
+    ):
+        """Built-in aliases should resolve through the public population resolver."""
+        backend_class = resolve_backend_class("population", backend_name)
+
+        assert backend_class.__name__ == expected_class_name
+
+    def test_instantiate_population_backend_resolves_module_class(self):
+        """Module:Class backends should resolve through the public population resolver."""
+        backend_class = resolve_backend_class("population", "tests.population.test_adapter:ModulePopulationBackend")
+
+        assert backend_class.__name__ == "ModulePopulationBackend"
+
+    def test_instantiate_population_backend_resolves_entry_point(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Third-party entry points should resolve through the public population resolver."""
+        alias = "population_test_adapter_alias"
+        _install_entry_point_backend(
+            tmp_path,
+            monkeypatch,
+            alias=alias,
+            package_name="population_test_adapter_backend_pkg",
+        )
+
+        backend_class = resolve_backend_class("population", alias)
+        backend = backend_class()
+
+        assert isinstance(backend, GWPopSimulator)
+        assert backend.__class__.__name__ == "EntryPointPopulationBackend"
+        assert backend.simulate(1)["detector_frame_mass_1"][0] == pytest.approx(7.0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `instantiate_population_backend()` function in the population module, enabling dynamic resolution and instantiation of population backends via string identifiers.

* **Refactor**
  * Enhanced backend resolution infrastructure with streamlined validation logic.
  * Extended test coverage for entry-point aliasing and module-based backend resolution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->