### PR TITLE
fix: Download glitch  URLs before handing them to gwmock-noise

### DIFF
--- a/src/gwmock/noise/adapter.py
+++ b/src/gwmock/noise/adapter.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import tempfile
 from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
 from typing import Any, Literal
+from urllib.parse import urlparse
 
 import numpy as np
 from gwmock_noise import (
@@ -27,6 +29,8 @@ from gwmock_noise import (
 )
 from gwmock_noise.gaussian import normalize_spectral_lines
 from gwmock_noise.glitches import normalize_glitch_models
+
+from gwmock.utils.download import download_file
 
 _SUPPORTED_OUTPUT_FORMATS = {"npy", "gwf"}
 _DETECTOR_PAIR_SIZE = 2
@@ -154,6 +158,65 @@ def _parse_csd_file_map(csd_files: dict[str, Path] | None) -> dict[tuple[str, st
             raise ValueError(f"Duplicate CSD file mapping for detector pair {detector_a}-{detector_b}.")
         parsed[normalized_key] = Path(file_path)
     return parsed
+
+
+_REMOTE_GLITCH_FILE_KEYS = ("population_file", "psd_file")
+
+
+def _is_remote_url(value: Any) -> bool:
+    """Return True if ``value`` is an ``http``/``https`` URL string.
+
+    Args:
+        value: The candidate file reference.
+
+    Returns:
+        Whether the value is a remote URL (named assets and local paths are not).
+    """
+    return isinstance(value, str) and urlparse(value).scheme in {"http", "https"}
+
+
+def _glitch_population_cache_directory() -> Path:
+    """Return the cache directory for downloaded glitch population/PSD files."""
+    return Path(tempfile.gettempdir()) / "gwmock" / "noise_glitches"
+
+
+def _resolve_glitch_file_urls(glitches: list[Any] | None) -> list[Any] | None:
+    """Download URL-valued glitch file references to a local cache.
+
+    gwmock-noise glitch models (e.g. ``GengliBlipGlitch``) read ``population_file``
+    and ``psd_file`` with ``Path``/``h5py``, which cannot handle URLs. Resolve any
+    ``http(s)`` URL to a cached local path so remote files declared in configs work
+    transparently. Named bundled assets (e.g. ``ET_10_full_cryo_psd``) and local
+    paths are returned unchanged. The input list and its entries are not mutated.
+
+    Args:
+        glitches: The raw glitch-model configuration entries.
+
+    Returns:
+        A copy of ``glitches`` with remote file references replaced by local paths.
+    """
+    if not glitches:
+        return glitches
+
+    resolved: list[Any] = []
+    for entry in glitches:
+        if not isinstance(entry, Mapping):
+            resolved.append(entry)
+            continue
+        updated = dict(entry)
+        for key in _REMOTE_GLITCH_FILE_KEYS:
+            value = updated.get(key)
+            if _is_remote_url(value):
+                updated[key] = str(
+                    download_file(
+                        value,
+                        outdir=_glitch_population_cache_directory(),
+                        allow_existing=True,
+                        dest_path_from_hashed_url=True,
+                    )
+                )
+        resolved.append(updated)
+    return resolved
 
 
 def _build_components(
@@ -675,6 +738,7 @@ class NoiseAdapter:
         if glitches is not None:
             if not glitches:
                 raise ValueError("glitches must contain at least one glitch model.")
+            resolved_glitches = _resolve_glitch_file_urls(glitches)
             if simulator is None:
                 simulator = _ZeroNoiseSimulator(
                     detectors=detectors,
@@ -682,7 +746,7 @@ class NoiseAdapter:
                     sampling_frequency=sampling_frequency,
                     seed=seed,
                 )
-            simulator = InjectGlitches(simulator, normalize_glitch_models(glitches))
+            simulator = InjectGlitches(simulator, normalize_glitch_models(resolved_glitches))
 
         return simulator
 

--- a/tests/noise/test_adapter.py
+++ b/tests/noise/test_adapter.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import numpy as np
 
 from gwmock.noise import NoiseAdapter
+from gwmock.noise import adapter as noise_adapter
 
 TEST_DURATION = 8.0
 TEST_SAMPLING_FREQUENCY = 256.0
@@ -333,3 +334,104 @@ class TestDefaultStreamBackendComponentNormalization:
         n_samples = round(TEST_DURATION * TEST_SAMPLING_FREQUENCY)
         assert chunk["H1"].shape == (n_samples,)
         assert np.all(np.isfinite(chunk["H1"]))
+
+
+def _gengli_glitch_dict(population_file: str) -> dict[str, object]:
+    """Return a dict-form gengli_blip glitch config with the given population_file."""
+    return {
+        "kind": "gengli_blip",
+        "rate": 1.0,
+        "amplitude_distribution": {"distribution": "lognormal", "mean": 1.0, "std": 0.0},
+        "population_file": population_file,
+        "psd_file": "ET_10_full_cryo_psd",
+        "low_frequency_cutoff": 5.0,
+    }
+
+
+class TestGlitchPopulationUrlResolution:
+    """Regression tests for ISS-012.
+
+    A glitch ``population_file`` given as an ``http(s)`` URL must be downloaded to a
+    local cache and replaced by the local path before it reaches the gwmock-noise
+    glitch model (which reads it with ``Path``/``h5py`` and cannot handle URLs).
+    Named bundled assets and local paths must pass through untouched.
+    """
+
+    def test_resolve_downloads_remote_population_file(self, monkeypatch, tmp_path: Path):
+        """A URL population_file is downloaded and replaced with the local path."""
+        local = tmp_path / "blip.hdf5"
+        local.write_bytes(b"")
+        calls = []
+
+        def fake_download(url, **kwargs):
+            calls.append((url, kwargs))
+            return local
+
+        monkeypatch.setattr(noise_adapter, "download_file", fake_download)
+
+        url = "https://example.org/records/1/files/blip.hdf5"
+        glitches = [_gengli_glitch_dict(url)]
+        resolved = noise_adapter._resolve_glitch_file_urls(glitches)
+
+        # URL replaced by the local path; named PSD asset untouched.
+        assert resolved[0]["population_file"] == str(local)
+        assert resolved[0]["psd_file"] == "ET_10_full_cryo_psd"
+        # Original input is not mutated.
+        assert glitches[0]["population_file"] == url
+        # Downloaded exactly once, with caching enabled.
+        assert len(calls) == 1
+        assert calls[0][0] == url
+        assert calls[0][1]["allow_existing"] is True
+        assert calls[0][1]["dest_path_from_hashed_url"] is True
+
+    def test_resolve_passes_through_non_url_values(self, monkeypatch, tmp_path: Path):
+        """Local paths and named assets are returned unchanged without downloading."""
+
+        def fail_download(*args, **kwargs):
+            raise AssertionError("download_file must not be called for non-URL inputs")
+
+        monkeypatch.setattr(noise_adapter, "download_file", fail_download)
+
+        local_population = tmp_path / "local_blip.hdf5"
+        glitches = [_gengli_glitch_dict(str(local_population)), _blip_glitch_dict()]
+        resolved = noise_adapter._resolve_glitch_file_urls(glitches)
+
+        assert resolved == glitches
+
+    def test_resolve_returns_empty_input_unchanged(self):
+        """``None``/empty glitch lists are returned as-is."""
+        assert noise_adapter._resolve_glitch_file_urls(None) is None
+        assert noise_adapter._resolve_glitch_file_urls([]) == []
+
+    def test_configure_default_stream_backend_resolves_urls(self, monkeypatch, tmp_path: Path):
+        """The streaming backend hands the local path (not the URL) to gwmock-noise."""
+        local = tmp_path / "blip.hdf5"
+        local.write_bytes(b"")
+        monkeypatch.setattr(noise_adapter, "download_file", lambda url, **kwargs: local)
+
+        received = {}
+
+        def fake_normalize(glitches):
+            received["glitches"] = glitches
+            return ["sentinel-model"]
+
+        monkeypatch.setattr(noise_adapter, "normalize_glitch_models", fake_normalize)
+
+        adapter = NoiseAdapter.from_backend()  # DefaultNoiseSimulator
+        url = "https://example.org/records/1/files/blip.hdf5"
+        adapter._configure_default_stream_backend(
+            chunk_duration=TEST_DURATION,
+            sampling_frequency=TEST_SAMPLING_FREQUENCY,
+            detectors=["E1"],
+            seed=TEST_SEED,
+            psd_file=None,
+            psd_schedule=None,
+            psd_files=None,
+            csd_files=None,
+            low_frequency_cutoff=2.0,
+            high_frequency_cutoff=None,
+            spectral_lines=None,
+            glitches=[_gengli_glitch_dict(url)],
+        )
+
+        assert received["glitches"][0]["population_file"] == str(local)


### PR DESCRIPTION
Close #174 

A glitch config with a remote population file (`population_file: https://sandbox.zenodo.org/.../blip_glitch_population_E1.hdf5`) aborted generation with:

```
FileNotFoundError: Population file not found: https:/sandbox.zenodo.org/.../blip_glitch_population_E1.hdf5
```

The URL was passed straight into gwmock-noise's `read_blip_population_file`, which does `Path(url)` (collapsing `https://` → `https:/`) and `h5py.File(...)` — neither accepts URLs. gwmock never resolved the URL, unlike the signal/population path
(gwmock-pop already downloads population URLs).

**Change** (gwmock only — gwmock-noise untouched): `NoiseAdapter` now resolves any `http(s)`-valued `population_file`/`psd_file` in glitch configs to a locally cached file via the existing `gwmock.utils.download.download_file`
(`allow_existing=True`, hashed dest name), applied just before `normalize_glitch_models` in the streaming backend. Named bundled assets (`ET_10_full_cryo_psd`) and local paths pass through unchanged; the file downloads at most once per run.

**Tests**: added `TestGlitchPopulationUrlResolution` (4 cases: URL download + substitution, non-URL pass-through, streaming-path wiring, empty input). Full suite: 532 passed, 23 skipped. Verified end-to-end against the real Zenodo
file — downloads once, caches on the second resolve, and gwmock-noise reads the local file (350,394 SNRs).