### PR TITLE
fix(cli): Fix noise detector alias not resolved

### DIFF
--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -11,6 +11,7 @@ import numpy as np
 from gwmock_noise import SimulationResult
 from gwmock_pop import GWPopSimulator
 from gwmock_signal import DetectorStrainStack, Network
+from gwpy.timeseries import TimeSeries as GWpyTimeSeries
 
 from gwmock.cli.utils.backend_resolver import instantiate_backend, resolve_backend_class, validate_backend
 from gwmock.cli.utils.config import OrchestrationConfig
@@ -40,13 +41,22 @@ def _normalize_keys(values: dict[str, Any]) -> dict[str, Any]:
     return {key.replace("-", "_"): value for key, value in values.items()}
 
 
-def _flatten_first(value: str | list[str] | list[list[str]]) -> str:
-    """Return the first scalar string from an expanded template."""
-    while isinstance(value, list):
-        if not value:
-            raise ValueError("Template expansion produced an empty list; cannot derive a scalar string.")
-        value = value[0]
-    return value
+class _NoiseTemplateProxy:
+    """Forward attribute access to an orchestrator, substituting noise detectors.
+
+    ``expand_template_variables`` resolves ``{{ detectors }}`` via ``getattr``.
+    This proxy redirects that lookup to the noise detector list instead of the
+    signal detector list stored on the real orchestrator.
+    """
+
+    __slots__ = ("_wrapped", "detectors")
+
+    def __init__(self, wrapped: Any, noise_detectors: list[str]) -> None:
+        object.__setattr__(self, "_wrapped", wrapped)
+        object.__setattr__(self, "detectors", noise_detectors)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_wrapped"), name)
 
 
 class AdapterOrchestrator(TimeSeriesMixin, Simulator):
@@ -369,7 +379,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
 
     def _run_noise_batch(self) -> SimulationResult:
         output_format = self._infer_noise_output_format(self.orchestration_config.noise.output.file_name)
-        output_prefix = self._derive_noise_output_prefix(self.orchestration_config.noise.output.file_name)
+        output_paths = self._expand_noise_output_paths(self.orchestration_config.noise.output.file_name)
         output_arguments = dict(self._active_noise_output_arguments)
         channel_prefix = str(output_arguments.pop("channel_prefix", "MOCK"))
         gps_start = float(output_arguments.pop("gps_start", float(self.start_time.value)))
@@ -380,12 +390,42 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                 f"Unsupported keys: {unsupported}."
             )
 
+        if not self._active_overwrite:
+            existing = [path for path in dict.fromkeys(output_paths) if path.exists()]
+            if existing:
+                raise FileExistsError(
+                    f"Noise adapter output(s) already exist: {', '.join(str(path) for path in existing)}. "
+                    "Use overwrite=True to overwrite them."
+                )
+
+        noise_detectors = list(self.noise_arguments["detectors"])
+        chunk = self._next_noise_chunk()
+        output_paths_by_detector: dict[str, Path] = {}
+
+        for i, detector in enumerate(noise_detectors):
+            output_path = output_paths[i] if len(output_paths) > 1 else output_paths[0]
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            if output_format == "gwf":
+                channel_id = f"{detector}:{channel_prefix}"
+                gwpy_ts = GWpyTimeSeries(
+                    np.asarray(chunk[detector], dtype=float),
+                    t0=gps_start,
+                    sample_rate=float(self.sampling_frequency.value),
+                )
+                DetectorStrainStack.from_mapping([channel_id], {channel_id: gwpy_ts}).write(output_path, format="gwf")
+            else:
+                np.save(output_path, chunk[detector])
+            output_paths_by_detector[detector] = output_path
+
+        self.noise_stream_committed_count = max(
+            int(self.noise_stream_committed_count), int(self._noise_stream_position)
+        )
         config = self.noise_adapter.build_config(
-            detectors=list(self.noise_arguments["detectors"]),
+            detectors=noise_detectors,
             duration=float(self.duration.value),
             sampling_frequency=float(self.sampling_frequency.value),
             output_directory=self._active_noise_output_directory,
-            output_prefix=output_prefix,
+            output_prefix="",
             output_format=output_format,
             gps_start=gps_start,
             channel_prefix=channel_prefix,
@@ -399,20 +439,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             spectral_lines=self.noise_arguments.get("spectral_lines"),
             glitches=self.noise_arguments.get("glitches"),
         )
