### PR TITLE
feat: validate on a content hash so reproduced frames pass

### DIFF
--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -25,7 +25,7 @@ from tqdm import tqdm
 from gwmock.cli.adapter_orchestration import AdapterOrchestrationResult, AdapterOrchestrator
 from gwmock.cli.utils.checkpoint import CheckpointManager
 from gwmock.cli.utils.config import OrchestrationConfig, SimulatorConfig, resolve_class_path
-from gwmock.cli.utils.hash import compute_file_hash
+from gwmock.cli.utils.hash import compute_content_hash, compute_file_hash
 from gwmock.cli.utils.metadata import save_metadata_record
 from gwmock.cli.utils.simulation_plan import (
     SimulationBatch,
@@ -279,6 +279,7 @@ def _build_output_records(
                         "t0": _to_plain_number(batch_data.signal_segment.start_time),
                         "duration": _to_plain_number(batch_data.signal_segment.duration),
                         "sha256": compute_file_hash(output_file),
+                        "content_sha256": compute_content_hash(output_file),
                     }
                 )
 
@@ -297,6 +298,7 @@ def _build_output_records(
                         "t0": _to_plain_number(simulator.start_time),
                         "duration": _to_plain_number(simulator.duration),
                         "sha256": compute_file_hash(output_path),
+                        "content_sha256": compute_content_hash(output_path),
                     }
                 )
         return output_records
@@ -312,6 +314,7 @@ def _build_output_records(
                     "t0": _to_plain_number(getattr(simulator, "start_time", None)),
                     "duration": _to_plain_number(getattr(simulator, "duration", None)),
                     "sha256": compute_file_hash(output_path),
+                    "content_sha256": compute_content_hash(output_path),
                 }
             )
         return output_records
@@ -327,6 +330,7 @@ def _build_output_records(
                 "t0": _to_plain_number(getattr(batch_data, "start_time", getattr(simulator, "start_time", None))),
                 "duration": _to_plain_number(getattr(batch_data, "duration", getattr(simulator, "duration", None))),
                 "sha256": compute_file_hash(output_file),
+                "content_sha256": compute_content_hash(output_file),
             }
         )
     return output_records
