### PR TITLE
docs: Correct the User Guide to match the migrated examples

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -192,13 +192,13 @@ orchestration:
     population:
         backend: FilePopulationLoader # or any registered backend alias
         source-type: bbh
-        n-samples: 128
+        n-samples: 128 # optional; omit to load the full catalogue
         arguments:
             path: population.h5
 
     signal:
         waveform-model: IMRPhenomXPHM
-        minimum-frequency: 2
+        minimum-frequency: 10
         detectors:
             - ET-Triangle-EMR
         output:
@@ -213,13 +213,13 @@ orchestration:
             psd_file: ET_10_full_cryo_psd
             seed: 42
             detectors:
-                - E1_triangle_emr
-                - E2_triangle_emr
-                - E3_triangle_emr
+                - ET-Triangle-EMR
         output:
-            file_name: et-noise-{{ counter }}.gwf
+            file_name:
+                'E-{{ detectors }}_STRAIN_NOISE-{{ start_time }}-{{ duration
+                }}.gwf'
             arguments:
-                channel_prefix: STRAIN
+                channel: '{{ detectors }}:STRAIN'
 ```
 
 For SGWB studies, use `signal.source-type: sgwb`. Constructor options for the
@@ -278,10 +278,10 @@ orchestration:
                 - E3_triangle_emr
         output:
             file_name:
-                'E-{{ detectors }}_NOISE_STRAIN-{{ start_time }}-{{ duration
+                'E-{{ detectors }}_STRAIN_NOISE-{{ start_time }}-{{ duration
                 }}.gwf'
             arguments:
-                channel_prefix: STRAIN
+                channel: '{{ detectors }}:STRAIN'
 ```
 
 In this example, `file_name` is automatically expanded for each detector being
@@ -291,7 +291,10 @@ processed.
 
 - `{{ start_time }}`: GPS start time from globals
 - `{{ duration }}`: Segment duration from globals
-- `{{ detectors }}`: Current detector being processed
+- `{{ detectors }}`: Current detector being processed. A network alias such as
+  `ET-Triangle-EMR` expands to one file/channel per interferometer, with
+  `{{ detectors }}` resolving to the per-interferometer token (`ET1_EMR`,
+  `ET2_EMR`, `ET3_EMR`)
 
 ## Checkpointing
 

--- a/docs/user-guide/examples.md
+++ b/docs/user-guide/examples.md
@@ -5,11 +5,14 @@ simulations.
 
 ## Overview
 