-        if not self._active_overwrite:
-            existing = [path for path in self.noise_adapter.expected_output_paths(config=config) if path.exists()]
-            if existing:
-                raise FileExistsError(
-                    f"Noise adapter output(s) already exist: {', '.join(str(path) for path in existing)}. "
-                    "Use overwrite=True to overwrite them."
-                )
-
-        chunk = self._next_noise_chunk()
-        result = self.noise_adapter.write_chunk(config=config, chunk=chunk)
-        self.noise_stream_committed_count = max(
-            int(self.noise_stream_committed_count), int(self._noise_stream_position)
-        )
-        return result
+        return SimulationResult(output_paths=output_paths_by_detector, config=config)
 
     def segment_seeds(self) -> list[int]:
         """Return the deterministic per-segment seeds derived locally by gwmock."""
@@ -451,10 +478,19 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             raise ValueError("Noise output templates must end with .npy or .gwf.")
         return cast(Literal["npy", "gwf"], suffix)
 
-    def _derive_noise_output_prefix(self, file_name_template: str) -> str:
-        prefix = _flatten_first(expand_template_variables(str(Path(file_name_template).with_suffix("")), self))
-        prefix = prefix.strip("-_ ")
-        return prefix or f"noise-{self.counter}"
+    def _expand_noise_output_paths(self, file_name_template: str) -> list[Path]:
+        """Expand the noise file_name template to one output path per detector."""
+        noise_detectors = list(self.noise_arguments["detectors"])
+        proxy = _NoiseTemplateProxy(self, noise_detectors)
+        expanded = expand_template_variables(file_name_template, proxy)
+        if isinstance(expanded, list):
+            if len(expanded) != len(noise_detectors):
+                raise ValueError(
+                    f"Noise file_name template expanded to {len(expanded)} paths "
+                    f"but there are {len(noise_detectors)} noise detectors."
+                )
+            return [self._active_noise_output_directory / str(p) for p in expanded]
+        return [self._active_noise_output_directory / str(expanded)] * len(noise_detectors)
 
     @staticmethod
     def _resolve_output_directory(

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -489,8 +489,15 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                     f"Noise file_name template expanded to {len(expanded)} paths "
                     f"but there are {len(noise_detectors)} noise detectors."
                 )
-            return [self._active_noise_output_directory / str(p) for p in expanded]
-        return [self._active_noise_output_directory / str(expanded)] * len(noise_detectors)
+            paths = [self._active_noise_output_directory / str(p) for p in expanded]
+        else:
+            paths = [self._active_noise_output_directory / str(expanded)] * len(noise_detectors)
+        if len(set(paths)) < len(paths):
+            raise ValueError(
+                "Noise file_name template produces identical paths for multiple detectors. "
+                "Include {{ detectors }} in the template to generate per-detector paths."
+            )
+        return paths
 
     @staticmethod
     def _resolve_output_directory(

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -157,7 +157,11 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                 raise ValueError(f"Population event ordering key '{sort_key}' is missing from one or more events.")
             population_events.sort(key=lambda event: event[sort_key])
 
-        noise_arguments.setdefault("detectors", resolved_detectors)
+        if "detectors" in noise_arguments:
+            noise_network, _ = cls._resolve_detector_network(noise_arguments["detectors"])
+            noise_arguments["detectors"] = cls._network_detector_names(noise_network)
+        else:
+            noise_arguments["detectors"] = resolved_detectors
         noise_adapter = cls._instantiate_noise_adapter(orchestration_config.noise)
 
         return cls(

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -193,8 +193,7 @@ def _fake_orchestration_config(tmp_path: Path, *, source_type: str) -> Config:
 
 def _assert_noise_outputs_exist(output_directory: Path) -> None:
     for counter in range(EXPECTED_BATCHES):
-        for detector in ["H1"]:
-            assert (output_directory / f"noise-{counter}_{detector}.npy").exists()
+        assert (output_directory / f"noise-{counter}.npy").exists()
 
 
 def test_create_plan_from_orchestration_config(tmp_path: Path):
@@ -332,3 +331,62 @@ def test_orchestrator_records_single_detector_preset_resolution(tmp_path: Path):
             }
         ],
     }
