### PR TITLE
fix(signal): Auto-drop unsopported waveform params from population

### DIFF
--- a/src/gwmock/signal/adapter.py
+++ b/src/gwmock/signal/adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Mapping, Sequence
 from functools import lru_cache
 from pathlib import Path
@@ -10,6 +11,8 @@ from typing import Any
 from gwmock_signal import CustomDetector, DetectorStrainStack, Network, resolve_simulator_backend
 
 from gwmock.data.time_series.time_series import TimeSeries
+
+logger = logging.getLogger("gwmock")
 
 _DEFAULT_WAVEFORM_MODEL = "IMRPhenomXPHM"
 _LEGACY_SINGLE_DETECTOR_ALIASES = {
@@ -158,6 +161,7 @@ class SignalAdapter:
         self._detector_names = tuple(
             detector if isinstance(detector, str) else detector.name for detector in self._network.detector_names
         )
+        self._unsupported_params: set[str] = set()
 
     @classmethod
     def from_source_type(
@@ -343,14 +347,41 @@ class SignalAdapter:
             A DetectorStrainStack instance.
         """
         backend_parameters = {**(waveform_arguments or {}), **dict(parameters)}
-        return self._backend.simulate(
-            backend_parameters,
-            self._network.detector_names,
-            background=None,
-            sampling_frequency=sampling_frequency,
-            minimum_frequency=minimum_frequency,
-            earth_rotation=earth_rotation,
-        )
+        if self._unsupported_params:
+            backend_parameters = {k: v for k, v in backend_parameters.items() if k not in self._unsupported_params}
+        try:
+            return self._backend.simulate(
+                backend_parameters,
+                self._network.detector_names,
+                background=None,
+                sampling_frequency=sampling_frequency,
+                minimum_frequency=minimum_frequency,
+                earth_rotation=earth_rotation,
+            )
+        except ValueError as exc:
+            _prefix = "Unsupported LAL waveform parameters:"
+            msg = str(exc)
+            if not msg.startswith(_prefix):
+                raise
+            extras = {k.strip() for k in msg[len(_prefix) :].split(",")}
+            new = extras - self._unsupported_params
+            if new:
+                logger.warning(
+                    "Waveform backend does not accept the following population parameters "
+                    "and they will be ignored: %s. "
+                    "They are still recorded in injection_parameters metadata.",
+                    ", ".join(sorted(new)),
+                )
+                self._unsupported_params |= new
+            filtered = {k: v for k, v in backend_parameters.items() if k not in self._unsupported_params}
+            return self._backend.simulate(
+                filtered,
+                self._network.detector_names,
+                background=None,
+                sampling_frequency=sampling_frequency,
+                minimum_frequency=minimum_frequency,
+                earth_rotation=earth_rotation,
+            )
 
     def simulate(
         self,

--- a/tests/cli/test_partial_orchestration.py
+++ b/tests/cli/test_partial_orchestration.py
@@ -216,7 +216,7 @@ class TestAdapterOrchestratorSimulate:
 
 
 # ---------------------------------------------------------------------------
-# ISS-007 — n_samples optional in PopulationConfig
+# n_samples optional in PopulationConfig
 # ---------------------------------------------------------------------------
 
 

--- a/tests/signal/test_adapter.py
+++ b/tests/signal/test_adapter.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -240,3 +240,103 @@ class TestSignalAdapter:
         assert backend.waveform_model.startswith("__gwmock_custom__")
         assert merged_calls[0]["reference_frequency"] == 50.0
         assert merged_calls[0]["detector_frame_mass_1"] == 30.0
+
+
+class FailingBackend:
+    """Backend that raises 'Unsupported LAL waveform parameters' on the first call."""
+
+    def __init__(self, *, waveform_model: str) -> None:
+        self.waveform_model = waveform_model
+        self.required_params = frozenset({"coa_time"})
+        self.call_count = 0
+        self.received_params: list[dict] = []
+
+    def simulate(
+        self,
+        params,
+        detector_names,
+        background=None,
+        *,
+        sampling_frequency,
+        minimum_frequency,
+        earth_rotation=True,
+        interpolate_if_offset=True,
+    ):
+        self.call_count += 1
+        self.received_params.append(dict(params))
+        if "redshift" in params or "lambda_1" in params:
+            raise ValueError("Unsupported LAL waveform parameters: lambda_1, redshift")
+        names = tuple(d if isinstance(d, str) else d.name for d in detector_names)
+        from gwpy.timeseries import TimeSeries as GWpyTimeSeries
+
+        return DetectorStrainStack.from_mapping(
+            names,
+            {name: GWpyTimeSeries([1.0, 2.0], t0=0.0, sample_rate=sampling_frequency) for name in names},
+        )
+
+
+def _make_network(detector_names=("H1",)):
+    """Return a minimal Network-like stub."""
+    return SimpleNamespace(detector_names=detector_names)
+
+
+def _make_adapter_with_backend(backend):
+    """Build a SignalAdapter using an already-instantiated backend stub."""
+    network = _make_network()
+    return SignalAdapter(source_type="bns", backend=backend, network=network)
+
+
+class TestSimulateStackUnsupportedParams:
+    """Verify catch-parse-retry for 'Unsupported LAL waveform parameters' errors."""
+
+    def test_unsupported_params_trigger_warning_and_retry(self):
+        """On first failure the adapter logs a WARNING and retries without bad keys."""
+        backend = FailingBackend(waveform_model="IMRPhenomXPHM")
+        adapter = _make_adapter_with_backend(backend)
+
+        params = {"mass_1": 1.4, "redshift": 0.05, "lambda_1": 300.0, "coa_time": 0.0}
+
+        with patch("gwmock.signal.adapter.logger") as mock_logger:
+            adapter.simulate_stack(params, sampling_frequency=4.0, minimum_frequency=20.0)
+
+        # Warning was emitted listing the ignored keys
+        mock_logger.warning.assert_called_once()
+        warning_msg = mock_logger.warning.call_args[0][0] % mock_logger.warning.call_args[0][1:]
+        assert "lambda_1" in warning_msg
+        assert "redshift" in warning_msg
+        assert "injection_parameters" in warning_msg
+        # Two backend calls: initial (failing) + retry (filtered)
+        assert backend.call_count == 2
+        assert "redshift" not in backend.received_params[1]
+        assert "lambda_1" not in backend.received_params[1]
+        assert "mass_1" in backend.received_params[1]
+
+    def test_unsupported_params_cached_on_second_call(self):
+        """Subsequent calls pre-filter and do NOT trigger a second backend failure."""
+        backend = FailingBackend(waveform_model="IMRPhenomXPHM")
+        adapter = _make_adapter_with_backend(backend)
+
+        params = {"mass_1": 1.4, "redshift": 0.05, "lambda_1": 300.0, "coa_time": 0.0}
+
+        with patch("gwmock.signal.adapter.logger") as mock_logger:
+            adapter.simulate_stack(params, sampling_frequency=4.0, minimum_frequency=20.0)
+            first_warning_count = mock_logger.warning.call_count
+            adapter.simulate_stack(params, sampling_frequency=4.0, minimum_frequency=20.0)
+            second_warning_count = mock_logger.warning.call_count
+
+        # No additional warning on the second call
+        assert second_warning_count == first_warning_count
+        # Second call: only one backend call (pre-filtered, no failure)
+        assert backend.call_count == 3  # 2 from first simulate_stack + 1 from second
+        assert "redshift" not in backend.received_params[2]
+        assert "lambda_1" not in backend.received_params[2]
+
+    def test_genuine_value_error_is_reraised(self):
+        """A ValueError not matching the prefix must propagate unchanged."""
+        backend = MagicMock()
+        backend.simulate.side_effect = ValueError("mass_1 must be positive")
+        network = _make_network()
+        adapter = SignalAdapter(source_type="bbh", backend=backend, network=network)
+
+        with pytest.raises(ValueError, match="mass_1 must be positive"):
+            adapter.simulate_stack({"mass_1": -1.0}, sampling_frequency=4.0, minimum_frequency=20.0)


### PR DESCRIPTION
Close #138 

**Problem**: `gwmock simulate` crashed with `ValueError: Unsupported LAL waveform parameters: lambda_1, lambda_2, redshift` when a BBH population catalogue contained columns the chosen waveform model doesn't accept.

**Fix**: `SignalAdapter.simulate_stack()` (`src/gwmock/signal/adapter.py`) now catches `ValueError: Unsupported LAL waveform parameters: ...`, strips the rejected keys, warns once, and retries — no user configuration required.

**Behaviour**:
- First event with bad params → 1 `WARNING` logged, 1 retry
- Subsequent events → pre-filtered (no retry cost)
- Other `ValueError`s → re-raised unchanged
- `injection_parameters` metadata retains full population parameters

**Warning example**:
```
WARNING  Waveform backend does not accept the following population parameters and they will be ignored: lambda_1, lambda_2, redshift. They are still recorded in injection_parameters metadata.
```

**Tests**: 3 new tests in `tests/signal/test_adapter.py`; 522 passed, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic handling of unsupported waveform parameters: the system now detects unsupported parameters from backend errors, filters them out, and retries the simulation automatically.
  * Implemented caching of unsupported parameters to prevent repeated failures across calls.
  
* **Improvements**
  * Users receive warnings listing parameters that will be ignored during simulation while still being recorded in metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Leuven-Gravity-Institute/gwmock/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->