### PR TITLE
fix(cli): Fixing signal output channel naming

### DIFF
--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -613,6 +613,8 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         ):
             series = data[index].copy()
             effective_name = channel_name if channel_name is not None else detector_name
+            if effective_name in mapping:
+                effective_name = f"{effective_name}__{detector_name}"
             effective_names.append(effective_name)
             mapping[effective_name] = series
         return DetectorStrainStack.from_mapping(effective_names, mapping)

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -607,11 +607,12 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             raise ValueError("Signal detector, channel, and data selections must have matching lengths.")
 
         mapping = {}
+        effective_names = []
         for detector_name, channel_name, index in zip(
             active_detector_names, channel_names, active_indices, strict=True
         ):
             series = data[index].copy()
-            if channel_name is not None:
-                series.channel = channel_name
-            mapping[detector_name] = series
-        return DetectorStrainStack.from_mapping(active_detector_names, mapping)
+            effective_name = channel_name if channel_name is not None else detector_name
+            effective_names.append(effective_name)
+            mapping[effective_name] = series
+        return DetectorStrainStack.from_mapping(effective_names, mapping)

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -442,3 +442,20 @@ def test_build_signal_stack_falls_back_to_detector_name_when_channel_is_none(tmp
     )
 
     assert stack.detector_names == ("H1",)
+
+
+def test_build_signal_stack_disambiguates_duplicate_channel_names(tmp_path: Path):
+    """Duplicate effective names are disambiguated so no series silently overwrites another."""
+    from gwmock.data.time_series.time_series import TimeSeries as GwmockTimeSeries
+
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+    data = GwmockTimeSeries(np.zeros((2, 4)), start_time=0.0, sampling_frequency=1.0)
+
+    stack = orchestrator._build_signal_stack(
+        data=data,
+        channel_names=["STRAIN", "STRAIN"],
+        detector_names=["H1", "L1"],
+    )
+
+    assert stack.detector_names == ("STRAIN", "STRAIN__L1")

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -408,3 +408,37 @@ def test_noise_batch_overwrite_check_uses_template_paths(tmp_path: Path):
 
     with pytest.raises(FileExistsError, match=r"noise-0\.npy"):
         orchestrator._run_noise_batch()
+
+
+def test_build_signal_stack_uses_channel_name_as_gwf_channel(tmp_path: Path):
+    """_build_signal_stack uses channel_name as the stack name so GWF writes the right channel."""
+    from gwmock.data.time_series.time_series import TimeSeries as GwmockTimeSeries
+
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+    data = GwmockTimeSeries(np.zeros((1, 4)), start_time=0.0, sampling_frequency=1.0)
+
+    stack = orchestrator._build_signal_stack(
+        data=data,
+        channel_names=["H1:STRAIN"],
+        detector_names=["H1"],
+    )
+
+    assert stack.detector_names == ("H1:STRAIN",)
+
+
+def test_build_signal_stack_falls_back_to_detector_name_when_channel_is_none(tmp_path: Path):
+    """_build_signal_stack uses detector_name when channel_name is None (no regression)."""
+    from gwmock.data.time_series.time_series import TimeSeries as GwmockTimeSeries
+
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+    data = GwmockTimeSeries(np.zeros((1, 4)), start_time=0.0, sampling_frequency=1.0)
+
+    stack = orchestrator._build_signal_stack(
+        data=data,
+        channel_names=[None],
+        detector_names=["H1"],
+    )
+
+    assert stack.detector_names == ("H1",)


### PR DESCRIPTION
Close #121 

### Problem

When `signal.output.arguments.channel` was set (e.g. `{{ detectors }}:STRAIN`), the configured
channel name was silently discarded and the bare detector name was written as the GWF channel
instead (`ET1_SARD` instead of `ET1_SARD:STRAIN`).

### Root cause

`_build_signal_stack` keyed the strain mapping under `detector_name`, so
`DetectorStrainStack.from_mapping` stored detector names in `self._names`. Since
`DetectorStrainStack.write(format="gwf")` uses `self._names` to set `ts_named.name`, the channel
override never reached the frame file. The `series.channel = channel_name` line was dead code.

### Fix

Use `channel_name` (when set) as the key passed to `DetectorStrainStack.from_mapping`, so `self._names` carries the channel names the user configured:

```python
# before
mapping[detector_name] = series
return DetectorStrainStack.from_mapping(active_detector_names, mapping)

# after
effective_name = channel_name if channel_name is not None else detector_name
effective_names.append(effective_name)
mapping[effective_name] = series
return DetectorStrainStack.from_mapping(effective_names, mapping)
```

Also removes the dead `series.channel = channel_name` assignment.

### Tests

Two regression tests added to `tests/cli/test_cli_orchestration.py`:
- `test_build_signal_stack_uses_channel_name_as_gwf_channel`
- `test_build_signal_stack_falls_back_to_detector_name_when_channel_is_none`

Full suite: 494 passed, 23 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed signal channel naming to correctly prioritize provided channel names when available, with fallback to detector names.

* **Tests**
  * Added tests for signal channel naming behavior to ensure correct identification of channels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Leuven-Gravity-Institute/gwmock/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->