+
+
+def test_noise_batch_gwf_writes_per_detector_files(monkeypatch, tmp_path: Path):
+    """Noise GWF template with {{ detectors }} produces one file per detector at the template-specified path."""
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+    config.orchestration.noise.arguments = {
+        "seed": 7,
+        "duration": 4.0,
+        "sampling_frequency": 4.0,
+        "detectors": ["H1", "L1"],
+    }
+    config.orchestration.noise.output = SimulatorOutputConfig(
+        file_name="noise-{{ counter }}-{{ detectors }}.gwf",
+        output_directory="noise",
+    )
+
+    monkeypatch.setattr("gwmock.cli.adapter_orchestration.DetectorStrainStack.write", _write_signal_file)
+
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+    orchestrator._active_noise_output_directory = tmp_path / "noise"
+    orchestrator._active_overwrite = True
+
+    result = orchestrator._run_noise_batch()
+
+    noise_dir = tmp_path / "noise"
+    assert (noise_dir / "noise-0-H1.gwf").exists()
+    assert (noise_dir / "noise-0-L1.gwf").exists()
+    assert result.output_paths["H1"] == noise_dir / "noise-0-H1.gwf"
+    assert result.output_paths["L1"] == noise_dir / "noise-0-L1.gwf"
+
+
+def test_noise_batch_npy_uses_template_path(tmp_path: Path):
+    """Noise NPY files are written to the exact template-expanded path (no detector suffix appended)."""
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+    orchestrator._active_noise_output_directory = tmp_path / "noise"
+    orchestrator._active_overwrite = True
+
+    result = orchestrator._run_noise_batch()
+
+    assert (tmp_path / "noise" / "noise-0.npy").exists()
+    assert result.output_paths["H1"] == tmp_path / "noise" / "noise-0.npy"
+
+
+def test_noise_batch_overwrite_check_uses_template_paths(tmp_path: Path):
+    """FileExistsError is raised when a template-expanded noise path already exists."""
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+    noise_dir = tmp_path / "noise"
+    noise_dir.mkdir(parents=True)
+    (noise_dir / "noise-0.npy").write_text("existing")
+
+    orchestrator._active_noise_output_directory = noise_dir
+    orchestrator._active_overwrite = False
+
+    with pytest.raises(FileExistsError, match=r"noise-0\.npy"):
+        orchestrator._run_noise_batch()

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -293,6 +293,23 @@ def test_orchestrator_records_preset_network_resolution(tmp_path: Path):
     }
 
 
+def test_orchestrator_resolves_noise_detector_alias(tmp_path: Path):
+    """Detector aliases in noise.arguments.detectors must be resolved to sub-detectors."""
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+    config.orchestration.signal.detectors = ["ET-Triangle-Sardinia"]
+    config.orchestration.noise.arguments = {
+        "seed": 7,
+        "duration": 4.0,
+        "sampling_frequency": 4.0,
+        "detectors": ["ET-Triangle-Sardinia"],
+    }
+
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+
+    assert orchestrator.noise_arguments["detectors"] == ["ET1_SARD", "ET2_SARD", "ET3_SARD"]
+    assert orchestrator.detectors == ["ET1_SARD", "ET2_SARD", "ET3_SARD"]
+
+
 def test_orchestrator_records_single_detector_preset_resolution(tmp_path: Path):
     """Single public ET-detector aliases should resolve via the preset-backed detector catalog."""
     config = _fake_orchestration_config(tmp_path, source_type="bbh")

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -376,6 +376,24 @@ def test_noise_batch_npy_uses_template_path(tmp_path: Path):
     assert result.output_paths["H1"] == tmp_path / "noise" / "noise-0.npy"
 
 
+def test_noise_batch_npy_scalar_template_multiple_detectors_raises(tmp_path: Path):
+    """Scalar NPY template with multiple detectors raises ValueError to prevent silent overwrites."""
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+    config.orchestration.noise.arguments = {
+        "seed": 7,
+        "duration": 4.0,
+        "sampling_frequency": 4.0,
+        "detectors": ["H1", "L1"],
+    }
+
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+    orchestrator._active_noise_output_directory = tmp_path / "noise"
+    orchestrator._active_overwrite = True
+
+    with pytest.raises(ValueError, match="identical paths for multiple detectors"):
+        orchestrator._run_noise_batch()
+
+
 def test_noise_batch_overwrite_check_uses_template_paths(tmp_path: Path):
     """FileExistsError is raised when a template-expanded noise path already exists."""
     config = _fake_orchestration_config(tmp_path, source_type="bbh")

