### PR TITLE
fix: Fix orchestration replay from metadata

### DIFF
--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -482,6 +482,9 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         if not isinstance(data, TimeSeries):
             raise TypeError(f"AdapterOrchestrator can only save TimeSeries signal data, got {type(data)}.")
 
+        if isinstance(file_name, list):
+            file_name = np.asarray(file_name, dtype=object)
+
         channel_names = self._resolve_signal_channels(data=data, channel_spec=kwargs.pop("channel", None))
         if kwargs:
             unsupported = ", ".join(sorted(kwargs))
@@ -644,11 +647,15 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         return cast(Literal["gwf", "hdf5", "npy", "txt"], suffix)
 
     def _infer_noise_output_format(self, file_name_template: str | list[str]) -> Literal["npy", "gwf"]:
-        first = file_name_template[0] if isinstance(file_name_template, list) else file_name_template
-        suffix = Path(first).suffix.lower().lstrip(".")
-        if suffix not in {"npy", "gwf"}:
+        names = list(file_name_template) if isinstance(file_name_template, list) else [file_name_template]
+        if not names:
+            raise ValueError("Noise file_name list must contain at least one entry.")
+        suffixes = {Path(name).suffix.lower().lstrip(".") for name in names}
+        if not suffixes <= {"npy", "gwf"}:
             raise ValueError("Noise output templates must end with .npy or .gwf.")
-        return cast(Literal["npy", "gwf"], suffix)
+        if len(suffixes) != 1:
+            raise ValueError("All noise file_name entries must use the same extension (.npy or .gwf).")
+        return cast(Literal["npy", "gwf"], suffixes.pop())
 
     def _expand_noise_output_paths(self, file_name_template: str | list[str]) -> list[Path]:
         """Expand the noise file_name template to one output path per detector."""
@@ -659,18 +666,19 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                     f"Noise file_name list has {len(file_name_template)} entries "
                     f"but there are {len(noise_detectors)} noise detectors."
                 )
-            return [self._active_noise_output_directory / str(p) for p in file_name_template]
-        proxy = _NoiseTemplateProxy(self, noise_detectors)
-        expanded = expand_template_variables(file_name_template, proxy)
-        if isinstance(expanded, list):
-            if len(expanded) != len(noise_detectors):
-                raise ValueError(
-                    f"Noise file_name template expanded to {len(expanded)} paths "
-                    f"but there are {len(noise_detectors)} noise detectors."
-                )
-            paths = [self._active_noise_output_directory / str(p) for p in expanded]
+            paths = [self._active_noise_output_directory / str(p) for p in file_name_template]
         else:
-            paths = [self._active_noise_output_directory / str(expanded)] * len(noise_detectors)
+            proxy = _NoiseTemplateProxy(self, noise_detectors)
+            expanded = expand_template_variables(file_name_template, proxy)
+            if isinstance(expanded, list):
+                if len(expanded) != len(noise_detectors):
+                    raise ValueError(
+                        f"Noise file_name template expanded to {len(expanded)} paths "
+                        f"but there are {len(noise_detectors)} noise detectors."
+                    )
+                paths = [self._active_noise_output_directory / str(p) for p in expanded]
+            else:
+                paths = [self._active_noise_output_directory / str(expanded)] * len(noise_detectors)
         if len(set(paths)) < len(paths):
             raise ValueError(
                 "Noise file_name template produces identical paths for multiple detectors. "

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -127,6 +127,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         self._active_signal_output_directory = Path("signal")
         self._active_noise_output_directory = Path("noise")
         self._active_noise_output_arguments: dict[str, Any] = {}
+        self._active_noise_file_name: str | list[str] | None = None
         self._active_overwrite = False
         self._noise_stream: Iterator[dict[str, Any]] | None = None
         self._noise_stream_position = 0
@@ -390,6 +391,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             noise_detectors = list(self.noise_arguments.get("detectors", []))
             proxy = _NoiseTemplateProxy(self, noise_detectors)
             self._active_noise_output_arguments = expand_template_variables(noise_output.arguments or {}, proxy)
+            self._active_noise_file_name = noise_output.file_name
         self._active_overwrite = overwrite
 
     def simulate(self) -> AdapterOrchestrationResult:
@@ -517,8 +519,17 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             )
 
     def _run_noise_batch(self) -> SimulationResult:
