### PR TITLE
fix(cli): Fix config file supported modes

### DIFF
--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -32,8 +32,8 @@ from gwmock.simulator.state import StateAttribute
 class AdapterOrchestrationResult:
     """Artifacts produced by one adapter-backed orchestration batch."""
 
-    signal_segment: TimeSeries
-    noise_result: SimulationResult
+    signal_segment: TimeSeries | None
+    noise_result: SimulationResult | None
 
 
 def _normalize_keys(values: dict[str, Any]) -> dict[str, Any]:
@@ -101,18 +101,26 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         self.minimum_frequency = minimum_frequency
         self.earth_rotation = earth_rotation
         self.orchestration_config = orchestration_config
-        self.signal_adapter = (
-            signal_adapter
-            if signal_adapter is not None
-            else SignalAdapter.from_source_type(
+        if signal_adapter is not None:
+            self.signal_adapter = signal_adapter
+        elif orchestration_config.signal is not None:
+            self.signal_adapter = SignalAdapter.from_source_type(
                 source_type=source_type,
                 waveform_model=waveform_model,
                 network=detector_network,
             )
+        else:
+            self.signal_adapter = None
+        self.detectors = (
+            list(self.signal_adapter.detector_names) if self.signal_adapter is not None else list(detectors)
         )
-        self.detectors = list(self.signal_adapter.detector_names)
         self.noise_arguments = noise_arguments
-        self.noise_adapter = noise_adapter if noise_adapter is not None else NoiseAdapter.from_backend()
+        if noise_adapter is not None:
+            self.noise_adapter = noise_adapter
+        elif orchestration_config.noise is not None:
+            self.noise_adapter = NoiseAdapter.from_backend()
+        else:
+            self.noise_adapter = None
         self._active_signal_output_directory = Path("signal")
         self._active_noise_output_directory = Path("noise")
         self._active_noise_output_arguments: dict[str, Any] = {}
@@ -141,61 +149,136 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         duration = float(global_args.get("duration", 4.0))
         sampling_frequency = float(global_args.get("sampling_frequency", 4096.0))
         start_time = float(global_args.get("start_time", 0.0))
-        noise_arguments = _normalize_keys(orchestration_config.noise.arguments)
-        if global_args.get("seed") is not None:
-            noise_arguments.setdefault("seed", int(global_args["seed"]))
+
+        has_population = orchestration_config.population is not None
+        has_signal = orchestration_config.signal is not None
+
+        noise_arguments, detector_network, detector_resolution, resolved_detectors = (
+            cls._resolve_detectors_and_noise_args(orchestration_config, global_args)
+        )
         top_level_seed = int(noise_arguments["seed"]) if noise_arguments.get("seed") is not None else None
         population_seed = derive_seed(top_level_seed, "population") if top_level_seed is not None else None
-        detector_network, detector_resolution = cls._resolve_detector_network(orchestration_config.signal.detectors)
-        resolved_detectors = cls._network_detector_names(detector_network)
 
-        population_backend = cls._instantiate_population_backend(orchestration_config.population)
-        population_adapter = PopulationAdapter.from_backend(
-            population_backend,
-            n_samples=orchestration_config.population.n_samples,
-            **({"seed": population_seed} if population_seed is not None else {}),
-        )
-        signal_adapter = cls._instantiate_signal_adapter(
-            orchestration_config.signal,
-            source_type=population_adapter.source_type,
-            detector_network=detector_network,
-        )
-        population_events = list(population_adapter.iter_event_parameters())
-        if orchestration_config.population.sort_by:
-            sort_key = orchestration_config.population.sort_by
-            if population_events and any(sort_key not in event for event in population_events):
-                raise ValueError(f"Population event ordering key '{sort_key}' is missing from one or more events.")
-            population_events.sort(key=lambda event: event[sort_key])
+        population_events: list[dict[str, Any]] = []
+        population_metadata: dict[str, Any] = {}
+        source_type = ""
+        source_detector_specs: list[str] = []
+        waveform_model: str | None = None
+        waveform_arguments: dict[str, Any] = {}
+        minimum_frequency = 5.0
+        earth_rotation = True
+        signal_adapter: SignalAdapter | None = None
+        noise_adapter: NoiseAdapter | None = None
 
-        if "detectors" in noise_arguments:
-            noise_network, _ = cls._resolve_detector_network(noise_arguments["detectors"])
-            noise_arguments["detectors"] = cls._network_detector_names(noise_network)
-        else:
-            noise_arguments["detectors"] = resolved_detectors
-        noise_adapter = cls._instantiate_noise_adapter(orchestration_config.noise)
+        if has_population:
+            population_events, population_metadata, source_type = cls._build_population_context(
+                orchestration_config.population,  # type: ignore[arg-type]
+                population_seed,
+            )
+
+        if has_signal:
+            signal_adapter = cls._instantiate_signal_adapter(
+                orchestration_config.signal,
+                source_type=source_type,
+                detector_network=detector_network,
+            )
+            source_detector_specs = list(orchestration_config.signal.detectors)  # type: ignore[union-attr]
+            waveform_model = orchestration_config.signal.waveform_model  # type: ignore[union-attr]
+            waveform_arguments = orchestration_config.signal.waveform_arguments  # type: ignore[union-attr]
+            minimum_frequency = orchestration_config.signal.minimum_frequency  # type: ignore[union-attr]
+            earth_rotation = orchestration_config.signal.earth_rotation  # type: ignore[union-attr]
+            if orchestration_config.noise is None:
+                noise_arguments["detectors"] = resolved_detectors
+
+        if orchestration_config.noise is not None:
+            noise_adapter = cls._instantiate_noise_adapter(orchestration_config.noise)
 
         return cls(
             population_events=population_events,
-            population_metadata=population_adapter.metadata,
-            source_type=population_adapter.source_type,
-            source_detector_specs=list(orchestration_config.signal.detectors),
+            population_metadata=population_metadata,
+            source_type=source_type,
+            source_detector_specs=source_detector_specs,
             detector_network=detector_network,
             detector_resolution=detector_resolution,
-            waveform_model=orchestration_config.signal.waveform_model,
-            waveform_arguments=orchestration_config.signal.waveform_arguments,
+            waveform_model=waveform_model,
+            waveform_arguments=waveform_arguments,
             detectors=resolved_detectors,
             duration=duration,
             sampling_frequency=sampling_frequency,
             start_time=start_time,
             max_samples=max_samples,
-            minimum_frequency=orchestration_config.signal.minimum_frequency,
-            earth_rotation=orchestration_config.signal.earth_rotation,
+            minimum_frequency=minimum_frequency,
+            earth_rotation=earth_rotation,
             noise_arguments=noise_arguments,
             orchestration_config=orchestration_config,
             population_seed=population_seed,
             signal_adapter=signal_adapter,
             noise_adapter=noise_adapter,
         )
+
+    @classmethod
+    def _resolve_detectors_and_noise_args(
+        cls,
+        orchestration_config: OrchestrationConfig,
+        global_args: dict[str, Any],
+    ) -> tuple[dict[str, Any], Network | None, dict[str, Any], list[str]]:
+        """Resolve noise arguments and detector lists for all active adapters."""
+        has_noise = orchestration_config.noise is not None
+        has_signal = orchestration_config.signal is not None
+
+        noise_arguments: dict[str, Any] = (
+            _normalize_keys(orchestration_config.noise.arguments)  # type: ignore[union-attr]
+            if has_noise
+            else {}
+        )
+        if global_args.get("seed") is not None:
+            noise_arguments.setdefault("seed", int(global_args["seed"]))
+
+        detector_network: Network | None = None
+        detector_resolution: dict[str, Any] = {}
+        resolved_detectors: list[str] = []
+
+        if has_signal:
+            detector_network, detector_resolution = cls._resolve_detector_network(
+                orchestration_config.signal.detectors  # type: ignore[union-attr]
+            )
+            resolved_detectors = cls._network_detector_names(detector_network)
+
+        if has_noise:
+            if "detectors" in noise_arguments:
+                noise_network, _ = cls._resolve_detector_network(noise_arguments["detectors"])
+                noise_arguments["detectors"] = cls._network_detector_names(noise_network)
+                if not has_signal:
+                    resolved_detectors = noise_arguments["detectors"]
+            elif has_signal:
+                noise_arguments["detectors"] = resolved_detectors
+            else:
+                raise ValueError(
+                    "noise-only orchestration config must specify detectors under noise.arguments.detectors"
+                )
+
+        return noise_arguments, detector_network, detector_resolution, resolved_detectors
+
+    @classmethod
+    def _build_population_context(
+        cls,
+        population_config: Any,
+        population_seed: int | None,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any], str]:
+        """Materialise population events and return (events, metadata, source_type)."""
+        population_backend = cls._instantiate_population_backend(population_config)
+        population_adapter = PopulationAdapter.from_backend(
+            population_backend,
+            n_samples=population_config.n_samples,
+            **({"seed": population_seed} if population_seed is not None else {}),
+        )
+        population_events = list(population_adapter.iter_event_parameters())
+        sort_key = population_config.sort_by
+        if sort_key:
+            if population_events and any(sort_key not in event for event in population_events):
+                raise ValueError(f"Population event ordering key '{sort_key}' is missing from one or more events.")
+            population_events.sort(key=lambda event: event[sort_key])
+        return population_events, population_adapter.metadata, population_adapter.source_type
 
     @staticmethod
     def _instantiate_population_backend(population_config) -> GWPopSimulator:
@@ -270,27 +353,29 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
 
     def set_batch_context(self, *, batch: Any, output_directory: Path, overwrite: bool) -> None:
         """Resolve per-batch output directories and runtime arguments."""
-        signal_output = batch.simulator_config.signal.output
-        noise_output = batch.simulator_config.noise.output
-        self._active_signal_output_directory = self._resolve_output_directory(
-            output_directory,
-            signal_output.output_directory,
-            fallback_subdir="signal",
-        )
-        self._active_noise_output_directory = self._resolve_output_directory(
-            output_directory,
-            noise_output.output_directory,
-            fallback_subdir="noise",
-        )
-        noise_detectors = list(self.noise_arguments["detectors"])
-        proxy = _NoiseTemplateProxy(self, noise_detectors)
-        self._active_noise_output_arguments = expand_template_variables(noise_output.arguments or {}, proxy)
+        if batch.simulator_config.signal is not None:
+            signal_output = batch.simulator_config.signal.output
+            self._active_signal_output_directory = self._resolve_output_directory(
+                output_directory,
+                signal_output.output_directory,
+                fallback_subdir="signal",
+            )
+        if batch.simulator_config.noise is not None:
+            noise_output = batch.simulator_config.noise.output
+            self._active_noise_output_directory = self._resolve_output_directory(
+                output_directory,
+                noise_output.output_directory,
+                fallback_subdir="noise",
+            )
+            noise_detectors = list(self.noise_arguments.get("detectors", []))
+            proxy = _NoiseTemplateProxy(self, noise_detectors)
+            self._active_noise_output_arguments = expand_template_variables(noise_output.arguments or {}, proxy)
         self._active_overwrite = overwrite
 
     def simulate(self) -> AdapterOrchestrationResult:
-        """Generate one signal segment and one noise segment for the current batch."""
-        signal_segment = TimeSeriesMixin.simulate(self)
-        noise_result = self._run_noise_batch()
+        """Generate signal and/or noise for the current batch depending on active adapters."""
+        signal_segment = TimeSeriesMixin.simulate(self) if self.signal_adapter is not None else None
+        noise_result = self._run_noise_batch() if self.noise_adapter is not None else None
         return AdapterOrchestrationResult(signal_segment=signal_segment, noise_result=noise_result)
 
     def _simulate(self) -> TimeSeriesList:
@@ -331,6 +416,8 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
 
     def signal_output_arguments(self) -> dict[str, Any]:
         """Return the active signal output keyword arguments."""
+        if self.orchestration_config.signal is None:
+            return {}
         return dict(self.orchestration_config.signal.output.arguments or {})
 
     def _save_data(

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -254,7 +254,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                 noise_arguments["detectors"] = resolved_detectors
             else:
                 raise ValueError(
-                    "noise-only orchestration config must specify detectors under noise.arguments.detectors"
+                    "noise orchestration without a signal section must specify detectors under noise.arguments.detectors"
                 )
 
         return noise_arguments, detector_network, detector_resolution, resolved_detectors

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -183,6 +183,8 @@ def _build_population_section(simulator: Simulator, batch: SimulationBatch) -> d
     """Build the population section for the metadata schema."""
     simulator_metadata = simulator.metadata
     if isinstance(simulator, AdapterOrchestrator):
+        if batch.simulator_config.population is None:
+            return None
         return {
             "backend": batch.simulator_config.population.backend,
             "source_type": simulator_metadata["orchestration"]["source_type"],
@@ -206,6 +208,8 @@ def _build_signal_section(simulator: Simulator, batch: SimulationBatch) -> dict[
     """Build the signal section for the metadata schema."""
     simulator_metadata = simulator.metadata
     if isinstance(simulator, AdapterOrchestrator):
+        if batch.simulator_config.signal is None or simulator.signal_adapter is None:
+            return None
         return {
             "backend": _backend_path_from_object(simulator.signal_adapter._backend),
             "waveform_model": simulator.waveform_model,
@@ -227,6 +231,8 @@ def _build_noise_section(simulator: Simulator, batch: SimulationBatch) -> dict[s
     """Build the noise section for the metadata schema."""
     simulator_metadata = simulator.metadata
     if isinstance(simulator, AdapterOrchestrator):
+        if batch.simulator_config.noise is None or simulator.noise_adapter is None:
+            return None
         psd_value = simulator.noise_arguments.get("psd_file")
         if psd_value is None and simulator.noise_arguments.get("psd_files"):
             psd_value = "multiple"
@@ -255,42 +261,44 @@ def _build_output_records(
     output_records: list[dict[str, Any]] = []
 
     if isinstance(batch_data, AdapterOrchestrationResult):
-        signal_files = _resolve_output_paths(
-            file_name_template=batch.simulator_config.signal.output.file_name,
-            simulator=simulator,
-            output_directory=cast(AdapterOrchestrator, simulator).signal_output_directory(),
-        )
-        signal_channels = _flatten_to_strings(
-            expand_template_variables(batch.simulator_config.signal.output.arguments.get("channel"), simulator)
-        )
-        for index, output_file in enumerate(signal_files):
-            output_records.append(
-                {
-                    "kind": "signal",
-                    "path": _to_path_string(output_file, working_directory),
-                    "channels": signal_channels[index : index + 1] if signal_channels else [],
-                    "t0": _to_plain_number(batch_data.signal_segment.start_time),
-                    "duration": _to_plain_number(batch_data.signal_segment.duration),
-                    "sha256": compute_file_hash(output_file),
-                }
+        if batch.simulator_config.signal is not None and batch_data.signal_segment is not None:
+            signal_files = _resolve_output_paths(
+                file_name_template=batch.simulator_config.signal.output.file_name,
+                simulator=simulator,
+                output_directory=cast(AdapterOrchestrator, simulator).signal_output_directory(),
             )
+            signal_channels = _flatten_to_strings(
+                expand_template_variables(batch.simulator_config.signal.output.arguments.get("channel"), simulator)
+            )
+            for index, output_file in enumerate(signal_files):
+                output_records.append(
+                    {
+                        "kind": "signal",
+                        "path": _to_path_string(output_file, working_directory),
+                        "channels": signal_channels[index : index + 1] if signal_channels else [],
+                        "t0": _to_plain_number(batch_data.signal_segment.start_time),
+                        "duration": _to_plain_number(batch_data.signal_segment.duration),
+                        "sha256": compute_file_hash(output_file),
+                    }
+                )
 
-        noise_output_config = batch_data.noise_result.config.output
-        for detector, output_path in batch_data.noise_result.output_paths.items():
-            if noise_output_config.channels and detector in noise_output_config.channels:
-                channel_id = noise_output_config.channels[detector]
-            else:
-                channel_id = f"{detector}:{noise_output_config.channel}"
-            output_records.append(
-                {
-                    "kind": "noise",
-                    "path": _to_path_string(output_path, working_directory),
-                    "channels": [channel_id],
-                    "t0": _to_plain_number(simulator.start_time),
-                    "duration": _to_plain_number(simulator.duration),
-                    "sha256": compute_file_hash(output_path),
-                }
-            )
+        if batch_data.noise_result is not None:
+            noise_output_config = batch_data.noise_result.config.output
+            for detector, output_path in batch_data.noise_result.output_paths.items():
+                if noise_output_config.channels and detector in noise_output_config.channels:
+                    channel_id = noise_output_config.channels[detector]
+                else:
+                    channel_id = f"{detector}:{noise_output_config.channel}"
+                output_records.append(
+                    {
+                        "kind": "noise",
+                        "path": _to_path_string(output_path, working_directory),
+                        "channels": [channel_id],
+                        "t0": _to_plain_number(simulator.start_time),
+                        "duration": _to_plain_number(simulator.duration),
+                        "sha256": compute_file_hash(output_path),
+                    }
+                )
         return output_records
 
     if isinstance(batch_data, SimulationResult):
@@ -658,33 +666,44 @@ def process_batch(
         if not isinstance(batch.simulator_config, OrchestrationConfig):
             raise TypeError("Adapter orchestration results require an OrchestrationConfig batch.")
 
-        signal_output = batch.simulator_config.signal.output
-        logger.debug(
-            "[PROCESS] Batch %s: Saving adapter-backed outputs - counter=%s, signal_template=%s, noise_template=%s",
-            batch.batch_index,
-            simulator.counter,
-            signal_output.file_name,
-            batch.simulator_config.noise.output.file_name,
-        )
-        signal_output_files = _resolve_output_paths(
-            file_name_template=signal_output.file_name,
-            simulator=simulator,
-            output_directory=cast(AdapterOrchestrator, simulator).signal_output_directory(),
-        )
-        simulator.save_data(
-            data=batch_data.signal_segment,
-            file_name=signal_output.file_name,
-            output_directory=cast(AdapterOrchestrator, simulator).signal_output_directory(),
-            overwrite=overwrite,
-            **cast(AdapterOrchestrator, simulator).signal_output_arguments(),
-        )
-        noise_output_files = list(batch_data.noise_result.output_paths.values())
-        missing_noise_outputs = [path for path in noise_output_files if not path.exists()]
-        if missing_noise_outputs:
-            raise FileNotFoundError(
-                "Noise adapter reported output files that do not exist: "
-                + ", ".join(str(path) for path in missing_noise_outputs)
+        signal_output_files: list[Path] = []
+        if batch.simulator_config.signal is not None and batch_data.signal_segment is not None:
+            signal_output = batch.simulator_config.signal.output
+            logger.debug(
+                "[PROCESS] Batch %s: Saving signal output - counter=%s, template=%s",
+                batch.batch_index,
+                simulator.counter,
+                signal_output.file_name,
             )
+            signal_output_files = _resolve_output_paths(
+                file_name_template=signal_output.file_name,
+                simulator=simulator,
+                output_directory=cast(AdapterOrchestrator, simulator).signal_output_directory(),
+            )
+            simulator.save_data(
+                data=batch_data.signal_segment,
+                file_name=signal_output.file_name,
+                output_directory=cast(AdapterOrchestrator, simulator).signal_output_directory(),
+                overwrite=overwrite,
+                **cast(AdapterOrchestrator, simulator).signal_output_arguments(),
+            )
+
+        noise_output_files: list[Path] = []
+        if batch_data.noise_result is not None:
+            noise_output_files = list(batch_data.noise_result.output_paths.values())
+            missing_noise_outputs = [path for path in noise_output_files if not path.exists()]
+            if missing_noise_outputs:
+                raise FileNotFoundError(
+                    "Noise adapter reported output files that do not exist: "
+                    + ", ".join(str(path) for path in missing_noise_outputs)
+                )
+
+        logger.debug(
+            "[PROCESS] Batch %s: adapter outputs - signal=%d files, noise=%d files",
+            batch.batch_index,
+            len(signal_output_files),
+            len(noise_output_files),
+        )
         return [*signal_output_files, *noise_output_files]
 
     if isinstance(batch_data, SimulationResult):
@@ -799,9 +818,9 @@ def validate_plan(plan: SimulationPlan) -> None:
             raise ValueError(f"Batch {batch.batch_index} has invalid index")
 
         if isinstance(batch.simulator_config, OrchestrationConfig):
-            if not batch.simulator_config.signal.output.file_name:
+            if batch.simulator_config.signal is not None and not batch.simulator_config.signal.output.file_name:
                 raise ValueError(f"Batch {batch.simulator_name}-{batch.batch_index} missing signal output file_name")
-            if not batch.simulator_config.noise.output.file_name:
+            if batch.simulator_config.noise is not None and not batch.simulator_config.noise.output.file_name:
                 raise ValueError(f"Batch {batch.simulator_name}-{batch.batch_index} missing noise output file_name")
         else:
             output_config = batch.simulator_config.output

--- a/src/gwmock/cli/utils/config.py
+++ b/src/gwmock/cli/utils/config.py
@@ -205,9 +205,17 @@ class NoiseAdapterConfig(BaseModel):
 class OrchestrationConfig(BaseModel):
     """Composite adapter-backed orchestration configuration."""
 
-    population: PopulationConfig
-    signal: SignalConfig
-    noise: NoiseAdapterConfig
+    noise: NoiseAdapterConfig | None = None
+    population: PopulationConfig | None = None
+    signal: SignalConfig | None = None
+
+    @model_validator(mode="after")
+    def _validate_combinations(self) -> OrchestrationConfig:
+        if self.noise is None and self.population is None and self.signal is None:
+            raise ValueError("orchestration must define at least one of: noise, population, signal")
+        if self.signal is not None and self.population is None:
+            raise ValueError("orchestration.signal requires orchestration.population")
+        return self
 
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
@@ -392,11 +400,15 @@ def validate_config(config: dict) -> None:
     if not isinstance(orchestration, dict):
         raise ValueError("'orchestration' must be a dictionary")
 
-    for section in ("population", "signal", "noise"):
-        if section not in orchestration:
-            raise ValueError(f"'orchestration' missing required '{section}' section")
+    known_sections = {"population", "signal", "noise"}
+    present_sections = known_sections & set(orchestration.keys())
+    if not present_sections:
+        raise ValueError("'orchestration' must define at least one of: noise, population, signal")
+    for section in present_sections:
         if not isinstance(orchestration[section], dict):
             raise ValueError(f"'orchestration.{section}' must be a dictionary")
+    if "signal" in orchestration and "population" not in orchestration:
+        raise ValueError("'orchestration.signal' requires 'orchestration.population'")
 
     # Validate globals section if present
     if "globals" in config:

--- a/tests/cli/test_partial_orchestration.py
+++ b/tests/cli/test_partial_orchestration.py
@@ -1,0 +1,214 @@
+"""Tests for partial OrchestrationConfig modes (noise-only, population-only, combinations)."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from gwmock.cli.adapter_orchestration import AdapterOrchestrationResult, AdapterOrchestrator
+from gwmock.cli.utils.config import (
+    NoiseAdapterConfig,
+    OrchestrationConfig,
+    PopulationConfig,
+    SignalConfig,
+    SimulatorOutputConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal fake adapters reused across tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeNoiseBackend:
+    metadata: ClassVar[dict] = {"kind": "fake"}
+
+    def __init__(
+        self,
+        duration: float = 4.0,
+        sampling_frequency: float = 4.0,
+        detectors: list[str] | None = None,
+        seed: int | None = None,
+        **_kwargs,
+    ) -> None:
+        self.duration = duration
+        self.sampling_frequency = sampling_frequency
+        self.detectors = ["H1"] if detectors is None else list(detectors)
+        self.seed = seed
+
+    def generate(self, duration, sampling_frequency, detectors, seed=None):
+        return {d: np.zeros(round(duration * sampling_frequency)) for d in detectors}
+
+    def generate_stream(self, chunk_duration, sampling_frequency, detectors, seed=None):
+        while True:
+            yield {d: np.zeros(round(chunk_duration * sampling_frequency)) for d in detectors}
+
+    @property
+    def backend(self):
+        return self
+
+
+class _FakePopulationBackend:
+    parameter_names: ClassVar[tuple] = ("coa_time",)
+    metadata: ClassVar[dict] = {}
+    source_type = "bbh"
+
+    def __init__(self, **_kwargs):
+        pass
+
+    def simulate(self, n_samples, **_kwargs):
+        return {"coa_time": np.array([100.0] * n_samples)}
+
+
+# ---------------------------------------------------------------------------
+# Validation tests (model construction only — no I/O)
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestrationConfigValidation:
+    def test_noise_only_config_validates(self):
+        cfg = OrchestrationConfig(
+            noise=NoiseAdapterConfig(
+                arguments={"detectors": ["H1"]},
+                output=SimulatorOutputConfig(file_name="noise-{{ counter }}.gwf"),
+            )
+        )
+        assert cfg.noise is not None
+        assert cfg.population is None
+        assert cfg.signal is None
+
+    def test_population_only_config_validates(self):
+        cfg = OrchestrationConfig(population=PopulationConfig(backend="fake", n_samples=1))
+        assert cfg.population is not None
+        assert cfg.noise is None
+        assert cfg.signal is None
+
+    def test_population_signal_no_noise_validates(self):
+        cfg = OrchestrationConfig(
+            population=PopulationConfig(backend="fake", n_samples=1),
+            signal=SignalConfig(
+                detectors=["H1"],
+                output=SimulatorOutputConfig(file_name="signal-{{ counter }}.gwf"),
+            ),
+        )
+        assert cfg.signal is not None
+        assert cfg.noise is None
+
+    def test_full_config_still_validates(self):
+        cfg = OrchestrationConfig(
+            noise=NoiseAdapterConfig(
+                arguments={"detectors": ["H1"]},
+                output=SimulatorOutputConfig(file_name="noise-{{ counter }}.gwf"),
+            ),
+            population=PopulationConfig(backend="fake", n_samples=1),
+            signal=SignalConfig(
+                detectors=["H1"],
+                output=SimulatorOutputConfig(file_name="signal-{{ counter }}.gwf"),
+            ),
+        )
+        assert cfg.noise is not None
+        assert cfg.population is not None
+        assert cfg.signal is not None
+
+    def test_signal_without_population_rejected(self):
+        with pytest.raises(ValidationError, match="population"):
+            OrchestrationConfig(
+                signal=SignalConfig(
+                    detectors=["H1"],
+                    output=SimulatorOutputConfig(file_name="signal.gwf"),
+                )
+            )
+
+    def test_empty_orchestration_rejected(self):
+        with pytest.raises(ValidationError, match="at least one"):
+            OrchestrationConfig()
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator construction tests (mock out real adapters)
+# ---------------------------------------------------------------------------
+
+
+def _make_noise_config(detectors=None):
+    return NoiseAdapterConfig(
+        backend="tests.cli.test_partial_orchestration:_FakeNoiseBackend",
+        arguments={"detectors": detectors or ["H1"], "seed": 1},
+        output=SimulatorOutputConfig(file_name="noise-{{ counter }}.npy", output_directory="noise"),
+    )
+
+
+def _make_population_config():
+    return PopulationConfig(
+        backend="tests.cli.test_partial_orchestration:_FakePopulationBackend",
+        n_samples=1,
+        arguments={},
+    )
+
+
+_GLOBAL_ARGS = {
+    "sampling-frequency": 4,
+    "duration": 4,
+    "start-time": 0,
+    "max-samples": 2,
+}
+
+
+class TestAdapterOrchestratorFromConfig:
+    def test_noise_only_from_config(self):
+        cfg = OrchestrationConfig(noise=_make_noise_config())
+        orch = AdapterOrchestrator.from_config(cfg, _GLOBAL_ARGS)
+        assert orch.signal_adapter is None
+        assert orch.noise_adapter is not None
+        assert orch.detectors == ["H1"]
+
+    def test_population_only_from_config(self):
+        cfg = OrchestrationConfig(population=_make_population_config())
+        orch = AdapterOrchestrator.from_config(cfg, _GLOBAL_ARGS)
+        assert orch.signal_adapter is None
+        assert orch.noise_adapter is None
+        assert orch.detectors == []
+        assert len(orch._population_events) == 1
+
+
+# ---------------------------------------------------------------------------
+# Simulate result tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterOrchestratorSimulate:
+    def test_noise_only_simulate_result(self, tmp_path):
+        cfg = OrchestrationConfig(noise=_make_noise_config())
+        orch = AdapterOrchestrator.from_config(cfg, _GLOBAL_ARGS)
+
+        batch_mock = MagicMock()
+        batch_mock.simulator_config = cfg
+        orch.set_batch_context(
+            batch=batch_mock,
+            output_directory=tmp_path,
+            overwrite=True,
+        )
+
+        result = orch.simulate()
+        assert isinstance(result, AdapterOrchestrationResult)
+        assert result.signal_segment is None
+        assert result.noise_result is not None
+
+    def test_population_only_simulate_result(self):
+        cfg = OrchestrationConfig(population=_make_population_config())
+        orch = AdapterOrchestrator.from_config(cfg, _GLOBAL_ARGS)
+
+        batch_mock = MagicMock()
+        batch_mock.simulator_config = cfg
+        orch.set_batch_context(
+            batch=batch_mock,
+            output_directory=MagicMock(),
+            overwrite=True,
+        )
+
+        result = orch.simulate()
+        assert isinstance(result, AdapterOrchestrationResult)
+        assert result.signal_segment is None
+        assert result.noise_result is None


### PR DESCRIPTION
Close #129 

### Summary

All three sections of `OrchestrationConfig` (`noise`, `population`, `signal`) are now
optional. Supported modes:

| Mode | noise | population | signal |
|------|-------|-----------|--------|
| Noise-only | ✓ | — | — |
| Population-only | — | ✓ | — |
| Population + noise | ✓ | ✓ | — |
| Population + signal (± noise) | opt | ✓ | ✓ |
| Full | ✓ | ✓ | ✓ |

Invalid combinations (signal without population; no sections) are rejected at parse
time with a clear error.

### Changes

- **`config.py`**: `OrchestrationConfig` fields now `Optional = None`; model
  validator enforces combination rules; `validate_config()` updated to match
- **`adapter_orchestration.py`**: `AdapterOrchestrationResult` fields optional;
  `from_config()` builds adapters conditionally; `simulate()` dispatches on adapter
  presence; `set_batch_context()` and `signal_output_arguments()` guarded
- **`simulate_utils.py`**: all `_build_*_section()` helpers, `_build_output_records()`,
  `validate_plan()`, and `process_batch()` guarded against absent configs/results
- **`tests/cli/test_partial_orchestration.py`**: 10 new tests

### Test results

```
510 passed, 23 skipped — no regressions
gwmock config --get noise/uncorrelated_gaussian/et_triangle_emr → exit 0 ✅
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simulations now support flexible configuration modes: noise-only, population-only, or signal+population combinations
  * Configuration validation updated to enforce valid option combinations while allowing optional components

* **Tests**
  * Added comprehensive tests for partial orchestration scenarios to ensure correct behavior across different configuration modes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Leuven-Gravity-Institute/gwmock/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->