### PR TITLE
build: require gwmock-noise>=0.6.1 and gwmock-pop>=0.10.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = [
   "gwmock-signal>=0.9.3",
-  "gwmock-noise>=0.6.0",
-  "gwmock-pop>=0.10.2",
+  "gwmock-noise>=0.6.1",
+  "gwmock-pop>=0.10.3",
   "typer>=0.26.8",
   "tqdm>=4.68.3",
   "h5py>=3.16.0",

--- a/uv.lock
+++ b/uv.lock
@@ -675,8 +675,8 @@ release = [
 [package.metadata]
 requires-dist = [
     { name = "filelock", specifier = ">=3.29.4" },
-    { name = "gwmock-noise", specifier = ">=0.6.0" },
-    { name = "gwmock-pop", specifier = ">=0.10.2" },
+    { name = "gwmock-noise", specifier = ">=0.6.1" },
+    { name = "gwmock-pop", specifier = ">=0.10.3" },
     { name = "gwmock-signal", specifier = ">=0.9.3" },
     { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", specifier = ">=0.9.3" },
     { name = "h5py", specifier = ">=3.16.0" },


### PR DESCRIPTION
## Summary

Floors the sub-package dependencies at the releases carrying the workshop-prep fixes, so a plain `pip install gwmock` pulls them:

- **gwmock-pop 0.10.3** — 64-bit JAX floats by default (GPS-scale `coa_time` no longer quantized to a 128 s float32 grid; Leuven-Gravity-Institute/gwmock-pop#308) and top-level catalogue I/O exports (Leuven-Gravity-Institute/gwmock-pop#309).
- **gwmock-noise 0.6.1** — statistical diagnostics whiten before testing, so coloured output is no longer flagged non-stationary (Leuven-Gravity-Institute/gwmock-noise#234).

Full gwmock suite against the bumped resolution: **648 passed**. Once merged, the next gwmock release also ships the metadata-replay fix (#226).

🤖 Generated with [Claude Code](https://claude.com/claude-code)