--- a/tests/cli/test_third_party_backend.py
+++ b/tests/cli/test_third_party_backend.py
@@ -245,7 +245,7 @@ def test_orchestrator_uses_third_party_entry_points(monkeypatch: pytest.MonkeyPa
 
     metadata = yaml.safe_load((tmp_path / "metadata" / "orchestration-0.metadata.json").read_text())
     assert (tmp_path / "output" / "signal" / "signal-0.gwf").exists()
-    assert (tmp_path / "output" / "noise" / "noise-0_H1.npy").exists()
+    assert (tmp_path / "output" / "noise" / "noise-0.npy").exists()
     assert metadata["config"]["orchestration"]["population"]["backend"] == aliases["population"]
     assert metadata["config"]["orchestration"]["signal"]["backend"] == aliases["signal"]
     assert metadata["config"]["orchestration"]["noise"]["backend"] == aliases["noise"]

--- a/tests/cli/utils/test_simulation_plan.py
+++ b/tests/cli/utils/test_simulation_plan.py
@@ -784,10 +784,10 @@ class TestCreatePlanFromMetadata:
         assert plan.batches[0].batch_metadata["author"] == "test_user"
         assert plan.batches[0].batch_metadata["email"] == "test@example.com"
 
-    def test_create_plan_from_metadata_directory_not_found(self):
+    def test_create_plan_from_metadata_directory_not_found(self, tmp_path: Path):
         """Test that non-existent metadata directory raises error."""
         with pytest.raises(FileNotFoundError):
-            create_plan_from_metadata(Path("/nonexistent"), Path("checkpoints"))
+            create_plan_from_metadata(tmp_path / "does_not_exist", Path("checkpoints"))
 
     def test_create_plan_from_metadata_empty_directory(self, tmp_path: Path):
         """Test creating a plan from an empty metadata directory."""


### PR DESCRIPTION
Close #119 

-------------------------------------------------------------------

Fix a one-line bug in `AdapterOrchestrator.from_config` where detector aliases in `noise.arguments.detectors` (e.g. `ET-Triangle-Sardinia`) were stored as-is into `noise_arguments`, causing `FrameWriter` to see a single pseudo-detector and write only one output file instead of the expected three. The fix replaces the `setdefault` call with an explicit branch: if `detectors` is present in `noise_arguments`, the entries are run through `_resolve_detector_network`/`_network_detector_names` — the same alias-resolution path already used for signal detectors — before being stored; if absent, the existing fallback to the signal-resolved detector list is preserved. A new unit test (`test_orchestrator_resolves_noise_detector_alias`) verifies that `ET-Triangle-Sardinia` in `noise.arguments.detectors` resolves to `["ET1_SARD", "ET2_SARD", "ET3_SARD"]`. 
All 487 existing tests continue to pass.

-------------------------------------------------------------------

Replace the `_derive_noise_output_prefix` / `_flatten_first` / `FrameWriter` pipeline in `AdapterOrchestrator._run_noise_batch` with a direct template-expansion approach that writes noise outputs to the exact paths the `file_name` template specifies.

The root cause was `_derive_noise_output_prefix` collapsing a per-detector template expansion to a single prefix string via `_flatten_first`, then passing it to `FrameWriter` (gwmock-noise), which appended its own naming convention on top — producing double-stamped filenames like `E-ET1_SARD_NOISE-..._E-ET-Triangle-Sardinia:STRAIN_NOISE_....gwf`.

The fix: a new `_expand_noise_output_paths` method expands the `file_name` template directly (using a `_NoiseTemplateProxy` that substitutes noise detectors for signal detectors during `{{ detectors }}` expansion), producing one output path per detector. `_run_noise_batch` then writes each detector's chunk directly — via `DetectorStrainStack.write()` for GWF (channel name = `{detector}:{channel_prefix}`) or `np.save` for NPY — bypassing `FrameWriter` entirely. The overwrite pre-check was updated to use the same template-expanded paths.

`_flatten_first` and `_derive_noise_output_prefix` are removed. Three new unit tests cover per-detector GWF naming, exact NPY path, and overwrite protection. Two existing test assertions updated to reflect the correct new behaviour (`noise-0.npy` instead of `noise-0_H1.npy`).
All 491 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored noise output file generation system to improve efficiency and consistency
  * Changed noise output filename format to omit detector-specific suffixes for cleaner organization
  * Improved detector configuration alias resolution—aliases now properly map to canonical preset names
  * Enhanced noise batch processing with optimized file serialization and expanded output path validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Leuven-Gravity-Institute/gwmock/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->