### PR TITLE
fix: accept literal file_name lists in save_data for metadata replay

### DIFF
--- a/src/gwmock/simulator/base.py
+++ b/src/gwmock/simulator/base.py
@@ -281,7 +281,7 @@ class Simulator(ABC):
     def save_data(
         self,
         data: Any,
-        file_name: str | Path,
+        file_name: str | Path | list[str] | np.ndarray[Any, np.dtype[np.object_]],
         output_directory: str | Path | None = None,
         overwrite: bool = False,
         **kwargs: Any,
@@ -292,16 +292,35 @@ class Simulator(ABC):
 
         Args:
             data: Data to save.
-            file_name: Output file path.
+            file_name: Output file path template, or a list/array of already-expanded
+                literal paths (one per detector) as carried by metadata written for a
+                multi-detector template — reproduction from metadata replays those
+                literal lists.
             output_directory: Optional output directory to prepend to the file name.
             overwrite: Whether to overwrite existing files.
             **kwargs: Additional arguments for specific file formats.
         """
-        file_name_resolved = get_file_name_from_template(
-            template=str(file_name),
-            instance=self,
-            output_directory=output_directory,
-        )
+        if isinstance(file_name, (list, tuple, np.ndarray)):
+            resolved_entries: list[Path] = []
+            for single_name in np.asarray(file_name, dtype=object).flatten():
+                single_resolved = get_file_name_from_template(
+                    template=str(single_name),
+                    instance=self,
+                    output_directory=output_directory,
+                )
+                if isinstance(single_resolved, Path):
+                    resolved_entries.append(single_resolved)
+                else:
+                    resolved_entries.extend(single_resolved.flatten())
+            file_name_resolved: Path | np.ndarray[Any, np.dtype[np.object_]] = np.asarray(
+                resolved_entries, dtype=object
+            )
+        else:
+            file_name_resolved = get_file_name_from_template(
+                template=str(file_name),
+                instance=self,
+                output_directory=output_directory,
+            )
 
         if not overwrite:
             if isinstance(file_name_resolved, Path):

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -342,6 +342,107 @@ def test_simulate_command_runs_adapter_orchestration(monkeypatch, tmp_path: Path
     ]
 
 
+def _fake_multi_detector_config(working_directory: str) -> Config:
+    """Orchestration config whose signal file_name uses a multi-detector template.
+
+    ``{{ detectors }}`` renders to one file per detector, so the metadata sidecar
+    records ``file_name`` (and ``channel``) as per-detector lists.
+    """
+    return Config(
+        globals=GlobalsConfig(
+            working_directory=working_directory,
+            output_directory="output",
+            metadata_directory="metadata",
+            simulator_arguments={
+                "sampling-frequency": 4,
+                "duration": 4,
+                "start-time": 100,
+                "max-samples": 2,
+            },
+        ),
+        orchestration=OrchestrationConfig(
+            population=PopulationConfig(
+                backend=FAKE_POPULATION_BACKEND,
+                source_type="bbh",
+                n_samples=2,
+                arguments={"path": "population.h5", "source_type": "bbh"},
+            ),
+            signal=SignalConfig(
+                backend=FAKE_SIGNAL_BACKEND,
+                waveform_model="IMRPhenomD",
+                detectors=["H1", "L1"],
+                output=SimulatorOutputConfig(
+                    file_name="E-{{ detectors }}_BBH-{{ counter }}.gwf",
+                    output_directory="signal",
+                    arguments={"channel": "{{ detectors }}:STRAIN"},
+                ),
+            ),
+            noise=NoiseAdapterConfig(
+                backend=FAKE_NOISE_BACKEND,
+                arguments={"seed": 7, "detectors": ["H1", "L1"], "duration": 4.0, "sampling_frequency": 4.0},
+                output=SimulatorOutputConfig(
+                    file_name="E-{{ detectors }}_NOISE-{{ counter }}.npy",
+                    output_directory="noise",
+                ),
+            ),
+        ),
+    )
+
+
+def test_simulate_reproduces_metadata_with_multi_detector_signal_template(monkeypatch, tmp_path: Path):
+    """Replay: metadata from a multi-detector ``{{ detectors }}`` signal template re-runs cleanly.
+
+    The metadata sidecar stores the rendered per-detector ``file_name`` list rather than
+    the template. Regression: the replay path stringified that list into a single bogus
+    path (suffix ``.gwf']``), failing the signal output-format check; with a noise section
+    the retried batch then collided with its own freshly written noise outputs.
+    """
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    monkeypatch.setattr("gwmock.cli.adapter_orchestration.DetectorStrainStack.write", _write_signal_file)
+    monkeypatch.chdir(run_dir)
+
+    config = _fake_multi_detector_config(".")
+    config_file = run_dir / "config.yaml"
+    config_file.write_text(yaml.safe_dump(config.model_dump(by_alias=True, exclude_none=True), sort_keys=False))
+
+    _simulate_impl(str(config_file), overwrite=True, metadata=True)
+
+    expected_signal_names = [
+        "E-H1_BBH-0.gwf",
+        "E-L1_BBH-0.gwf",
+        "E-H1_BBH-1.gwf",
+        "E-L1_BBH-1.gwf",
+    ]
+    for name in expected_signal_names:
+        assert (run_dir / "output" / "signal" / name).exists()
+
+    metadata_file = run_dir / "metadata" / "orchestration-0.metadata.json"
+    metadata = yaml.safe_load(metadata_file.read_text())
+    # Lock in the serialization this regression test relies on: the sidecar carries the
+    # rendered per-detector list, not the original template.
+    assert metadata["config"]["orchestration"]["signal"]["output"]["file_name"] == [
+        "E-H1_BBH-0.gwf",
+        "E-L1_BBH-0.gwf",
+    ]
+
+    repro_dir = tmp_path / "repro"
+    repro_dir.mkdir()
+    for metadata_name in ("orchestration-0.metadata.json", "orchestration-1.metadata.json"):
+        (repro_dir / metadata_name).write_text((run_dir / "metadata" / metadata_name).read_text())
+    monkeypatch.chdir(repro_dir)
+
+    _simulate_impl(
+        [str(repro_dir / "orchestration-0.metadata.json"), str(repro_dir / "orchestration-1.metadata.json")],
+        metadata=False,
+    )
+
+    for name in expected_signal_names:
+        assert (repro_dir / "output" / "signal" / name).exists()
+    for name in ("E-H1_NOISE-0.npy", "E-L1_NOISE-0.npy", "E-H1_NOISE-1.npy", "E-L1_NOISE-1.npy"):
+        assert (repro_dir / "output" / "noise" / name).exists()
+
+
 def test_simulate_command_runs_signal_only_sgwb_orchestration(monkeypatch, tmp_path: Path):
     """The CLI should generate stationary SGWB segments without a population catalogue."""
     config = _fake_sgwb_config(tmp_path)

--- a/tests/simulator/test_base_simulator.py
+++ b/tests/simulator/test_base_simulator.py
@@ -319,6 +319,37 @@ class TestSimulatorSaveData:
             with open(f"{temp_dir}/L1-8.yaml", encoding="utf-8") as f:
                 assert yaml.safe_load(f) == data[1, 1]
 
+    def test_save_data_literal_list_file_names(self, simulator: MockSimulator):
+        """Metadata reproduction: save_data accepts an already-expanded literal list.
+
+        Metadata written for a multi-detector ``{{ detectors }}`` template stores the
+        rendered per-detector file names as a list. Replaying such metadata must not
+        stringify the list into a single bogus path (regression: ``str(list)`` produced
+        a name ending in ``.gwf']`` which failed the output-format check).
+        """
+        data = np.array([1, 2], dtype=object)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_names = ["E-H1_BBH-100-4.yaml", "E-L1_BBH-100-4.yaml"]
+            simulator.save_data(data, file_names, output_directory=temp_dir)
+
+            for name, expected in zip(file_names, [1, 2], strict=True):
+                path = Path(temp_dir) / name
+                assert path.exists()
+                with path.open(encoding="utf-8") as f:
+                    assert yaml.safe_load(f) == expected
+
+    def test_save_data_literal_list_overwrite_false_raises(self, simulator: MockSimulator):
+        """Literal-list file names still honour the overwrite=False existence check."""
+        data = np.array([1, 2], dtype=object)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_names = ["E-H1_BBH-100-4.yaml", "E-L1_BBH-100-4.yaml"]
+            (Path(temp_dir) / file_names[1]).write_text("existing")
+
+            with pytest.raises(FileExistsError, match=r"E-L1_BBH-100-4\.yaml"):
+                simulator.save_data(data, file_names, output_directory=temp_dir)
+
     def test_save_data_array_shape_mismatch(self, simulator_with_attrs: MockSimulator):
         """Test save_data with mismatched data shape raises ValueError."""
         sim = simulator_with_attrs


### PR DESCRIPTION
## Summary

`gwmock simulate <metadata.json>` failed for any run whose **signal** section used a multi-detector template in `file_name` (e.g. `E-{{ detectors }}_BBH-{{ start_time }}-{{ duration }}.gwf` — the canonical BBH workflow from the bundled examples):

- **signal-only** replay → `ValueError: Signal output files must end with .gwf, .hdf5, .h5, .npy, or .txt.`
- **signal+noise** replay → noise frames written, signal batch fails and is retried, retry collides with the just-written noise frames → `FileExistsError: Noise adapter output(s) already exist …`

**Root cause:** the metadata sidecar stores the *rendered per-detector list* (`"file_name": ["E-ET1_…gwf", "E-ET2_…gwf"]`) rather than the template. On replay `Simulator.save_data` did `str(file_name)` on that list, producing a single bogus path whose suffix `.gwf']` fails `_infer_signal_output_format`.

**Fix:** `save_data` now resolves list/tuple/ndarray `file_name` inputs entry by entry and hands `_save_data` a 1-D object array of paths — the same already-expanded-literal handling the noise adapter gained for per-batch replay in ISS-016 (`_active_noise_file_name`). `_save_data` already supported per-detector array writes, so no change below `save_data` is needed. Noise-only and single-file signal replay (e.g. SGWB `{{ counter }}.hdf5`) were unaffected and stay unchanged.

## Tests

- `tests/simulator/test_base_simulator.py`: unit regression — `save_data` with a literal file-name list writes one file per entry with `output_directory` prepended; the `overwrite=False` existence check still fires per entry.
- `tests/cli/test_cli_orchestration.py::test_simulate_reproduces_metadata_with_multi_detector_signal_template`: end-to-end — simulate with a `{{ detectors }}` signal template (2 detectors × 2 batches), assert the sidecar records the rendered list, then replay both metadata files in a fresh directory and assert all signal + noise outputs appear.

Both tests **fail on `main`** (verified by reverting the src change) and pass with the fix. Full suite: 566 passed, 23 skipped. Also verified against the real-world repro that surfaced this (Leuven workshop prep, released 0.8.2): the previously failing BBH signal+noise and signal-only metadata replays now succeed with **bit-identical** strain vs the original run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simulator output saving now supports multiple detector-specific file name templates, allowing per-detector paths to be generated and saved in one run.
  * Replay and orchestration flows now preserve and reuse expanded per-detector output file lists correctly.

* **Bug Fixes**
  * Improved file overwrite checks so existing outputs in multi-file saves are detected and handled correctly.
  * Metadata now records expanded output paths instead of the original template when multiple detector files are produced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->