-All example configurations in the
+Most of the ET noise, BBH, and BNS example configurations in the
 [`examples/`](https://github.com/Leuven-Gravity-Institute/gwmock/tree/main/examples)
-directory generate one day of data per detector, divided into 4096-seconds
-frames (21 frame files in total), sampled at 4096 Hz, starting from 1
-January 2030.
+directory generate one day of data per interferometer, divided into 4096-second
+frames (21 frame files per interferometer), sampled at 4096 Hz. The noise
+examples start at GPS 1577491218 (1 January 2030); the BBH/BNS signal examples
+start at GPS 1000000540 (14 September 2011). A few examples differ on purpose:
+`quick_start` is a short single-segment (1024 s) demonstration, and the SGWB
+examples generate a short stochastic-background segment.
 
 For guidance on changing dataset duration or simulation properties, see the
 [Generating Data](generating-data.md) page. For a more complete guide to writing
@@ -34,16 +37,18 @@ gwmock simulate config.yaml
 
 ## Blank Starting Config
 
-The `default_config` label produces a minimal template that shows the full
-`orchestration:` schema with a local `population.h5` placeholder. Use it as a
-starting point when writing a custom configuration from scratch:
+The `default_config` label produces a minimal, hand-commented noise-only
+orchestration template for the ET Sardinia triangle. Use it as a starting point
+when writing a custom configuration from scratch:
 
 ```bash
 gwmock config --get default_config --output config.yaml
 ```
 
-The generated file expects you to supply a local `population.h5` file. Replace
-`path: population.h5` with an actual path or URL before running.
+It runs as-is (noise only). To generate signals as well, add `population` and
+`signal` sections to the `orchestration:` block — see the
+[Configuration Files](configuration.md) and [Orchestration](orchestration.md)
+guides, or copy one of the signal examples below.
 
 ## Noise Generation
 
@@ -66,22 +71,40 @@ and sensitivities.
 
 ## CBC Signals Generation
 
-Example configurations for generating detector data with BBH signals with
-various configurations and sensitivities.
+Example configurations for generating detector data with compact-binary
+coalescence (BBH and BNS) signals for various detector configurations.
 
-### Einstein Telescope - Triangular
+### Binary Black Hole (BBH)
 
-- EMR location:
+- EMR (triangular):
   [`signal/bbh/et_triangle_emr/config.yaml`](https://github.com/Leuven-Gravity-Institute/gwmock/tree/main/examples/signal/bbh/et_triangle_emr/config.yaml)
-- Sardinia location:
+- Sardinia (triangular):
   [`signal/bbh/et_triangle_sardinia/config.yaml`](https://github.com/Leuven-Gravity-Institute/gwmock/tree/main/examples/signal/bbh/et_triangle_sardinia/config.yaml)
-
-### Einstein Telescope - 2L
-
-- Aligned configuration:
+- 2L aligned:
   [`signal/bbh/et_2l_aligned/config.yaml`](https://github.com/Leuven-Gravity-Institute/gwmock/tree/main/examples/signal/bbh/et_2l_aligned/config.yaml)
-- Misaligned configuration:
+- 2L misaligned:
   [`signal/bbh/et_2l_misaligned/config.yaml`](https://github.com/Leuven-Gravity-Institute/gwmock/tree/main/examples/signal/bbh/et_2l_misaligned/config.yaml)
+
+### Binary Neutron Star (BNS)
+
+- EMR (triangular):
+  [`signal/bns/et_triangle_emr/config.yaml`](https://github.com/Leuven-Gravity-Institute/gwmock/tree/main/examples/signal/bns/et_triangle_emr/config.yaml)
+- Sardinia (triangular):
+  [`signal/bns/et_triangle_sardinia/config.yaml`](https://github.com/Leuven-Gravity-Institute/gwmock/tree/main/examples/signal/bns/et_triangle_sardinia/config.yaml)
+- 2L aligned:
+  [`signal/bns/et_2l_aligned/config.yaml`](https://github.com/Leuven-Gravity-Institute/gwmock/tree/main/examples/signal/bns/et_2l_aligned/config.yaml)
+- 2L misaligned:
+  [`signal/bns/et_2l_misaligned/config.yaml`](https://github.com/Leuven-Gravity-Institute/gwmock/tree/main/examples/signal/bns/et_2l_misaligned/config.yaml)
+
+## Stochastic Background (SGWB) Generation
+
+Example configurations for generating an isotropic stochastic gravitational-wave
+background. These set `signal.source-type: sgwb` and require no population:
+
+- Sardinia (triangular):
+  [`signal/sgwb/et_triangle_sardinia/config.yaml`](https://github.com/Leuven-Gravity-Institute/gwmock/tree/main/examples/signal/sgwb/et_triangle_sardinia/config.yaml)
+- 2L aligned:
+  [`signal/sgwb/et_2l_aligned/config.yaml`](https://github.com/Leuven-Gravity-Institute/gwmock/tree/main/examples/signal/sgwb/et_2l_aligned/config.yaml)
 
 ## Glitch Generation
 

--- a/docs/user-guide/generating-data.md
+++ b/docs/user-guide/generating-data.md
@@ -14,7 +14,7 @@ output GWF files, see the [Reading Data](reading-data.md) page.
 
 Detector noise can be generated using configuration files in the
 [`examples/noise`](https://github.com/Leuven-Gravity-Institute/gwmock/tree/main/examples/noise)
-directory. An example configuration for producing two hours of ET noise data is
+directory. An example configuration for producing one day of ET noise data is
 provided in
 [`uncorrelated_gaussian/et_triangle_emr/config.yaml`](https://github.com/Leuven-Gravity-Institute/gwmock/blob/main/examples/noise/uncorrelated_gaussian/et_triangle_emr/config.yaml):
 
@@ -22,15 +22,16 @@ provided in
 --8<-- "examples/noise/uncorrelated_gaussian/et_triangle_emr/config.yaml"
 ```
 
-This configuration generates one day of noise data per detector (E1, E2, E3).
-Each frame file covers 4096 seconds, resulting in 22 frame files, starting on 1
-January 2030.
+This configuration uses the `ET-Triangle-EMR` network alias, which expands to
+its three interferometers (`ET1_EMR`, `ET2_EMR`, `ET3_EMR`), generating one day
+of noise data per interferometer. Each frame file covers 4096 seconds, resulting
+in 21 frame files per interferometer, starting on 1 January 2030.
 
 Noise is simulated using the
 [ET_10_full_cryo_psd](https://github.com/Leuven-Gravity-Institute/gwmock/blob/main/src/gwmock/detector/noise_curves/ET_10_full_cryo_psd.txt)
 sensitivity curve from the
 [CoBA Science Study](https://iopscience.iop.org/article/10.1088/1475-7516/2023/07/068)
-and publicly available. A low-frequency cutoff of 20 Hz is used.
+and publicly available. A low-frequency cutoff of 3 Hz is used.
 
 To generate the ET noise data, run:
 
@@ -72,14 +73,15 @@ is provided in
 ```
 
 As with the noise example, this configuration file produces one day of data per
-detector, with each frame file lasting 4096 seconds (for a total of 21 frame
-files), starting on 1 January 2030.
+interferometer, with each frame file lasting 4096 seconds (for a total of 21
+frame files), starting at GPS 1000000540 (14 September 2011).
 
-BBH signals are injected into zero noise using the bundled smoke population
-file, which provides one BBH event with canonical columns compatible with the
-`FilePopulationLoader`. The
+BBH signals are injected into zero noise. The population is loaded with the
+`FilePopulationLoader` from the MDC1 BBH catalogue hosted on Zenodo
+(`mdc1_bbh.h5`); because `n-samples` is omitted, the full catalogue is used. The
 [IMRPhenomXPHM](https://journals.aps.org/prd/abstract/10.1103/PhysRevD.103.104056)
-waveform model is used, with a low-frequency cutoff of 20 Hz.
+waveform model is used, with a low-frequency cutoff of 10 Hz and the
+time-dependent detector response enabled (`earth-rotation: true`).
 
 To generate the ET data with BBH signals, run:
 
@@ -92,6 +94,25 @@ cd bbh_et_triangle_emr
 gwmock config --get signal/bbh/et_triangle_emr --output config.yaml
 
 # Run simulation
+gwmock simulate config.yaml
+```
+
+### Binary Neutron Star (BNS) Signals
+
+BNS datasets are produced the same way, using the `signal/bns/*` examples. These
+set `population.source-type: bns`, load the MDC1 BNS catalogue from Zenodo
+(`mdc1_bns.h5`), and use the tidal
+[IMRPhenomPv2_NRTidalv2](https://journals.aps.org/prd/abstract/10.1103/PhysRevD.100.044003)
+waveform model with a low-frequency cutoff of 20 Hz:
+
+```yaml
+--8<-- "examples/signal/bns/et_triangle_emr/config.yaml"
+```
+
+To generate the ET data with BNS signals, run:
+
+```bash
+gwmock config --get signal/bns/et_triangle_emr --output config.yaml
 gwmock simulate config.yaml
 ```
 
@@ -118,7 +139,7 @@ into 4096-second frame files (for a total of 21 frames), starting on 1
 January 2030.
 
 Blip glitches are injected into zero noise from the
-[blip_glitch_population_E1.h5](https://sandbox.zenodo.org/records/413548)
+[blip_glitch_population_E1.hdf5](https://sandbox.zenodo.org/records/514722)
 population file, which can be generated from GravitySpy tables with
 `gwmock-noise build-blip-glitch-table`. These glitches are modeled on LIGO blip
 glitches observed during the O3 observing run and recolored to match the ET
@@ -141,7 +162,7 @@ gwmock simulate config.yaml
 <!-- prettier-ignore -->
 !!! note
     The configuration file automatically downloads the glitch population file from a
-    [Zenodo repository](https://sandbox.zenodo.org/records/413548).
+    [Zenodo repository](https://sandbox.zenodo.org/records/514722).
     The file is saved in a cache directory (by default, `~/.gwmock/population/`).
     When the same population file is needed again, gwmock uses the cached copy to avoid re-downloading.
 
@@ -228,11 +249,14 @@ samples per second, measured in Hz), using the `sampling-frequency` argument.
 **Total number of frame files:**
 
 The total number of frame files depends on the duration of each frame file and
-the total duration of the dataset, and it's rounded up to the next integer:
+the total duration of the dataset, and it's rounded to the nearest integer:
 
 ```python
-max_samples = ceil(total-duration / duration)
+max_samples = round(total-duration / duration)
 ```
+
+For example, a one-day dataset (86400 s) in 4096-second frames yields
+`round(86400 / 4096) = 21` frame files per interferometer.
 
 <!-- prettier-ignore-start -->
 
@@ -292,39 +316,21 @@ globals:
     metadata-directory: metadata
 
 orchestration:
-    population:
-        backend: FilePopulationLoader
-        source-type: bbh
-        n-samples: 1
-        arguments:
-            path: https://raw.githubusercontent.com/Leuven-Gravity-Institute/gwmock/main/examples/noise/glitches/gengli/bbh_smoke_population.csv
-    signal:
-        waveform-model: IMRPhenomXPHM
-        minimum-frequency: 2
-        detectors:
-            - ET-Triangle-EMR
-        output:
-            file_name:
-                'E-{{ detectors }}_STRAIN_BBH-{{ start_time }}-{{ duration
-                }}.gwf'
-            arguments:
-                channel: '{{ detectors }}:STRAIN'
     noise:
         arguments:
             psd_file: ET_10_full_cryo_psd
             csd_file: path_to_csd_file.txt
             detectors:
-                - E1_triangle_emr
-                - E2_triangle_emr
-                - E3_triangle_emr
-            low_frequency_cutoff: 2
+                - ET-Triangle-EMR
+            minimum_frequency: 3
             seed: 42
         output:
+            output_directory: noise
             file_name:
-                'E-{{ detectors }}_CORRELATED-NOISE_STRAIN-{{ start_time }}-{{
+                'E-{{ detectors }}_STRAIN_CORRELATED-NOISE-{{ start_time }}-{{
                 duration }}.gwf'
             arguments:
-                channel_prefix: STRAIN
+                channel: '{{ detectors }}:STRAIN'
 ```
 
 `gwmock` uses a windowing approach to generate long-duration datasets. If the

--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -48,20 +48,30 @@ INFO Simulation completed successfully. Output written to output
 Your working directory will contain:
 
 ```text
-noise/
-└── et-noise-0.gwf
-signal/
-└── E-ET-Triangle-Sardinia_STRAIN_BBH-1577491218-1024.gwf
+output/
+├── noise/
+│   ├── E-ET1_SARD_STRAIN_NOISE-1577491218-1024.gwf
+│   ├── E-ET2_SARD_STRAIN_NOISE-1577491218-1024.gwf
+│   └── E-ET3_SARD_STRAIN_NOISE-1577491218-1024.gwf
+└── signal/
+    ├── E-ET1_SARD_STRAIN_BBH-1577491218-1024.gwf
+    ├── E-ET2_SARD_STRAIN_BBH-1577491218-1024.gwf
+    └── E-ET3_SARD_STRAIN_BBH-1577491218-1024.gwf
 metadata/
+├── index.yaml
 └── orchestration-0.metadata.json
 resource_usage_summary.json
 ```
 
+The `ET-Triangle-Sardinia` network alias expands to its three interferometers
+(`ET1_SARD`, `ET2_SARD`, `ET3_SARD`), so one frame file per interferometer is
+written for both noise and signal.
+
 ### Data Files
 
-`noise/` contains the simulated Gaussian noise strain. `signal/` contains the
-injected CBC signal strain. To produce a realistic data stream, merge the two
-using GWpy (see [Reading Data](reading-data.md)).
+`output/noise/` contains the simulated Gaussian noise strain. `output/signal/`
+contains the injected CBC signal strain. To produce a realistic data stream,
+merge the two using GWpy (see [Reading Data](reading-data.md)).
 
 ### Metadata File
 

--- a/docs/user-guide/reading-data.md
+++ b/docs/user-guide/reading-data.md
@@ -16,7 +16,7 @@ file:
 from gwpy.timeseries import TimeSeries
 
 # Read specific channel from a frame file
-data = TimeSeries.read("filename.gwf", channel="E1:STRAIN")
+data = TimeSeries.read("filename.gwf", channel="ET1_EMR:STRAIN")
 ```
 
 **Parameters:**
@@ -29,8 +29,8 @@ data = TimeSeries.read("filename.gwf", channel="E1:STRAIN")
 ```python
 from gwpy.timeseries import TimeSeries
 
-# Read E1 strain data
-e1_data = TimeSeries.read("E-E1-NOISE_STRAIN-1577491218-4096.gwf", channel="E1:STRAIN")
+# Read ET1_EMR strain data
+e1_data = TimeSeries.read("E-ET1_EMR_STRAIN_NOISE-1577491218-4096.gwf", channel="ET1_EMR:STRAIN")
 
 # Check properties
 print(f"Duration: {e1_data.duration}")
@@ -47,8 +47,8 @@ signals, glitches). To obtain a realistic data stream, merge multiple files:
 from gwpy.timeseries import TimeSeries
 
 # Read noise and signal data
-noise_data = TimeSeries.read("filename_noise.gwf", channel="E1:STRAIN")
-signal_data = TimeSeries.read("filename_signal.gwf", channel="E1:STRAIN")
+noise_data = TimeSeries.read("filename_noise.gwf", channel="ET1_EMR:STRAIN")
+signal_data = TimeSeries.read("filename_signal.gwf", channel="ET1_EMR:STRAIN")
 
 # Combine them
 combined_data = noise_data.inject(signal_data)
@@ -58,10 +58,10 @@ You can also merge files directly using the CLI:
 
 ```bash
 gwmock merge filename_noise.gwf filename_signal.gwf \
-    --metadata noise-0.metadata.json \
-    --metadata signal-0.metadata.json \
-    --channel E1:STRAIN \
-    --output-channel E1:STRAIN
+    --metadata noise/metadata/orchestration-0.metadata.json \
+    --metadata signal/metadata/orchestration-0.metadata.json \
+    --channel ET1_EMR:STRAIN \
+    --output-channel ET1_EMR:STRAIN
 ```
 
 This produces a merged frame file and a merged metadata file documenting all
@@ -75,13 +75,13 @@ To merge a sequence of files:
 from gwpy.timeseries import TimeSeries
 
 files = [
-    "E-E1-NOISE_STRAIN-1000000000-1024.gwf",
-    "E-E1-NOISE_STRAIN-1000001024-1024.gwf",
-    "E-E1-NOISE_STRAIN-1000002048-1024.gwf"
+    "E-ET1_EMR_STRAIN_NOISE-1000000000-1024.gwf",
+    "E-ET1_EMR_STRAIN_NOISE-1000001024-1024.gwf",
+    "E-ET1_EMR_STRAIN_NOISE-1000002048-1024.gwf"
 ]
 
 # Read all files
-data_list = [TimeSeries.read(f, channel="E1:STRAIN") for f in files]
+data_list = [TimeSeries.read(f, channel="ET1_EMR:STRAIN") for f in files]
 
 # Concatenate
 combined = data_list[0]
@@ -117,7 +117,7 @@ with:
 import json
 
 # Read a JSON metadata record
-with open("metadata/noise-0.metadata.json", "r") as f:
+with open("metadata/orchestration-0.metadata.json", "r") as f:
     metadata = json.load(f)
 
 print(metadata["schema_version"])    # e.g. "1.0.0"
@@ -153,13 +153,13 @@ Process data from multiple detectors:
 ```python
 from gwpy.timeseries import TimeSeries
 
-detectors = ["E1", "E2", "E3"]
+detectors = ["ET1_EMR", "ET2_EMR", "ET3_EMR"]
 
 # Read data for each detector
 detector_data = {}
 for detector in detectors:
     channel = f"{detector}:STRAIN"
-    filename = f"E-{detector}-NOISE_STRAIN-1000000000-1024.gwf"
+    filename = f"E-{detector}_STRAIN_NOISE-1000000000-1024.gwf"
     detector_data[detector] = TimeSeries.read(filename, channel=channel)
 
 # Process or analyze each
@@ -176,7 +176,7 @@ from gwpy.timeseries import TimeSeries
 import matplotlib.pyplot as plt
 
 # Read data
-data = TimeSeries.read("E-E1-NOISE_STRAIN-1000000000-1024.gwf", channel="E1:STRAIN")
+data = TimeSeries.read("E-ET1_EMR_STRAIN_NOISE-1000000000-1024.gwf", channel="ET1_EMR:STRAIN")
 
 # Plot time series
 plot = data.plot(title="Strain Data")

--- a/docs/user-guide/reproducibility.md
+++ b/docs/user-guide/reproducibility.md
@@ -31,7 +31,7 @@ Consumers must reject unknown major versions.
     "signal": {
         "backend": "module:Class",
         "waveform_model": "IMRPhenomXPHM",
-        "detector_network": ["ET1"],
+        "detector_network": ["ET1_SARD", "ET2_SARD", "ET3_SARD"],
         "metadata": {}
     },
     "noise": {
@@ -42,8 +42,8 @@ Consumers must reject unknown major versions.
     "outputs": [
         {
             "kind": "signal",
-            "path": "output/signal-0.gwf",
-            "channels": ["ET1:STRAIN"],
+            "path": "output/signal/E-ET1_SARD_STRAIN_BBH-1577491218-1024.gwf",
+            "channels": ["ET1_SARD:STRAIN"],
             "t0": 1577491218,
             "duration": 1024,
             "sha256": "..."
@@ -85,7 +85,7 @@ snapshot and per-segment seeds needed to reproduce that batch independently:
 
 ```bash
 # Reproduce specific batches from their metadata files
-gwmock simulate metadata/noise-0.metadata.json metadata/signal-0.metadata.json
+gwmock simulate metadata/orchestration-0.metadata.json metadata/orchestration-1.metadata.json
 
 # Or reproduce everything from a metadata directory
 gwmock simulate metadata/

--- a/docs/user-guide/validate.md
+++ b/docs/user-guide/validate.md
@@ -32,13 +32,13 @@ gwmock validate output/ metadata/
 gwmock finds the corresponding metadata files automatically:
 
 ```bash
-gwmock validate noise/et-noise-0.gwf signal/E-ET-Triangle-Sardinia_STRAIN_BBH-1577491218-1024.gwf
+gwmock validate output/noise/E-ET1_SARD_STRAIN_NOISE-1577491218-1024.gwf output/signal/E-ET1_SARD_STRAIN_BBH-1577491218-1024.gwf
 ```
 
 ### Validate from metadata files directly
 
 ```bash
-gwmock validate metadata/noise-0.metadata.json metadata/signal-0.metadata.json
+gwmock validate metadata/orchestration-0.metadata.json
 ```
 
 ### Validate a subset by pattern


### PR DESCRIPTION
Close #118 

Updated the User Guide (`docs/user-guide/*`) so it matches the current single-purpose example configs and the current orchestration schema. **Documentation only** — no `src/`, `examples/`, or subpackage files changed. All output names/trees were taken from a real `gwmock simulate` run, not assumptions.

**Key corrections**

| Area | Before | After |
|------|--------|-------|
| Noise output key | `channel_prefix: STRAIN` (removed; raises) | `channel: '{{ detectors }}:STRAIN'` |
| Output file names | `et-noise-{{ counter }}.gwf`, `E-…_NOISE_STRAIN-…`, `signal-0.gwf` | `E-{{ detectors }}_STRAIN_<NOISE\|BBH\|BNS\|GLITCH>-{{ start_time }}-{{ duration }}.gwf` |
| `{{ detectors }}` token | `E1` / network alias in filename | per-IFO token `ET1_EMR` / `ET1_SARD` |
| Output tree | `noise/`, `signal/` at top level | `output/noise/`, `output/signal/` (3 IFO files each) |
| Metadata file | `noise-0.metadata.json` / `signal-0.metadata.json` | `orchestration-N.metadata.json` |
| BBH source | "bundled smoke / one event" | Zenodo `mdc1_bbh.h5` full catalogue, minf 10, `earth-rotation` |
| Signal epoch | "1 January 2030" | GPS 1000000540 (14 Sep 2011) |
| Glitch Zenodo | `records/413548`, `.h5` | `records/514722`, `.hdf5` |
| Frame count | `ceil`, "22 frame files" | `round(86400/4096) = 21` |
| Sections required | "all three required" | "at least one of population/signal/noise" |
| Missing families | — | added **BNS** and **SGWB** examples |
| `default_config` | "full schema + population.h5 placeholder" | noise-only template (matches the file) |

**Files**: `configuration`, `quickstart`, `generating-data`, `examples`, `reading-data`, `validate`, `reproducibility` (`orchestration` & `metadata` already correct).

**Verification**
- `uv run pytest tests/ -q` → **555 passed, 23 skipped** ✅
- `zensical build` → **No issues found** ✅
- grep over `docs/` for stale patterns (`channel_prefix`, `NOISE_STRAIN`, `et-noise-`, `records/413548`, `ceil(`, "all three", …) → **none** ✅
- all `--8<--` snippet includes resolve ✅