### PR TITLE
fix(cli): Fixing PopulationConfig loader to make n-samples optional

### DIFF
--- a/src/gwmock/cli/utils/config.py
+++ b/src/gwmock/cli/utils/config.py
@@ -118,7 +118,11 @@ class PopulationConfig(BaseModel):
     """Adapter-backed population configuration."""
 
     backend: str = Field(..., description="Public gwmock-pop backend or loader name")
-    n_samples: int = Field(..., alias="n-samples", description="Number of population events to materialize")
+    n_samples: int | None = Field(
+        default=None,
+        alias="n-samples",
+        description="Number of population events to draw. Omit to load the full catalogue (file-backed loaders only).",
+    )
     source_type: str | None = Field(default=None, alias="source-type", description="Optional explicit source type")
     sort_by: str | None = Field(default="coa_time", alias="sort-by", description="Event ordering key")
     arguments: dict[str, Any] = Field(default_factory=dict, description="Arguments passed to the population backend")
@@ -135,9 +139,9 @@ class PopulationConfig(BaseModel):
 
     @field_validator("n_samples")
     @classmethod
-    def validate_n_samples(cls, v: int) -> int:
-        """Require an explicit positive population sample count."""
-        if v <= 0:
+    def validate_n_samples(cls, v: int | None) -> int | None:
+        """Reject n_samples=0 or negative; None means load the full catalogue."""
+        if v is not None and v <= 0:
             raise ValueError("'n-samples' must be a positive integer")
         return v
 

--- a/src/gwmock/population/adapter.py
+++ b/src/gwmock/population/adapter.py
@@ -41,14 +41,14 @@ class PopulationAdapter:
         cls,
         backend: GWPopSimulator,
         *,
-        n_samples: int,
+        n_samples: int | None,
         **kwargs: Any,
     ) -> PopulationAdapter:
         """Build an adapter from a ``gwmock-pop`` protocol backend.
 
         Args:
             backend: The backend to use.
-            n_samples: The number of samples to generate.
+            n_samples: The number of samples to generate, or ``None`` to load the full catalogue.
             **kwargs: Additional arguments to pass to the backend.
 
         Returns:
@@ -61,7 +61,7 @@ class PopulationAdapter:
         """
         if not isinstance(backend, GWPopSimulator):
             raise TypeError("backend must satisfy the GWPopSimulator protocol.")
-        if n_samples <= 0:
+        if n_samples is not None and n_samples <= 0:
             raise ValueError("n_samples must be a positive integer.")
 
         parameter_names = tuple(backend.parameter_names)

--- a/tests/cli/test_partial_orchestration.py
+++ b/tests/cli/test_partial_orchestration.py
@@ -17,6 +17,7 @@ from gwmock.cli.utils.config import (
     SignalConfig,
     SimulatorOutputConfig,
 )
+from gwmock.population.adapter import PopulationAdapter
 
 # ---------------------------------------------------------------------------
 # Minimal fake adapters reused across tests
@@ -212,3 +213,35 @@ class TestAdapterOrchestratorSimulate:
         assert isinstance(result, AdapterOrchestrationResult)
         assert result.signal_segment is None
         assert result.noise_result is None
+
+
+# ---------------------------------------------------------------------------
+# ISS-007 — n_samples optional in PopulationConfig
+# ---------------------------------------------------------------------------
+
+
+class TestPopulationConfigNSamples:
+    def test_population_config_without_n_samples_validates(self):
+        cfg_with = PopulationConfig(backend="X", n_samples=1)
+        assert cfg_with.n_samples == 1
+
+        cfg_without = PopulationConfig(backend="X")
+        assert cfg_without.n_samples is None
+
+    def test_population_config_zero_n_samples_rejected(self):
+        with pytest.raises(ValidationError, match="n-samples"):
+            PopulationConfig(backend="X", n_samples=0)
+
+    def test_from_backend_passes_none_to_simulate(self):
+        class _NoneAwareBackend:
+            parameter_names = ("coa_time",)
+            source_type = "bbh"
+            metadata: ClassVar[dict] = {}
+
+            def simulate(self, n_samples, **_kwargs):
+                self._last_n_samples = n_samples
+                return {"coa_time": np.array([1.0])}
+
+        backend = _NoneAwareBackend()
+        PopulationAdapter.from_backend(backend, n_samples=None)
+        assert backend._last_n_samples is None

