### PR TITLE
fix: normalize spectral-line/glitch config dicts in the noise stream …

### DIFF
--- a/src/gwmock/noise/adapter.py
+++ b/src/gwmock/noise/adapter.py
@@ -25,6 +25,8 @@ from gwmock_noise import (
 from gwmock_noise import (
     open_stream as upstream_open_stream,
 )
+from gwmock_noise.gaussian import normalize_spectral_lines
+from gwmock_noise.glitches import normalize_glitch_models
 
 _SUPPORTED_OUTPUT_FORMATS = {"npy", "gwf"}
 _DETECTOR_PAIR_SIZE = 2
@@ -657,16 +659,17 @@ class NoiseAdapter:
         if spectral_lines is not None:
             if not spectral_lines:
                 raise ValueError("spectral_lines must contain at least one spectral line.")
+            normalized_lines = normalize_spectral_lines(spectral_lines)
             simulator = (
                 SpectralLineSimulator(
-                    lines=spectral_lines,
+                    lines=normalized_lines,
                     detectors=detectors,
                     duration=chunk_duration,
                     sampling_frequency=sampling_frequency,
                     seed=seed,
                 )
                 if simulator is None
-                else AddLines(simulator, spectral_lines)
+                else AddLines(simulator, normalized_lines)
             )
 
         if glitches is not None:
@@ -679,7 +682,7 @@ class NoiseAdapter:
                     sampling_frequency=sampling_frequency,
                     seed=seed,
                 )
-            simulator = InjectGlitches(simulator, glitches)
+            simulator = InjectGlitches(simulator, normalize_glitch_models(glitches))
 
         return simulator
 

--- a/tests/noise/test_adapter.py
+++ b/tests/noise/test_adapter.py
@@ -256,3 +256,80 @@ class TestNoiseAdapter:
             tmp_path / "noise-0_H-H1:STRAIN_NOISE_100p5-4.gwf",
             tmp_path / "noise-0_L-L1:STRAIN_NOISE_100p5-4.gwf",
         ]
+
+
+def _blip_glitch_dict() -> dict[str, object]:
+    """Return a valid dict-form blip glitch config."""
+    return {
+        "kind": "blip",
+        "rate": 1.0,
+        "amplitude_distribution": {"distribution": "lognormal", "mean": 1e-21, "std": 0.0},
+        "width": 0.01,
+    }
+
+
+class TestDefaultStreamBackendComponentNormalization:
+    """Regression tests for ISS-011.
+
+    The default stream backend builds ``SpectralLineSimulator`` / ``AddLines`` /
+    ``InjectGlitches`` directly, so the adapter must normalize dict-form config
+    entries into ``SpectralLine`` / ``GlitchModel`` instances first. Before the
+    fix these raised ``AttributeError: 'dict' object has no attribute ...`` on the
+    first chunk.
+    """
+
+    def test_open_stream_accepts_dict_form_spectral_lines(self):
+        """A dict-form spectral_lines entry generates a chunk (no AttributeError)."""
+        adapter = NoiseAdapter.from_backend()  # DefaultNoiseSimulator
+        stream = adapter.open_stream(
+            chunk_duration=TEST_DURATION,
+            sampling_frequency=TEST_SAMPLING_FREQUENCY,
+            detectors=["H1"],
+            seed=TEST_SEED,
+            spectral_lines=[{"frequency": 60.0, "amplitude": 1e-23}],
+        )
+
+        chunk = next(stream)
+
+        n_samples = round(TEST_DURATION * TEST_SAMPLING_FREQUENCY)
+        assert chunk["H1"].shape == (n_samples,)
+        assert np.all(np.isfinite(chunk["H1"]))
+        assert np.any(chunk["H1"] != 0.0)
+
+    def test_open_stream_accepts_dict_form_glitches(self):
+        """A dict-form glitches entry generates a chunk (no AttributeError)."""
+        adapter = NoiseAdapter.from_backend()  # DefaultNoiseSimulator
+        stream = adapter.open_stream(
+            chunk_duration=TEST_DURATION,
+            sampling_frequency=TEST_SAMPLING_FREQUENCY,
+            detectors=["H1"],
+            seed=TEST_SEED,
+            glitches=[_blip_glitch_dict()],
+        )
+
+        chunk = next(stream)
+
+        n_samples = round(TEST_DURATION * TEST_SAMPLING_FREQUENCY)
+        assert chunk["H1"].shape == (n_samples,)
+        assert np.all(np.isfinite(chunk["H1"]))
+
+    def test_open_stream_accepts_dataclass_instances(self):
+        """Passing SpectralLine/GlitchModel instances still works (normalize is idempotent)."""
+        from gwmock_noise.gaussian import SpectralLine
+        from gwmock_noise.glitches.models import BlipGlitch, LogNormalAmplitudeDistribution
+
+        adapter = NoiseAdapter.from_backend()  # DefaultNoiseSimulator
+        stream = adapter.open_stream(
+            chunk_duration=TEST_DURATION,
+            sampling_frequency=TEST_SAMPLING_FREQUENCY,
+            detectors=["H1"],
+            seed=TEST_SEED,
+            spectral_lines=[SpectralLine(frequency=60.0, amplitude=1e-23)],
+            glitches=[BlipGlitch(rate=1.0, amplitude_distribution=LogNormalAmplitudeDistribution(mean=1e-21))],
+        )
+
+        chunk = next(stream)
+
+        n_samples = round(TEST_DURATION * TEST_SAMPLING_FREQUENCY)
+        assert chunk["H1"].shape == (n_samples,)
+        assert np.all(np.isfinite(chunk["H1"]))


### PR DESCRIPTION
Close #172 

The orchestration stream path (`NoiseAdapter._configure_default_stream_backend`) built `SpectralLineSimulator` / `AddLines` / `InjectGlitches` directly from the raw YAML config, passing plain dicts where `SpectralLine` / `GlitchModel` instances are required. Generation aborted on the first chunk with:

- `AttributeError: 'dict' object has no attribute 'frequency'` (spectral lines)
- `AttributeError: 'dict' object has no attribute 'rate'` (glitches)

The sibling `_build_components` path was unaffected because it routes through `from_component()`, which already normalizes.

**Change**: import `normalize_spectral_lines` (`gwmock_noise.gaussian`) and `normalize_glitch_models` (`gwmock_noise.glitches`) and apply them before constructing the simulators. Both accept dicts and dataclass instances.

**Tests**: added `TestDefaultStreamBackendComponentNormalization` (3 cases: dict-form lines, dict-form glitches, dataclass instances). Full suite: 529 passed, 23 skipped. Verified end-to-end by regenerating a colored-noise + spectral-line config — the 60 Hz line now appears (Welch peak at 60.00 Hz).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of spectral line and glitch configuration formats to prevent errors when using dictionary-based input.

* **Tests**
  * Added comprehensive test coverage for configuration input normalization, verifying correct behavior with multiple input format types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->