### PR TITLE
docs: drop stale (In-Progress) noise wording, note gwmock-noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ generation.
   configuration options
 - **Waveform Generation**: Integrates with PyCBC and LALSuite for accurate
   signal simulation
-- **Noise Models**: Supports colored and correlated noise generation
-  (In-Progress)
+- **Noise Models**: Colored and correlated noise, spectral lines, and detector
+  glitches via the `gwmock-noise` package
 - **Population Models**: Handles injection populations for signals and glitches
 - **Data Formats**: Outputs in standard GW formats (GWF frames)
 - **CLI**: Command-line tools for easy simulation workflows


### PR DESCRIPTION
Part of the JOSS submission polish (`gwmock-joss/readme-polish`).

`gwmock-noise` is now a published package, so the Features list no longer needs the "(In-Progress)" caveat. Updated the **Noise Models** bullet to state colored/correlated noise, spectral lines, and glitches provided via `gwmock-noise`.

No code changes; README only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)