--- a/tests/cli/test_partial_orchestration.py
+++ b/tests/cli/test_partial_orchestration.py
@@ -245,3 +245,29 @@ class TestPopulationConfigNSamples:
         backend = _NoneAwareBackend()
         PopulationAdapter.from_backend(backend, n_samples=None)
         assert backend._last_n_samples is None
+
+    def test_from_backend_rejects_non_protocol_object(self):
+        with pytest.raises(TypeError, match="GWPopSimulator protocol"):
+            PopulationAdapter.from_backend(object(), n_samples=1)
+
+    def test_from_backend_rejects_negative_n_samples(self):
+        class _MinimalBackend:
+            parameter_names = ("coa_time",)
+            source_type = "bbh"
+
+            def simulate(self, n_samples, **_kwargs):  # pragma: no cover
+                return {"coa_time": np.array([])}
+
+        with pytest.raises(ValueError, match="positive integer"):
+            PopulationAdapter.from_backend(_MinimalBackend(), n_samples=-1)
+
+    def test_from_backend_rejects_empty_parameter_names(self):
+        class _EmptyNamesBackend:
+            parameter_names: ClassVar[tuple] = ()
+            source_type = "bbh"
+
+            def simulate(self, n_samples, **_kwargs):  # pragma: no cover
+                return {}
+
+        with pytest.raises(ValueError, match="parameter_names must not be empty"):
+            PopulationAdapter.from_backend(_EmptyNamesBackend(), n_samples=1)

--- a/tests/population/test_adapter.py
+++ b/tests/population/test_adapter.py
@@ -282,3 +282,19 @@ class TestPopulationAdapter:
         assert isinstance(backend, GWPopSimulator)
         assert backend.__class__.__name__ == "EntryPointPopulationBackend"
         assert backend.simulate(1)["detector_frame_mass_1"][0] == pytest.approx(7.0)
+
+    def test_population_mapping_property_returns_proxy(self):
+        adapter = PopulationAdapter.from_mapping({"coa_time": np.array([1.0, 2.0])}, source_type="bbh")
+        mapping = adapter.population_mapping
+        assert mapping["coa_time"] == (1.0, 2.0)
+        with pytest.raises((TypeError, AttributeError)):
+            mapping["coa_time"] = np.array([9.0])  # type: ignore[index]
+
+    def test_get_event_parameters_out_of_bounds(self):
+        adapter = PopulationAdapter.from_mapping({"coa_time": np.array([1.0])}, source_type="bbh")
+        with pytest.raises(IndexError, match="out of range"):
+            adapter.get_event_parameters(5)
+
+    def test_from_mapping_rejects_invalid_source_type(self):
+        with pytest.raises(ValueError, match="non-empty string"):
+            PopulationAdapter.from_mapping({"coa_time": np.array([1.0])}, source_type="")


### PR DESCRIPTION
### What changed

- **`PopulationConfig.n_samples`** is now `int | None = None`. Omitting `n-samples` in a config passes `None` to the backend; `FilePopulationLoader` then loads the full catalogue.
- **`PopulationAdapter.from_backend`** signature updated to `n_samples: int | None`; the `<= 0` guard is skipped when `None`.

### Tests

```
513 passed, 23 skipped, 2 deselected
```

3 new tests in `tests/cli/test_partial_orchestration.py::TestPopulationConfigNSamples`:
- `test_population_config_without_n_samples_validates`
- `test_population_config_zero_n_samples_rejected`
- `test_from_backend_passes_none_to_simulate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Population sample size configuration is now optional; leave it unset to load the entire population.

* **Tests**
  * Added tests for optional population sampling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Leuven-Gravity-Institute/gwmock/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->