### PR TITLE
ci: attempt-scoped Pages artifact name

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,6 +37,11 @@ jobs:
             - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
               with:
                   path: site
+                  # Attempt-scoped so "Re-run failed jobs" does not leave two
+                  # same-named artifacts in the run, which deploy-pages rejects.
+                  name: github-pages-${{ github.run_attempt }}
 
             - id: deployment
               uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+              with:
+                  artifact_name: github-pages-${{ github.run_attempt }}


### PR DESCRIPTION
## Summary

Seen on gwmock-pop Documentation run #300: attempt 1 uploaded the `github-pages` artifact, then `deploy-pages` hit a transient GitHub Pages failure ("Deployment failed, try again later"). **Re-run failed jobs** uploaded a second same-named artifact into the same run, and `actions/deploy-pages` v4 hard-fails: `Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.` — so a re-run can never rescue a Pages deploy that failed after upload.

Scoping the artifact name by `github.run_attempt` (with the matching `artifact_name` on `deploy-pages`) makes each attempt self-contained, so re-running the failed job recovers cleanly. Same change across all gwmock repos, which share this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)