### PR TITLE
fix(cli): Resume must verify checkpointed outputs exist

### DIFF
--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -830,6 +830,97 @@ def validate_plan(plan: SimulationPlan) -> None:
     logger.info("Simulation plan validation completed successfully")
 
 
+def _resolve_recorded_output_paths(metadata: dict[str, Any], working_directory: str | None) -> list[Path]:
+    """Resolve the output file paths recorded in a batch's metadata.
+
+    Paths in ``outputs[].path`` are stored relative to the working directory (see
+    ``_to_path_string``); resolve them back against it so existence can be checked.
+    """
+    base = Path(working_directory) if working_directory else None
+    paths: list[Path] = []
+    for record in metadata.get("outputs", []) or []:
+        raw = record.get("path") if isinstance(record, dict) else None
+        if not raw:
+            continue
+        path = Path(raw)
+        if base is not None and not path.is_absolute():
+            path = base / path
+        paths.append(path)
+    return paths
+
+
+def _batch_outputs_present(batch: SimulationBatch, metadata_directory: Path) -> bool | None:
+    """Return whether the outputs recorded for ``batch`` all exist on disk.
+
+    Returns:
+        ``True`` if the batch metadata exists and every recorded output is present,
+        ``False`` if the metadata exists but one or more recorded outputs are missing,
+        ``None`` if the batch metadata file itself is missing.
+    """
+    metadata_file = metadata_directory / f"{batch.simulator_name}-{batch.batch_index}.metadata.json"
+    if not metadata_file.exists():
+        return None
+    try:
+        with metadata_file.open("r") as handle:
+            metadata = json.load(handle)
+    except (OSError, ValueError) as error:
+        logger.warning(
+            "Failed to read metadata for batch %d during checkpoint reconciliation: %s", batch.batch_index, error
+        )
+        return None
+    working_directory = getattr(batch.globals_config, "working_directory", None)
+    recorded = _resolve_recorded_output_paths(metadata, working_directory)
+    if not recorded:
+        # No output paths recorded to verify; trust the checkpoint for this batch.
+        return True
+    missing = [path for path in recorded if not path.exists()]
+    if missing:
+        logger.warning(
+            "Checkpoint marks batch %d complete but output(s) are missing: %s",
+            batch.batch_index,
+            ", ".join(str(path) for path in missing),
+        )
+        return False
+    return True
+
+
+def reconcile_completed_batches(
+    plan: SimulationPlan,
+    metadata_directory: Path,
+    completed_batch_indices: set[int],
+) -> set[int]:
+    """Prune checkpointed batches whose outputs are missing from disk.
+
+    Resume restores simulator state from a single tail snapshot and assumes the
+    completed batches form a contiguous prefix (the orchestration noise stream is
+    sequential/stateful). So the completed set is validated in order and truncated at
+    the FIRST batch whose recorded outputs (or metadata) are missing: that batch and
+    every later batch are dropped so they get re-run.
+
+    Returns the validated contiguous prefix of ``completed_batch_indices``.
+    """
+    if not completed_batch_indices:
+        return set()
+    batch_by_index = {batch.batch_index: batch for batch in plan.batches}
+    valid: set[int] = set()
+    for index in sorted(completed_batch_indices):
+        batch = batch_by_index.get(index)
+        if batch is None:
+            logger.warning("Checkpoint references unknown batch %d; it and later batches will be re-run.", index)
+            break
+        present = _batch_outputs_present(batch, metadata_directory)
+        if present is None:
+            logger.warning(
+                "Checkpoint marks batch %d complete but its metadata is missing; it and later batches will be re-run.",
+                index,
+            )
+            break
+        if not present:
+            break
+        valid.add(index)
+    return valid
+
+
 def execute_plan(  # noqa: PLR0915
     plan: SimulationPlan,
     output_directory: Path,
@@ -875,13 +966,32 @@ def execute_plan(  # noqa: PLR0915
 
     # Initialize checkpoint manager for resumption support
     checkpoint_manager = CheckpointManager(plan.checkpoint_directory)
-    completed_batch_indices = checkpoint_manager.get_completed_batch_indices()
+    loaded_batch_indices = checkpoint_manager.get_completed_batch_indices()
+    resuming = bool(loaded_batch_indices)
 
-    if completed_batch_indices:
+    # Reconcile the checkpoint against the filesystem: a batch may be recorded as
+    # completed while its output is missing (partial write at interrupt, an external
+    # move/backup, fs hiccup). Skipping such a batch would silently drop a file.
+    completed_batch_indices = reconcile_completed_batches(plan, metadata_directory, loaded_batch_indices)
+
+    if not resuming:
+        logger.debug("No checkpoint found or no batches completed yet")
+        last_simulator_state = None
+    elif completed_batch_indices == loaded_batch_indices:
         logger.info("Loaded checkpoint: %d batches already completed", len(completed_batch_indices))
         last_simulator_state = checkpoint_manager.get_last_simulator_state()
     else:
-        logger.debug("No checkpoint found or no batches completed yet")
+        # One or more checkpointed batches are missing their outputs. The checkpoint
+        # only holds the tail simulator state, so an interior batch cannot be
+        # regenerated in isolation; discard the checkpoint and regenerate from the
+        # first batch to keep the simulator/noise-stream/RNG state consistent.
+        logger.warning(
+            "Checkpoint listed %d completed batch(es) but only the first %d still have all outputs "
+            "on disk; regenerating the simulation from the start to restore the missing output(s).",
+            len(loaded_batch_indices),
+            len(completed_batch_indices),
+        )
+        completed_batch_indices = set()
         last_simulator_state = None
 
     # Group batches by simulator name to execute sequentially per simulator
@@ -904,13 +1014,19 @@ def execute_plan(  # noqa: PLR0915
 
             # Process batches sequentially, maintaining state across them
             for batch_idx, batch in enumerate(batches):
-                # Skip batches that were already completed (for resumption after interrupt)
-                if checkpoint_manager.should_skip_batch(batch.batch_index):
+                # Skip batches that were already completed AND whose outputs were verified
+                # on disk during reconciliation (for resumption after interrupt).
+                if batch.batch_index in completed_batch_indices:
                     logger.info(
                         "Skipping batch %d (already completed from checkpoint)",
                         batch.batch_index,
                     )
                     continue
+
+                # On resume, any output present for a batch we are about to run is an
+                # unverified leftover (orphan/partial) from the interrupted attempt, not
+                # user data, so allow overwriting it even without --overwrite.
+                batch_overwrite = overwrite or resuming
 
                 try:
                     logger.debug(
@@ -941,6 +1057,7 @@ def execute_plan(  # noqa: PLR0915
                         _batch=batch,
                         _output_directory=output_directory,
                         _pre_batch_state=pre_batch_state,
+                        _overwrite=batch_overwrite,
                     ):
                         """Execute a single batch with state management."""
                         set_batch_context = getattr(_simulator, "set_batch_context", None)
@@ -948,7 +1065,7 @@ def execute_plan(  # noqa: PLR0915
                             set_batch_context(
                                 batch=_batch,
                                 output_directory=_output_directory,
-                                overwrite=overwrite,
+                                overwrite=_overwrite,
                             )
 
                         # Generate data by calling next() - this advances simulator state
@@ -962,7 +1079,7 @@ def execute_plan(  # noqa: PLR0915
                             batch_data=batch_data,
                             batch=_batch,
                             output_directory=_output_directory,
-                            overwrite=overwrite,
+                            overwrite=_overwrite,
                         )
 
                         # Only save metadata if data save succeeded

--- a/tests/cli/test_cli_simulate.py
+++ b/tests/cli/test_cli_simulate.py
@@ -21,12 +21,14 @@ from gwmock.cli.simulate_utils import (
     execute_plan,
     instantiate_simulator,
     process_batch,
+    reconcile_completed_batches,
     restore_batch_state,
     retry_with_backoff,
     save_batch_metadata,
     update_metadata_index,
     validate_plan,
 )
+from gwmock.cli.utils.checkpoint import CheckpointManager
 from gwmock.cli.utils.config import (
     Config,
     GlobalsConfig,
@@ -814,6 +816,147 @@ class TestExecutePlan:
             counter_0 = metadata_0["pre_batch_state"]["counter"]
             counter_1 = metadata_1["pre_batch_state"]["counter"]
             assert counter_1 > counter_0
+
+
+class TestCheckpointReconciliation:
+    """Resume must reconcile the checkpoint against the filesystem (ISS-013).
+
+    A batch may be recorded as completed in the checkpoint while its output is
+    missing (partial write at interrupt, external move/backup, fs hiccup). Trusting
+    the checkpoint blindly silently drops files; an orphan output from a not-yet
+    checkpointed batch must not abort resume with FileExistsError.
+    """
+
+    @staticmethod
+    def _build_plan(checkpoint_dir: Path, n_batches: int) -> SimulationPlan:
+        plan = SimulationPlan(checkpoint_directory=checkpoint_dir)
+        for i in range(n_batches):
+            plan.add_batch(
+                SimulationBatch(
+                    simulator_name="mock",
+                    simulator_config=SimulatorConfig(
+                        class_="tests.cli.test_cli_simulate.MockSimulator",
+                        arguments={"seed": 42},
+                        output=SimulatorOutputConfig(file_name=f"batch_{i}.json"),
+                    ),
+                    globals_config=GlobalsConfig(),
+                    batch_index=i,
+                )
+            )
+        return plan
+
+    @staticmethod
+    def _stepped_state(plan: SimulationPlan, steps: int) -> dict[str, Any]:
+        """Return a valid simulator state advanced ``steps`` times (counter == steps)."""
+        simulator = instantiate_simulator(plan.batches[0].simulator_config, "mock", {})
+        for _ in range(steps):
+            simulator.simulate()
+            simulator.update_state()
+        return simulator.state
+
+    def test_reconcile_truncates_at_first_missing_artifact(self):
+        """reconcile_completed_batches keeps the valid contiguous prefix only."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "output"
+            metadata_dir = Path(tmpdir) / "metadata"
+            plan = self._build_plan(Path(tmpdir) / "ckpt", n_batches=3)
+
+            execute_plan(plan, output_dir, metadata_dir, overwrite=True)
+
+            # All outputs present -> whole set is valid.
+            assert reconcile_completed_batches(plan, metadata_dir, {0, 1, 2}) == {0, 1, 2}
+
+            # A missing output truncates at that batch (it and later batches re-run).
+            (output_dir / "batch_1.json").unlink()
+            assert reconcile_completed_batches(plan, metadata_dir, {0, 1, 2}) == {0}
+
+            # A missing metadata file truncates there too.
+            (metadata_dir / "mock-0.metadata.json").unlink()
+            assert reconcile_completed_batches(plan, metadata_dir, {0, 1, 2}) == set()
+
+    def test_resume_regenerates_when_checkpointed_output_missing(self):
+        """User scenario: checkpoint says batch done but its output is gone -> regenerate.
+
+        Before the fix this silently reported success with fewer files than configured.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "output"
+            metadata_dir = Path(tmpdir) / "metadata"
+            checkpoint_dir = Path(tmpdir) / "ckpt"
+            plan = self._build_plan(checkpoint_dir, n_batches=3)
+
+            # Produce a complete run, then plant a stale checkpoint claiming 0,1,2 done.
+            execute_plan(plan, output_dir, metadata_dir, overwrite=True)
+            CheckpointManager(checkpoint_dir).save_checkpoint(
+                completed_batch_indices=[0, 1, 2],
+                last_simulator_name="mock",
+                last_completed_batch_index=2,
+                last_simulator_state=self._stepped_state(plan, 3),
+            )
+
+            # The first batch's output goes missing while the checkpoint persists.
+            (output_dir / "batch_0.json").unlink()
+
+            execute_plan(plan, output_dir, metadata_dir, overwrite=True)
+
+            # Every configured batch output exists again (no silent drop).
+            for i in range(3):
+                assert (output_dir / f"batch_{i}.json").exists()
+
+    def test_resume_tolerates_orphan_output_without_overwrite_flag(self):
+        """An orphan output for a not-checkpointed batch must not abort resume.
+
+        Before the fix this raised FileExistsError (overwrite=False) and resume could
+        not proceed at all.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "output"
+            metadata_dir = Path(tmpdir) / "metadata"
+            checkpoint_dir = Path(tmpdir) / "ckpt"
+            plan = self._build_plan(checkpoint_dir, n_batches=3)
+
+            # All outputs on disk, but the checkpoint only records batch 0 as complete,
+            # so batch_1.json / batch_2.json are orphan leftovers relative to it.
+            execute_plan(plan, output_dir, metadata_dir, overwrite=True)
+            CheckpointManager(checkpoint_dir).save_checkpoint(
+                completed_batch_indices=[0],
+                last_simulator_name="mock",
+                last_completed_batch_index=0,
+                last_simulator_state=self._stepped_state(plan, 1),
+            )
+
+            # Resume WITHOUT --overwrite must succeed (orphans are unverified leftovers).
+            execute_plan(plan, output_dir, metadata_dir, overwrite=False)
+
+            for i in range(3):
+                assert (output_dir / f"batch_{i}.json").exists()
+
+    def test_resume_skips_completed_batches_with_present_outputs(self):
+        """Happy path: validated-complete batches are skipped, not regenerated."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir) / "output"
+            metadata_dir = Path(tmpdir) / "metadata"
+            checkpoint_dir = Path(tmpdir) / "ckpt"
+            plan = self._build_plan(checkpoint_dir, n_batches=3)
+
+            execute_plan(plan, output_dir, metadata_dir, overwrite=True)
+            CheckpointManager(checkpoint_dir).save_checkpoint(
+                completed_batch_indices=[0, 1],
+                last_simulator_name="mock",
+                last_completed_batch_index=1,
+                last_simulator_state=self._stepped_state(plan, 2),
+            )
+
+            # Sentinel content on the completed batches: untouched iff they are skipped.
+            sentinel = '{"sentinel": true}'
+            (output_dir / "batch_0.json").write_text(sentinel)
+            (output_dir / "batch_1.json").write_text(sentinel)
+
+            execute_plan(plan, output_dir, metadata_dir, overwrite=True)
+
+            assert (output_dir / "batch_0.json").read_text() == sentinel
+            assert (output_dir / "batch_1.json").read_text() == sentinel
+            assert (output_dir / "batch_2.json").exists()
 
 
 @pytest.mark.skip(reason="Legacy simulator configs removed; orchestration tests cover this path.")


### PR DESCRIPTION
Close #176 

A 6-batch noise run that was interrupted and resumed logged "3 batches already completed", skipped batches 0–2, and reported "Simulation completed successfully" — but produced **5 files per detector instead of 6** (batch 0's `.gwf` and metadata were gone). Resume decided what to skip purely from the checkpoint's `completed_batch_indices`, **never checking that those batches' outputs existed on disk**. A related defect: the output file is written before the checkpoint is committed, so an interrupt leaves an orphan output that aborts the next `overwrite=False` resume with `FileExistsError`.

**Change** (gwmock only): `execute_plan` now reconciles the checkpoint against the filesystem before skipping anything.

- `reconcile_completed_batches` validates each checkpointed batch in order against its
  recorded `outputs[].path` (from `{sim}-{idx}.metadata.json`) and keeps only the valid
  contiguous prefix. The check is simulator-agnostic — it covers noise, signal, full
  signal+noise, and glitch runs (glitches are baked into the noise `.gwf`).
- If any checkpointed batch's output is missing, the checkpoint is discarded and the run
  regenerates from the start (the checkpoint holds only the tail state, so an interior
  batch can't be restored in isolation), with a clear warning. The silent-success
  failure mode is gone.
- On resume, batches being re-run overwrite stale orphan/partial outputs regardless of
  `--overwrite`, so an interrupted-mid-write batch resumes without `FileExistsError`
  (covers both the noise guard and base `Simulator.save_data`). A normal first run still
  honours `overwrite=False`.

**Tests**: added `TestCheckpointReconciliation` (4 cases: prefix truncation on missing output/metadata, regenerate-on-missing-output, orphan tolerance without `--overwrite`, happy-path skip). Full suite: **537 passed, 23 skipped**. Reproduced the exact user symptom (5/6 files) and confirmed the fix restores all 6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added filesystem-aware checkpoint reconciliation that validates previously-recorded outputs exist on disk before skipping batches, preventing unnecessary re-execution of incomplete work during resumption.

* **Bug Fixes**
  * Fixed inconsistent overwrite behavior when resuming simulations with partial outputs from prior runs, ensuring correct handling across the entire batch execution lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->