@@ -616,8 +620,12 @@ def save_batch_metadata(
     # Store just the file names, not full paths
     metadata["output_files"] = [f.name for f in output_files]
 
-    # Compute and add file hashes for integrity checking
+    # Compute and add file hashes for integrity checking. Two hashes are kept:
+    #   * file_hashes    -- raw container bytes (exact-file integrity)
+    #   * content_hashes -- decoded scientific content, stable across write-time
+    #                       and frame-library version (reproducibility check)
     file_hashes = {}
+    content_hashes = {}
     for output_file in output_files:
         try:
             file_hash = compute_file_hash(output_file)
@@ -626,8 +634,12 @@ def save_batch_metadata(
         except OSError as e:
             logger.warning("Failed to compute hash for %s: %s", output_file.name, e)
             # Continue without failing - metadata is still useful
+        content_hash = compute_content_hash(output_file)
+        if content_hash is not None:
+            content_hashes[output_file.name] = content_hash
 
     metadata["file_hashes"] = file_hashes
+    metadata["content_hashes"] = content_hashes
 
     metadata_file_name = f"{batch.simulator_name}-{batch.batch_index}.metadata.json"
     metadata_file = metadata_directory / metadata_file_name

--- a/src/gwmock/cli/utils/hash.py
+++ b/src/gwmock/cli/utils/hash.py
@@ -1,9 +1,18 @@
-"""Contains utility functions for hashing operations."""
+# ruff: noqa: PLC0415
+"""Contains utility functions for hashing operations.
+
+``numpy``/``gwpy``/``h5py`` are imported lazily inside the content-hash helpers
+so importing this module stays cheap; the heavy readers are only pulled in when
+a file is actually decoded for content hashing.
+"""
 
 from __future__ import annotations
 
 import hashlib
+import logging
 from pathlib import Path
+
+logger = logging.getLogger("gwmock")
 
 
 def compute_file_hash(file_path: str | Path, algorithm: str = "sha256") -> str:
@@ -20,4 +29,107 @@ def compute_file_hash(file_path: str | Path, algorithm: str = "sha256") -> str:
     with open(file_path, "rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):
             hash_func.update(chunk)
+    return f"{algorithm}:{hash_func.hexdigest()}"
+
+
+def _hash_named_arrays(hash_func: hashlib._Hash, items: list[tuple[str, dict, object]]) -> None:
+    """Fold a list of ``(label, scalar-meta, array)`` into *hash_func* canonically.
+
+    Channels/datasets are hashed in the order given (callers sort first). Arrays
+    are normalised to little-endian, C-contiguous bytes so the digest is stable
+    across platforms and write order. Scalar metadata is packed as raw bytes (not
+    ``repr``) to avoid float-formatting ambiguity.
+    """
+    import numpy as np
+
+    for label, meta, array in items:
+        hash_func.update(b"\x00CHAN\x00")
+        hash_func.update(label.encode("utf-8"))
+        for key in sorted(meta):
+            value = meta[key]
+            hash_func.update(f"\x00{key}=".encode())
+            if isinstance(value, (int, float)):
+                hash_func.update(np.asarray([value], dtype="<f8").tobytes())
+            else:
+                hash_func.update(str(value).encode("utf-8"))
+        arr = np.ascontiguousarray(array)
+        arr = arr.astype(arr.dtype.newbyteorder("<"), copy=False)
+        hash_func.update(f"\x00dtype={arr.dtype.str}\x00shape={tuple(arr.shape)}\x00".encode())
+        hash_func.update(arr.tobytes())
+
+
+def _read_content_items(file_path: Path) -> list[tuple[str, dict, object]] | None:
+    """Decode *file_path* into ``(label, meta, array)`` items, or ``None`` if the
+    format is not understood (caller then falls back to the raw-file hash)."""
+    suffix = file_path.suffix.lower()
+
+    if suffix == ".gwf":
+        from gwpy.io.gwf import iter_channel_names
+        from gwpy.timeseries import TimeSeriesDict
+
+        # The framel reader does not auto-discover channels, so enumerate them.
+        channels = sorted(iter_channel_names(str(file_path)))
+        if not channels:
+            return []
+        tsd = TimeSeriesDict.read(str(file_path), channels=channels)
+        items = []
+        for name in channels:
+            series = tsd[name]
+            meta = {"t0": float(series.t0.value), "dt": float(series.dt.value), "n": int(series.size)}
+            items.append((name, meta, series.value))
+        return items
+
+    if suffix in (".hdf5", ".h5"):
+        import h5py
+
+        names: list[str] = []
+        with h5py.File(file_path, "r") as handle:
+            handle.visititems(lambda name, obj: names.append(name) if isinstance(obj, h5py.Dataset) else None)
+            return [(name, {}, handle[name][()]) for name in sorted(names)]
+
+    if suffix == ".npy":
+        import numpy as np
+
+        return [("array", {}, np.load(file_path))]
+
+    if suffix == ".npz":
+        import numpy as np
+
+        with np.load(file_path) as data:
+            return [(key, {}, data[key]) for key in sorted(data.files)]
+
+    return None
+
+
+def compute_content_hash(file_path: str | Path, algorithm: str = "sha256") -> str | None:
+    """Compute a hash of the *scientific content* of an output file.
+
+    Unlike :func:`compute_file_hash`, which hashes the raw container bytes, this
+    decodes the file and hashes the decoded data (channel/dataset names plus the
+    sample arrays in a canonical little-endian layout). Two files holding
+    identical data therefore share a content hash even when their container bytes
+    differ -- e.g. GWF frames embed a write-time timestamp and the frame-library
+    version string, so byte-identical GWF output is not achievable across
+    machines, but the content hash is.
+
+    Args:
+        file_path: Path to the output file (``.gwf``, ``.hdf5``/``.h5``, ``.npy``,
+            ``.npz``).
+        algorithm: Hashing algorithm to use (default ``"sha256"``).
+
+    Returns:
+        ``"<algorithm>:<hexdigest>"``, or ``None`` if the format is unsupported or
+        the file could not be decoded (the caller should fall back to the
+        raw-file hash in that case).
+    """
+    path = Path(file_path)
+    try:
+        items = _read_content_items(path)
+    except Exception as exc:
+        logger.debug("Could not compute content hash for %s: %s", path, exc)
+        return None
+    if items is None:
+        return None
+    hash_func = hashlib.new(algorithm)
+    _hash_named_arrays(hash_func, items)
     return f"{algorithm}:{hash_func.hexdigest()}"

--- a/src/gwmock/cli/utils/metadata.py
+++ b/src/gwmock/cli/utils/metadata.py
@@ -11,7 +11,7 @@ import numpy as np
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "1.1.0"
 _SCHEMA_VERSION_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
 
@@ -61,6 +61,7 @@ class OutputRecord(BaseModel):
     t0: float | int | None = None
     duration: float | int | None = None
     sha256: str | None = None
+    content_sha256: str | None = None
 
 
 class HostRecord(BaseModel):

--- a/src/gwmock/cli/validate.py
+++ b/src/gwmock/cli/validate.py
@@ -76,7 +76,7 @@ def validate_command(
     from rich.console import Console
     from rich.table import Table
 
-    from gwmock.cli.utils.hash import compute_file_hash
+    from gwmock.cli.utils.hash import compute_content_hash, compute_file_hash
     from gwmock.cli.utils.metadata import load_metadata_with_external_state
 
     logger = logging.getLogger("gwmock")
@@ -215,60 +215,116 @@ def validate_command(
         logger.error("Error: No metadata files found")
         raise typer.Exit(1)
 
-    # Create results table
+    # Create results table. The authoritative verdict is the *content* hash
+    # (decoded data); the raw-file byte hash is a secondary integrity signal.
+    # A file whose content matches but whose container bytes differ is reported
+    # as "same data, repackaged" -- this is the normal case for re-generated GWF
+    # frames, which embed a write-time timestamp and the frame-library version.
     table = Table(title="Validation Results")
     table.add_column("Metadata File", style="cyan")
     table.add_column("Output File", style="magenta")
-    table.add_column("Hash Match", style="green")
+    table.add_column("Content", style="green")
+    table.add_column("Bytes", style="green")
     table.add_column("Status", style="yellow")
 
     total_files = len(output_to_metadata)
     failed_files = 0
+    repackaged_files = 0
+
+    def _expected(metadata: dict, name: str, file_key: str, record_key: str) -> str | None:
+        """Look up an expected hash by filename, from the top-level map or outputs[]."""
+        top = metadata.get(file_key, {})
+        if name in top:
+            return top[name]
+        records = {Path(o["path"]).name: o for o in metadata.get("outputs", [])}
+        return records.get(name, {}).get(record_key)
 
     # Order output for consistent reporting
     for output_file in sorted(output_to_metadata.keys()):
         metadata_file = output_to_metadata[output_file]
+        name = output_file.name
         if metadata_file is None:
-            table.add_row("N/A", output_file.name, "N/A", "[red]No metadata found[/red]")
+            table.add_row("N/A", name, "N/A", "N/A", "[red]No metadata found[/red]")
             failed_files += 1
             continue
         try:
-            metadata: dict = load_metadata_with_external_state(metadata_file)
+            metadata = load_metadata_with_external_state(metadata_file)
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger.error("Error loading metadata %s: %s", metadata_file, e)
-            table.add_row(str(metadata_file.name), output_file.name, "N/A", "[red]Error loading metadata[/red]")
+            table.add_row(str(metadata_file.name), name, "N/A", "N/A", "[red]Error loading metadata[/red]")
             continue
-
-        file_hashes = metadata.get("file_hashes", {})
-        if file_hashes:
-            expected_hash = file_hashes.get(output_file.name)
-        else:
-            output_records = {Path(output["path"]).name: output for output in metadata.get("outputs", [])}
-            expected_hash = output_records.get(output_file.name, {}).get("sha256")
 
         if not output_file.exists():
-            table.add_row(str(metadata_file.name), output_file.name, "N/A", "[red]File not found[/red]")
+            table.add_row(str(metadata_file.name), name, "N/A", "N/A", "[red]File not found[/red]")
             failed_files += 1
             continue
 
-        if not expected_hash:
-            table.add_row(str(metadata_file.name), output_file.name, "N/A", "[yellow]No hash in metadata[/yellow]")
-            failed_files += 1
-            continue
+        expected_content = _expected(metadata, name, "content_hashes", "content_sha256")
+        expected_bytes = _expected(metadata, name, "file_hashes", "sha256")
 
         try:
-            actual_hash = compute_file_hash(output_file)
-            if actual_hash == expected_hash:
-                table.add_row(str(metadata_file.name), output_file.name, "[green]✓[/green]", "[green]PASS[/green]")
+            actual_bytes = compute_file_hash(output_file)
+            bytes_ok = None if not expected_bytes else (actual_bytes == expected_bytes)
+            bytes_cell = "[green]✓[/green]" if bytes_ok else ("[yellow]≠[/yellow]" if bytes_ok is False else "—")
+
+            if expected_content:
+                actual_content = compute_content_hash(output_file)
+                if actual_content is None:
+                    # Couldn't decode -- fall back to the byte hash as the verdict.
+                    if bytes_ok is None:
+                        table.add_row(
+                            str(metadata_file.name),
+                            name,
+                            "[yellow]?[/yellow]",
+                            bytes_cell,
+                            "[yellow]Could not read content[/yellow]",
+                        )
+                        failed_files += 1
+                    elif bytes_ok:
+                        table.add_row(str(metadata_file.name), name, "—", bytes_cell, "[green]PASS[/green]")
+                    else:
+                        table.add_row(str(metadata_file.name), name, "—", bytes_cell, "[red]BYTES MISMATCH[/red]")
+                        failed_files += 1
+                elif actual_content == expected_content:
+                    if bytes_ok is False:
+                        table.add_row(
+                            str(metadata_file.name),
+                            name,
+                            "[green]✓[/green]",
+                            bytes_cell,
+                            "[green]PASS[/green] [dim](same data, repackaged)[/dim]",
+                        )
+                        repackaged_files += 1
+                    else:
+                        table.add_row(
+                            str(metadata_file.name), name, "[green]✓[/green]", bytes_cell, "[green]PASS[/green]"
+                        )
+                else:
+                    table.add_row(
+                        str(metadata_file.name), name, "[red]✗[/red]", bytes_cell, "[red]CONTENT MISMATCH[/red]"
+                    )
+                    failed_files += 1
+            elif expected_bytes:
+                # Legacy metadata (no content hash): byte hash is the verdict.
+                if bytes_ok:
+                    table.add_row(str(metadata_file.name), name, "—", bytes_cell, "[green]PASS[/green]")
+                else:
+                    table.add_row(str(metadata_file.name), name, "—", bytes_cell, "[red]HASH MISMATCH[/red]")
+                    failed_files += 1
             else:
-                table.add_row(str(metadata_file.name), output_file.name, "[red]✗[/red]", "[red]HASH MISMATCH[/red]")
+                table.add_row(str(metadata_file.name), name, "N/A", "N/A", "[yellow]No hash in metadata[/yellow]")
                 failed_files += 1
         except Exception as e:  # pylint: disable=broad-exception-caught
-            table.add_row(str(metadata_file.name), output_file.name, "N/A", f"[red]Error: {e}[/red]")
+            table.add_row(str(metadata_file.name), name, "N/A", "N/A", f"[red]Error: {e}[/red]")
             failed_files += 1
 
     console.print(table)
     console.print(f"\n[bold]Summary:[/bold] {total_files - failed_files}/{total_files} files passed validation")
+    if repackaged_files:
+        console.print(
+            f"[dim]{repackaged_files} file(s): content matches but container bytes differ "
+            f"(same data, repackaged) — expected for re-generated GWF frames.[/dim]"
+        )
 
     if failed_files > 0:
         console.print(f"[red]{failed_files} files failed validation[/red]")

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -313,7 +313,7 @@ def test_simulate_command_runs_adapter_orchestration(monkeypatch, tmp_path: Path
     assert (tmp_path / "output" / "signal" / "signal-1.gwf").exists()
     _assert_noise_outputs_exist(tmp_path / "output" / "noise")
     metadata = yaml.safe_load((tmp_path / "metadata" / "orchestration-0.metadata.json").read_text())
-    assert metadata["schema_version"] == "1.0.0"
+    assert metadata["schema_version"] == "1.1.0"
     assert metadata["config"]["orchestration"]["population"]["backend"] == FAKE_POPULATION_BACKEND
     assert metadata["config"]["orchestration"]["signal"]["backend"] == FAKE_SIGNAL_BACKEND
     assert metadata["config"]["orchestration"]["noise"]["backend"] == FAKE_NOISE_BACKEND

--- a/tests/cli/test_validate.py
+++ b/tests/cli/test_validate.py
@@ -6,11 +6,12 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 import typer
 import yaml
 
-from gwmock.cli.utils.hash import compute_file_hash
+from gwmock.cli.utils.hash import compute_content_hash, compute_file_hash
 from gwmock.cli.validate import validate_command
 
 
@@ -236,6 +237,70 @@ def test_validate_command_outputs_in_subdirectory(temp_dir, capsys):
     # Exactly the two real files pass; nothing is reported as missing.
     assert "2/2 files passed validation" in captured.out
     assert "File not found" not in captured.out
+
+
+def _npy_output_with_metadata(temp_dir, *, file_hash: str, content_hash: str):
+    """Write an ``output/data.npy`` and a metadata file carrying the given hashes."""
+    out_dir = temp_dir / "output"
+    out_dir.mkdir(exist_ok=True)
+    data_file = out_dir / "data.npy"
+    np.save(data_file, np.arange(16, dtype="float64"))
+
+    metadata = {
+        "author": "test_user",
+        "email": "test@example.com",
+        "timestamp": "2023-01-01T00:00:00Z",
+        "outputs": [{"kind": "signal", "path": "output/data.npy", "sha256": file_hash, "content_sha256": content_hash}],
+        "file_hashes": {"data.npy": file_hash},
+        "content_hashes": {"data.npy": content_hash},
+        "globals_config": {"working-directory": str(temp_dir)},
+    }
+    meta_dir = temp_dir / "metadata"
+    meta_dir.mkdir(exist_ok=True)
+    meta_file = meta_dir / "orchestration-0.metadata.yaml"
+    with open(meta_file, "w") as f:
+        yaml.dump(metadata, f)
+    return data_file, meta_dir
+
+
+def test_validate_content_match_but_bytes_differ_is_repackaged(temp_dir, capsys):
+    """Content hash matches but the recorded file hash does not -> PASS (repackaged).
+
+    This is the normal reproduce-from-metadata case for GWF frames, whose
+    container bytes carry a write-time timestamp.
+    """
+    # Write the data file first, compute its real content hash, then record it
+    # alongside a deliberately wrong byte hash.
+    data_file, _ = _npy_output_with_metadata(temp_dir, file_hash="sha256:" + "0" * 64, content_hash="")
+    content_hash = compute_content_hash(data_file)
+    _, meta_dir = _npy_output_with_metadata(temp_dir, file_hash="sha256:" + "0" * 64, content_hash=content_hash)
+
+    with patch("os.getcwd", return_value=str(temp_dir)):
+        validate_command([str(temp_dir / "output")], metadata_paths=[str(meta_dir)])
+
+    captured = capsys.readouterr()
+    assert "repackaged" in captured.out
+    assert "1/1 files passed validation" in captured.out
+
+
+def test_validate_content_mismatch_fails(temp_dir, capsys):
+    """A wrong content hash fails validation regardless of the byte hash."""
+    data_file = temp_dir / "output" / "data.npy"
+    temp_dir.joinpath("output").mkdir(exist_ok=True)
+    np.save(data_file, np.arange(16, dtype="float64"))
+    real_file_hash = compute_file_hash(data_file)
+    _, meta_dir = _npy_output_with_metadata(
+        temp_dir,
+        file_hash=real_file_hash,  # bytes are fine...
+        content_hash="sha256:" + "f" * 64,  # ...but content hash is wrong
+    )
+
+    with patch("os.getcwd", return_value=str(temp_dir)), pytest.raises(typer.Exit):
+        validate_command([str(temp_dir / "output")], metadata_paths=[str(meta_dir)])
+
+    captured = capsys.readouterr()
+    assert "CONTENT MISMATCH" in captured.out
+    assert "0/1 files passed validation" in captured.out
 
 
 def test_validate_command_output_file_discovery(temp_dir, capsys):

--- a/tests/cli/utils/test_hash.py
+++ b/tests/cli/utils/test_hash.py
@@ -1,0 +1,53 @@
+"""Unit tests for content/file hashing utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from gwmock.cli.utils.hash import compute_content_hash, compute_file_hash
+
+
+def test_content_hash_identical_data_matches(tmp_path: Path):
+    """Two files holding identical data share a content hash."""
+    a = tmp_path / "a.npy"
+    b = tmp_path / "b.npy"
+    data = np.arange(32, dtype="float64")
+    np.save(a, data)
+    np.save(b, data)
+    assert compute_content_hash(a) == compute_content_hash(b)
+
+
+def test_content_hash_changes_with_data(tmp_path: Path):
+    """Different data yields a different content hash."""
+    a = tmp_path / "a.npy"
+    b = tmp_path / "b.npy"
+    np.save(a, np.arange(32, dtype="float64"))
+    np.save(b, np.arange(32, dtype="float64") + 1.0)
+    assert compute_content_hash(a) != compute_content_hash(b)
+
+
+def test_content_hash_is_byteorder_independent(tmp_path: Path):
+    """Content hash ignores on-disk byte order (canonical little-endian)."""
+    le = tmp_path / "le.npy"
+    be = tmp_path / "be.npy"
+    data = np.linspace(0, 1, 16)
+    np.save(le, data.astype("<f8"))
+    np.save(be, data.astype(">f8"))
+    assert compute_content_hash(le) == compute_content_hash(be)
+
+
+def test_content_hash_unsupported_format_returns_none(tmp_path: Path):
+    """Unsupported/undecodable formats return None (caller falls back to bytes)."""
+    txt = tmp_path / "note.txt"
+    txt.write_text("not an array")
+    assert compute_content_hash(txt) is None
+
+
+def test_content_hash_prefixed_like_file_hash(tmp_path: Path):
+    """Content hash carries the ``<algorithm>:`` prefix, like compute_file_hash."""
+    a = tmp_path / "a.npy"
+    np.save(a, np.zeros(4))
+    assert compute_content_hash(a).startswith("sha256:")
+    assert compute_file_hash(a).startswith("sha256:")

--- a/tests/cli/utils/test_metadata.py
+++ b/tests/cli/utils/test_metadata.py
@@ -59,7 +59,7 @@ def test_metadata_record_uses_versioned_json_schema(tmp_path: Path) -> None:
     metadata_path = tmp_path / "metadata" / "mock-0.metadata.json"
     record = load_metadata_record(metadata_path)
 
-    assert record.schema_version == "1.0.0"
+    assert record.schema_version == "1.1.0"
     assert record.config_sha256 == compute_file_hash(config_file)
     assert record.seed == 42
     assert record.outputs[0].path == "output/data.json"


### PR DESCRIPTION
GWF frames embed a write-time timestamp and the frame-library version string, so byte-identical GWF output is not achievable across machines or re-runs. The raw-file sha256 therefore reports HASH MISMATCH when validating a reproduced dataset even though the strain is bit-for-bit identical.

Record a second hash per output, `content_sha256`, computed over the decoded scientific content (channel/dataset names + sample arrays in a canonical little-endian layout) for .gwf / .hdf5 / .npy / .npz. `gwmock validate` now uses the content hash as the authoritative verdict and keeps the raw-file sha256 as a secondary integrity signal: a file whose content matches but whose bytes differ is reported as "PASS (same data, repackaged)".

- new `compute_content_hash` in cli/utils/hash.py (returns None for formats it can't decode -> validate falls back to the byte hash)
- `_build_output_records` / `save_batch_metadata` record content_sha256 and a top-level `content_hashes` map
- metadata schema 1.0.0 -> 1.1.0 (additive, backward-compatible; legacy metadata without content hashes still validates on the byte hash)
- tests: content-hash unit tests + validate repackaged/mismatch cases