-        output_format = self._infer_noise_output_format(self.orchestration_config.noise.output.file_name)
-        output_paths = self._expand_noise_output_paths(self.orchestration_config.noise.output.file_name)
+        # Source the file_name from the active per-batch context so that reproduction from
+        # metadata (where each batch carries its own already-expanded literal file_name) writes
+        # to the correct per-batch path instead of reusing the first batch's filenames. Falls
+        # back to the instantiation-time config when no batch context has been set.
+        file_name = (
+            self._active_noise_file_name
+            if self._active_noise_file_name is not None
+            else self.orchestration_config.noise.output.file_name
+        )
+        output_format = self._infer_noise_output_format(file_name)
+        output_paths = self._expand_noise_output_paths(file_name)
         output_arguments = dict(self._active_noise_output_arguments)
         if "channel_prefix" in output_arguments:
             raise ValueError(
@@ -632,15 +643,23 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             raise ValueError("Signal output files must end with .gwf, .hdf5, .h5, .npy, or .txt.")
         return cast(Literal["gwf", "hdf5", "npy", "txt"], suffix)
 
-    def _infer_noise_output_format(self, file_name_template: str) -> Literal["npy", "gwf"]:
-        suffix = Path(file_name_template).suffix.lower().lstrip(".")
+    def _infer_noise_output_format(self, file_name_template: str | list[str]) -> Literal["npy", "gwf"]:
+        first = file_name_template[0] if isinstance(file_name_template, list) else file_name_template
+        suffix = Path(first).suffix.lower().lstrip(".")
         if suffix not in {"npy", "gwf"}:
             raise ValueError("Noise output templates must end with .npy or .gwf.")
         return cast(Literal["npy", "gwf"], suffix)
 
-    def _expand_noise_output_paths(self, file_name_template: str) -> list[Path]:
+    def _expand_noise_output_paths(self, file_name_template: str | list[str]) -> list[Path]:
         """Expand the noise file_name template to one output path per detector."""
         noise_detectors = list(self.noise_arguments["detectors"])
+        if isinstance(file_name_template, list):
+            if len(file_name_template) != len(noise_detectors):
+                raise ValueError(
+                    f"Noise file_name list has {len(file_name_template)} entries "
+                    f"but there are {len(noise_detectors)} noise detectors."
+                )
+            return [self._active_noise_output_directory / str(p) for p in file_name_template]
         proxy = _NoiseTemplateProxy(self, noise_detectors)
         expanded = expand_template_variables(file_name_template, proxy)
         if isinstance(expanded, list):

--- a/src/gwmock/cli/utils/config.py
+++ b/src/gwmock/cli/utils/config.py
@@ -78,7 +78,13 @@ def _raise_removed_noise_simulator_error(class_spec: str) -> None:
 class SimulatorOutputConfig(BaseModel):
     """Configuration for simulator output handling."""
 
-    file_name: str = Field(..., description="Output file name template (supports {{ variable }} placeholders)")
+    file_name: str | list[str] = Field(
+        ...,
+        description=(
+            "Output file name template (supports {{ variable }} placeholders), "
+            "or a pre-resolved list of filenames as stored in batch metadata."
+        ),
+    )
     arguments: dict[str, Any] = Field(
         default_factory=dict, description="Output-specific arguments (e.g., channel name)"
     )

--- a/src/gwmock/cli/utils/simulation_plan.py
+++ b/src/gwmock/cli/utils/simulation_plan.py
@@ -456,7 +456,7 @@ def create_plan_from_metadata_files(
                 raw_simulator_config = metadata["simulator_config"]
             if "class" in raw_simulator_config or "class_" in raw_simulator_config:
                 simulator_config = SimulatorConfig(**raw_simulator_config)
-            elif {"population", "signal", "noise"}.issubset(raw_simulator_config):
+            elif raw_simulator_config.keys() & {"population", "signal", "noise"}:
                 simulator_config = OrchestrationConfig(**raw_simulator_config)
             else:
                 raise ValueError("unknown simulator_config shape")

--- a/src/gwmock/cli/utils/simulation_plan.py
+++ b/src/gwmock/cli/utils/simulation_plan.py
@@ -486,11 +486,53 @@ def create_plan_from_metadata_files(
         )
         plan.add_batch(batch)
 
+    _warn_version_mismatches(plan.batches, get_dependency_versions())
+
     logger.info(
         "Created simulation plan from %d metadata files",
         len(metadata_files),
     )
     return plan
+
+
+def _warn_version_mismatches(
+    batches: list[SimulationBatch],
+    installed: dict[str, str | None],
+) -> None:
+    """Emit a warning for each gwmock-family package whose stored version differs from installed."""
+    field_to_pkg: list[tuple[str | None, str, str]] = [
+        # (top-level key or None, subpackage_versions subkey or "", installed pkg key)
+        ("gwmock_version", "", "gwmock"),
+        (None, "gwmock_noise", "gwmock-noise"),
+        (None, "gwmock_pop", "gwmock-pop"),
+        (None, "gwmock_signal", "gwmock-signal"),
+    ]
+
+    seen: dict[str, set[str]] = {}
+    for batch in batches:
+        metadata = batch.batch_metadata
+        if not metadata:
+            continue
+        for top_key, sub_key, pkg_key in field_to_pkg:
+            if top_key:
+                stored = metadata.get(top_key)
+            else:
+                subpkg = metadata.get("subpackage_versions") or {}
+                stored = subpkg.get(sub_key) if isinstance(subpkg, dict) else None
+            if stored:
+                seen.setdefault(pkg_key, set()).add(stored)
+
+    for pkg_key, stored_versions in seen.items():
+        installed_ver = installed.get(pkg_key)
+        for stored_ver in stored_versions:
+            if stored_ver != installed_ver:
+                logger.warning(
+                    "Version mismatch for %s: metadata records %s but %s is installed."
+                    " Results may not be bit-per-bit reproducible.",
+                    pkg_key,
+                    stored_ver,
+                    installed_ver or "unknown",
+                )
 
 
 def create_plan_from_metadata(

--- a/src/gwmock/simulator/base.py
+++ b/src/gwmock/simulator/base.py
@@ -112,7 +112,17 @@ class Simulator(ABC):
         for key, value in state.items():
             if key not in state_attrs:
                 raise ValueError(f"Attribute {key} is not registered as a state attribute.")
-            setattr(self, key, value)
+            existing = getattr(self, key, None)
+            if (
+                existing is not None
+                and hasattr(existing, "unit")
+                and hasattr(existing, "value")
+                and not (hasattr(value, "unit") and hasattr(value, "value"))
+                and value is not None
+            ):
+                setattr(self, key, existing.__class__(value, unit=existing.unit))
+            else:
+                setattr(self, key, value)
 
     @property
     def metadata(self) -> dict:

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -23,7 +23,7 @@ from gwmock.cli.utils.config import (
     SignalConfig,
     SimulatorOutputConfig,
 )
-from gwmock.cli.utils.simulation_plan import create_plan_from_config
+from gwmock.cli.utils.simulation_plan import SimulationBatch, create_plan_from_config
 from gwmock.simulator.seeds import derive_seed
 
 EXPECTED_BATCHES = 2
@@ -517,6 +517,69 @@ def test_noise_batch_overwrite_check_uses_template_paths(tmp_path: Path):
 
     with pytest.raises(FileExistsError, match=r"noise-0\.npy"):
         orchestrator._run_noise_batch()
+
+
+def _make_noise_only_batch(tmp_path: Path, *, batch_index: int, file_name: list[str]) -> SimulationBatch:
+    """Build a noise-only orchestration batch with an explicit per-batch file_name list.
+
+    Mirrors a metadata-reproduction batch, where ``file_name`` is an already-expanded literal
+    list (one entry per detector) rather than a template.
+    """
+    return SimulationBatch(
+        simulator_name="orchestration",
+        simulator_config=OrchestrationConfig(
+            noise=NoiseAdapterConfig(
+                backend=FAKE_NOISE_BACKEND,
+                arguments={"seed": 7, "detectors": ["H1", "L1"], "duration": 4.0, "sampling_frequency": 4.0},
+                output=SimulatorOutputConfig(file_name=file_name, output_directory="noise"),
+            ),
+        ),
+        globals_config=GlobalsConfig(
+            working_directory=str(tmp_path),
+            output_directory="output",
+            metadata_directory="metadata",
+            simulator_arguments={"sampling-frequency": 4, "duration": 4, "start-time": 100, "max-samples": 6},
+        ),
+        batch_index=batch_index,
+    )
+
+
+def test_set_batch_context_applies_per_batch_noise_file_name(tmp_path: Path):
+    """Reproduction: each batch writes its own per-batch noise file_name, not batch 0's (ISS-016).
+
+    The orchestrator is instantiated once from the first batch's config. When reproducing from
+    metadata each batch carries its own already-expanded literal file_name; ``set_batch_context``
+    must make ``_run_noise_batch`` use that per-batch file_name rather than the instantiation-time
+    config, otherwise every batch reuses the first batch's filenames and the second batch collides.
+    """
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+    config.orchestration.noise.arguments = {
+        "seed": 7,
+        "duration": 4.0,
+        "sampling_frequency": 4.0,
+        "detectors": ["H1", "L1"],
+    }
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+
+    batch0 = _make_noise_only_batch(tmp_path, batch_index=0, file_name=["E-H1-100.npy", "E-L1-100.npy"])
+    batch1 = _make_noise_only_batch(tmp_path, batch_index=1, file_name=["E-H1-104.npy", "E-L1-104.npy"])
+    output_directory = tmp_path / "output"
+
+    orchestrator.set_batch_context(batch=batch0, output_directory=output_directory, overwrite=True)
+    assert orchestrator._active_noise_file_name == ["E-H1-100.npy", "E-L1-100.npy"]
+    result0 = orchestrator._run_noise_batch()
+    assert {path.name for path in result0.output_paths.values()} == {"E-H1-100.npy", "E-L1-100.npy"}
+
+    orchestrator.set_batch_context(batch=batch1, output_directory=output_directory, overwrite=True)
+    assert orchestrator._active_noise_file_name == ["E-H1-104.npy", "E-L1-104.npy"]
+    result1 = orchestrator._run_noise_batch()
+    # Second batch must use its own filenames (104), not batch 0's (100) — the collision bug.
+    assert {path.name for path in result1.output_paths.values()} == {"E-H1-104.npy", "E-L1-104.npy"}
+    assert set(result1.output_paths.values()).isdisjoint(result0.output_paths.values())
+
+    noise_dir = result0.output_paths["H1"].parent
+    for name in ("E-H1-100.npy", "E-L1-100.npy", "E-H1-104.npy", "E-L1-104.npy"):
+        assert (noise_dir / name).exists()
 
 
 def test_build_signal_stack_uses_channel_name_as_gwf_channel(tmp_path: Path):

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -582,6 +582,68 @@ def test_set_batch_context_applies_per_batch_noise_file_name(tmp_path: Path):
         assert (noise_dir / name).exists()
 
 
+def test_infer_noise_format_empty_list_raises(tmp_path: Path):
+    """_infer_noise_output_format rejects an empty list."""
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+    with pytest.raises(ValueError, match="at least one entry"):
+        orchestrator._infer_noise_output_format([])
+
+
+def test_infer_noise_format_invalid_suffix_in_list_raises(tmp_path: Path):
+    """_infer_noise_output_format rejects a list entry with an unsupported extension."""
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+    with pytest.raises(ValueError, match=r"must end with \.npy or \.gwf"):
+        orchestrator._infer_noise_output_format(["noise-H1.wav", "noise-L1.wav"])
+
+
+def test_infer_noise_format_mixed_suffixes_raises(tmp_path: Path):
+    """_infer_noise_output_format rejects a list that mixes .npy and .gwf entries."""
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+    with pytest.raises(ValueError, match="same extension"):
+        orchestrator._infer_noise_output_format(["noise-H1.npy", "noise-L1.gwf"])
+
+
+def test_expand_noise_output_paths_list_duplicate_paths_raises(tmp_path: Path):
+    """_expand_noise_output_paths rejects a pre-resolved list where two entries map to the same path."""
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+    config.orchestration.noise.arguments = {
+        "seed": 7,
+        "duration": 4.0,
+        "sampling_frequency": 4.0,
+        "detectors": ["H1", "L1"],
+    }
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+    orchestrator._active_noise_output_directory = tmp_path / "noise"
+    with pytest.raises(ValueError, match="identical paths"):
+        orchestrator._expand_noise_output_paths(["same-file.npy", "same-file.npy"])
+
+
+def test_save_data_list_file_name_coerced_to_ndarray(monkeypatch, tmp_path: Path):
+    """_save_data accepts list[str] file_name and routes it through the ndarray dispatch path."""
+    from gwmock.data.time_series.time_series import TimeSeries as GwmockTimeSeries
+
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+    orchestrator = AdapterOrchestrator.from_config(config.orchestration, config.globals.simulator_arguments)
+    data = GwmockTimeSeries(np.zeros((1, 4)), start_time=0.0, sampling_frequency=1.0)
+
+    written: list[Path] = []
+
+    def _mock_write(self, path, **kwargs):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+        written.append(path)
+
+    monkeypatch.setattr("gwmock.cli.adapter_orchestration.DetectorStrainStack.write", _mock_write)
+
+    out = tmp_path / "signal" / "H1.npy"
+    orchestrator._save_data(data, [str(out)])
+
+    assert written == [out]
+
+
 def test_build_signal_stack_uses_channel_name_as_gwf_channel(tmp_path: Path):
     """_build_signal_stack uses channel_name as the stack name so GWF writes the right channel."""
     from gwmock.data.time_series.time_series import TimeSeries as GwmockTimeSeries

--- a/tests/cli/utils/test_simulation_plan.py
+++ b/tests/cli/utils/test_simulation_plan.py
@@ -6,8 +6,8 @@ import datetime
 import json
 import tempfile
 from pathlib import Path
-from typing import Any
-from unittest.mock import MagicMock
+from typing import Any, ClassVar
+from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
@@ -25,6 +25,7 @@ from gwmock.cli.utils.config import (
 from gwmock.cli.utils.simulation_plan import (
     SimulationBatch,
     SimulationPlan,
+    _warn_version_mismatches,
     create_batch_metadata,
     create_plan_from_config,
     create_plan_from_metadata,
@@ -1317,3 +1318,124 @@ class TestMergePlans:
         assert noise_batch.has_state_snapshot()
         assert noise_batch.batch_metadata["author"] == "merge_author"
         assert noise_batch.batch_metadata["email"] == "merge@example.com"
+
+
+# ============================================================================
+# _warn_version_mismatches Tests
+# ============================================================================
+
+
+def _make_batch_with_metadata(
+    globals_config: GlobalsConfig,
+    simulator_config: SimulatorConfig,
+    batch_metadata: dict,
+) -> SimulationBatch:
+    """Build a minimal SimulationBatch with the given batch_metadata dict."""
+    return SimulationBatch(
+        simulator_name="orchestration",
+        simulator_config=simulator_config,
+        globals_config=globals_config,
+        batch_index=0,
+        source="metadata_config",
+        batch_metadata=batch_metadata,
+    )
+
+
+class TestWarnVersionMismatches:
+    """Tests for _warn_version_mismatches helper."""
+
+    _INSTALLED: ClassVar[dict[str, str]] = {
+        "gwmock": "0.7.1",
+        "gwmock-noise": "0.5.2",
+        "gwmock-pop": "0.9.3",
+        "gwmock-signal": "0.8.2",
+    }
+
+    def _metadata(self, **overrides) -> dict:
+        """Return a metadata dict with all four versions set to match _INSTALLED."""
+        base = {
+            "gwmock_version": "0.7.1",
+            "subpackage_versions": {
+                "gwmock_noise": "0.5.2",
+                "gwmock_pop": "0.9.3",
+                "gwmock_signal": "0.8.2",
+            },
+        }
+        base.update(overrides)
+        return base
+
+    def test_no_warning_on_version_match(
+        self,
+        globals_config: GlobalsConfig,
+        simulator_config: SimulatorConfig,
+    ):
+        """All stored versions match installed → logger.warning never called."""
+        batch = _make_batch_with_metadata(globals_config, simulator_config, self._metadata())
+        with patch("gwmock.cli.utils.simulation_plan.logger") as mock_logger:
+            _warn_version_mismatches([batch], self._INSTALLED)
+        mock_logger.warning.assert_not_called()
+
+    def test_warns_on_gwmock_version_mismatch(
+        self,
+        globals_config: GlobalsConfig,
+        simulator_config: SimulatorConfig,
+    ):
+        """gwmock_version differs from installed → warning names package and both versions."""
+        batch = _make_batch_with_metadata(globals_config, simulator_config, self._metadata(gwmock_version="0.6.0"))
+        with patch("gwmock.cli.utils.simulation_plan.logger") as mock_logger:
+            _warn_version_mismatches([batch], self._INSTALLED)
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert "gwmock" in call_args.args[1]
+        assert "0.6.0" in call_args.args[2]
+        assert "0.7.1" in call_args.args[3]
+
+    def test_warns_on_subpackage_mismatch(
+        self,
+        globals_config: GlobalsConfig,
+        simulator_config: SimulatorConfig,
+    ):
+        """gwmock_noise version differs → warning emitted for gwmock-noise."""
+        meta = self._metadata()
+        meta["subpackage_versions"]["gwmock_noise"] = "0.4.0"
+        batch = _make_batch_with_metadata(globals_config, simulator_config, meta)
+        with patch("gwmock.cli.utils.simulation_plan.logger") as mock_logger:
+            _warn_version_mismatches([batch], self._INSTALLED)
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args
+        assert "gwmock-noise" in call_args.args[1]
+        assert "0.4.0" in call_args.args[2]
+        assert "0.5.2" in call_args.args[3]
+
+    def test_no_warning_for_none_version(
+        self,
+        globals_config: GlobalsConfig,
+        simulator_config: SimulatorConfig,
+    ):
+        """gwmock_version is None in metadata → silently skipped, no warning."""
+        batch = _make_batch_with_metadata(globals_config, simulator_config, self._metadata(gwmock_version=None))
+        with patch("gwmock.cli.utils.simulation_plan.logger") as mock_logger:
+            _warn_version_mismatches([batch], self._INSTALLED)
+        mock_logger.warning.assert_not_called()
+
+    def test_deduplicates_across_batches(
+        self,
+        globals_config: GlobalsConfig,
+        simulator_config: SimulatorConfig,
+    ):
+        """Two batches with the same stored mismatch → warning called exactly once per package."""
+        stale_meta = self._metadata(gwmock_version="0.6.0")
+        batches = [
+            _make_batch_with_metadata(globals_config, simulator_config, stale_meta),
+            SimulationBatch(
+                simulator_name="orchestration",
+                simulator_config=simulator_config,
+                globals_config=globals_config,
+                batch_index=1,
+                source="metadata_config",
+                batch_metadata=stale_meta,
+            ),
+        ]
+        with patch("gwmock.cli.utils.simulation_plan.logger") as mock_logger:
+            _warn_version_mismatches(batches, self._INSTALLED)
+        assert mock_logger.warning.call_count == 1

--- a/tests/cli/utils/test_simulation_plan.py
+++ b/tests/cli/utils/test_simulation_plan.py
@@ -810,6 +810,134 @@ class TestCreatePlanFromMetadata:
         with pytest.raises(ValueError, match="Invalid metadata"):
             create_plan_from_metadata(metadata_directory, Path("checkpoints"))
 
+    def test_create_plan_from_metadata_orchestration_noise_only(
+        self,
+        metadata_directory: Path,
+        globals_config: GlobalsConfig,
+        simulator_config: SimulatorConfig,
+    ):
+        """Noise-only orchestration metadata (config.orchestration with only 'noise') must produce OrchestrationConfig."""
+        noise_orch = OrchestrationConfig(noise=NoiseAdapterConfig())
+        config_payload = {
+            "globals": globals_config.model_dump(by_alias=True, exclude_none=True),
+            "orchestration": noise_orch.model_dump(by_alias=True, exclude_none=True),
+        }
+        metadata = create_batch_metadata(
+            simulator_name="orchestration",
+            batch_index=0,
+            simulator_config=simulator_config,
+            globals_config=globals_config,
+            config_payload=config_payload,
+        )
+        metadata_file = metadata_directory / "orchestration-0.metadata.json"
+        with metadata_file.open("w") as f:
+            json.dump(metadata, f)
+
+        plan = create_plan_from_metadata(metadata_directory, Path("checkpoints"))
+
+        assert plan.total_batches == 1
+        assert isinstance(plan.batches[0].simulator_config, OrchestrationConfig)
+        assert plan.batches[0].simulator_config.noise is not None
+        assert plan.batches[0].simulator_config.population is None
+        assert plan.batches[0].simulator_config.signal is None
+
+    def test_create_plan_from_metadata_orchestration_population_only(
+        self,
+        metadata_directory: Path,
+        globals_config: GlobalsConfig,
+        simulator_config: SimulatorConfig,
+    ):
+        """Population-only orchestration metadata must produce OrchestrationConfig."""
+        pop_orch = OrchestrationConfig(population=PopulationConfig(backend="file"))
+        config_payload = {
+            "globals": globals_config.model_dump(by_alias=True, exclude_none=True),
+            "orchestration": pop_orch.model_dump(by_alias=True, exclude_none=True),
+        }
+        metadata = create_batch_metadata(
+            simulator_name="orchestration",
+            batch_index=0,
+            simulator_config=simulator_config,
+            globals_config=globals_config,
+            config_payload=config_payload,
+        )
+        metadata_file = metadata_directory / "orchestration-0.metadata.json"
+        with metadata_file.open("w") as f:
+            json.dump(metadata, f)
+
+        plan = create_plan_from_metadata(metadata_directory, Path("checkpoints"))
+
+        assert plan.total_batches == 1
+        assert isinstance(plan.batches[0].simulator_config, OrchestrationConfig)
+        assert plan.batches[0].simulator_config.population is not None
+        assert plan.batches[0].simulator_config.noise is None
+
+    def test_create_plan_from_metadata_orchestration_noise_only_list_file_name(
+        self,
+        metadata_directory: Path,
+        globals_config: GlobalsConfig,
+        simulator_config: SimulatorConfig,
+    ):
+        """Noise-only orchestration metadata with pre-resolved list file_name (as stored by _build_config_payload) must round-trip."""
+        config_payload = {
+            "globals": globals_config.model_dump(by_alias=True, exclude_none=True),
+            "orchestration": {
+                "noise": {
+                    "arguments": {"detectors": ["ET1_EMR", "ET2_EMR", "ET3_EMR"]},
+                    "output": {
+                        "file_name": [
+                            "E-ET1_EMR_STRAIN_NOISE-1577491218-4096.gwf",
+                            "E-ET2_EMR_STRAIN_NOISE-1577491218-4096.gwf",
+                            "E-ET3_EMR_STRAIN_NOISE-1577491218-4096.gwf",
+                        ],
+                        "output_directory": "noise",
+                        "arguments": {"channel": ["ET1_EMR:STRAIN", "ET2_EMR:STRAIN", "ET3_EMR:STRAIN"]},
+                    },
+                }
+            },
+        }
+        metadata = create_batch_metadata(
+            simulator_name="orchestration",
+            batch_index=0,
+            simulator_config=simulator_config,
+            globals_config=globals_config,
+            config_payload=config_payload,
+        )
+        metadata_file = metadata_directory / "orchestration-0.metadata.json"
+        with metadata_file.open("w") as f:
+            json.dump(metadata, f)
+
+        plan = create_plan_from_metadata(metadata_directory, Path("checkpoints"))
+
+        assert plan.total_batches == 1
+        assert isinstance(plan.batches[0].simulator_config, OrchestrationConfig)
+        noise_cfg = plan.batches[0].simulator_config.noise
+        assert noise_cfg is not None
+        assert isinstance(noise_cfg.output.file_name, list)
+        assert len(noise_cfg.output.file_name) == 3
+
+    def test_create_plan_from_metadata_orchestration_unknown_shape_raises(
+        self,
+        metadata_directory: Path,
+        globals_config: GlobalsConfig,
+    ):
+        """Orchestration config with no recognised section keys must still raise 'Invalid metadata'."""
+        metadata = {
+            "simulator_name": "orchestration",
+            "batch_index": 0,
+            "config": {
+                "globals": globals_config.model_dump(by_alias=True, exclude_none=True),
+                "orchestration": {"unrecognised": "value"},
+            },
+            "globals_config": globals_config.model_dump(by_alias=True, exclude_none=True),
+            "simulator_config": {},
+        }
+        metadata_file = metadata_directory / "orchestration-0.metadata.json"
+        with metadata_file.open("w") as f:
+            json.dump(metadata, f)
+
+        with pytest.raises(ValueError, match="Invalid metadata"):
+            create_plan_from_metadata(metadata_directory, Path("checkpoints"))
+
     def test_create_plan_from_metadata_missing_simulator_name(
         self,
         metadata_directory: Path,

--- a/tests/simulator/test_base_simulator.py
+++ b/tests/simulator/test_base_simulator.py
@@ -9,7 +9,9 @@ from typing import Any
 import numpy as np
 import pytest
 import yaml
+from astropy.units.quantity import Quantity
 
+from gwmock.mixin.time_series import TimeSeriesMixin
 from gwmock.simulator.base import Simulator
 
 
@@ -50,6 +52,16 @@ class MockSimulator(Simulator):
                 data = data.item()
             with Path(file_name).open("w", encoding="utf-8") as f:
                 yaml.safe_dump(data, f)
+
+
+class MockTimeSeriesSimulator(TimeSeriesMixin, Simulator):
+    """Mock simulator with TimeSeriesMixin for testing Quantity state restoration."""
+
+    def simulate(self) -> int:
+        return self.counter
+
+    def _save_data(self, data: Any, file_name: str | Path | np.ndarray[Any, np.dtype[np.object_]], **kwargs) -> None:
+        pass
 
 
 @pytest.fixture
@@ -340,3 +352,35 @@ class TestSimulatorSaveData:
             with open(file_path, encoding="utf-8") as f:
                 loaded_data = yaml.safe_load(f)
             assert loaded_data == new_data
+
+
+class TestSimulatorStateQuantityRewrap:
+    """Test that state setter re-wraps plain numbers to Quantity for Quantity StateAttributes."""
+
+    def test_start_time_plain_float_rewrapped_to_quantity(self):
+        """state setter must restore a plain-float start_time as a Quantity."""
+        sim = MockTimeSeriesSimulator()
+        assert hasattr(sim.start_time, "unit"), "start_time must be a Quantity after __init__"
+
+        sim.state = {"start_time": 1577491218.0, "counter": 3}
+
+        assert hasattr(sim.start_time, "unit"), "start_time must remain a Quantity after state restore"
+        assert hasattr(sim.start_time, "value")
+        assert sim.start_time.value == 1577491218.0
+        # This is the exact call that crashed during reproduction runs
+        assert float(sim.start_time.value) == 1577491218.0
+
+    def test_start_time_quantity_accepted_without_double_wrap(self):
+        """state setter must accept a Quantity start_time unchanged."""
+        sim = MockTimeSeriesSimulator()
+        q = Quantity(1577491218.0, unit="s")
+        sim.state = {"start_time": q, "counter": 0}
+        assert sim.start_time.value == 1577491218.0
+        assert str(sim.start_time.unit) == "s"
+
+    def test_non_quantity_state_attribute_unaffected(self):
+        """Plain int state attributes must be stored as-is, not wrapped in Quantity."""
+        sim = MockTimeSeriesSimulator()
+        sim.state = {"counter": 42, "start_time": sim.start_time}
+        assert sim.counter == 42
+        assert not hasattr(sim.counter, "unit")


### PR DESCRIPTION
Close #178 

This PR fixes several bugs that together caused simulation reproduction runs — where output is regenerated from stored metadata rather than from scratch — to fail or write incorrect files.

## Quantity units dropped on state restore

When resuming from metadata, state values such as start_time are deserialized as plain floats. The base Simulator.set_state now detects when the existing attribute is an astropy Quantity and re-wraps the incoming value with the correct unit, preventing crashes in downstream arithmetic.

## Partial orchestration configs not recognised during replay

Metadata replay uses the stored simulator_config shape to distinguish OrchestrationConfig from SimulatorConfig. The detection logic required all three keys (population, signal, noise) to be present, so noise-only or population-only runs were rejected as unknown. Relaxed to a set intersection so any subset is accepted.

## Multi-batch runs overwriting batch 0's output files

Each batch in a reproduction run carries its own pre-expanded list of output filenames (one per detector). The orchestrator was ignoring this and always falling back to the first batch's instantiation-time template, causing every batch to attempt writing to the same paths. set_batch_context now captures the per-batch filename list and _run_noise_batch uses it. SimulatorOutputConfig.file_name is widened to str | list[str] to accommodate pre-resolved lists stored in metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for per-batch noise output filename configuration in orchestration workflows.
  * Enhanced configuration format to accept filename lists for multi-detector scenarios.
  * Improved state attribute handling for unit-aware properties in simulators.

* **Tests**
  * Expanded test coverage for per-batch orchestration configuration and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->