### PR TITLE
feat: add signal.waveform-options for extra waveform options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = [
-  "gwmock-signal>=0.10.0",
+  "gwmock-signal>=0.11.0",
   "gwmock-noise>=0.7.1",
   "gwmock-pop>=0.11.1",
   "typer>=0.19.0",         # Literal-type CLI options; the SPEC 0 floor (0.13) predates them
@@ -36,7 +36,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-sgwb = ["gwmock-signal[sgwb]>=0.10.0"]
+sgwb = ["gwmock-signal[sgwb]>=0.11.0"]
 
 [dependency-groups]
 dev = [

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -76,6 +76,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         detector_resolution: dict[str, Any],
         waveform_model: str | None,
         waveform_arguments: dict[str, Any],
+        waveform_options: dict[str, Any],
         signal_parameters: dict[str, Any],
         detectors: list[str],
         duration: float,
@@ -99,6 +100,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         self._population_seed = population_seed
         self.waveform_model = waveform_model
         self.waveform_arguments = waveform_arguments
+        self.waveform_options = waveform_options
         self.signal_parameters = signal_parameters
         self.minimum_frequency = minimum_frequency
         self.earth_rotation = earth_rotation
@@ -169,6 +171,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         source_detector_specs: list[str] = []
         waveform_model: str | None = None
         waveform_arguments: dict[str, Any] = {}
+        waveform_options: dict[str, Any] = {}
         signal_parameters: dict[str, Any] = {}
         minimum_frequency = 5.0
         earth_rotation = True
@@ -193,6 +196,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             source_detector_specs = list(orchestration_config.signal.detectors)  # type: ignore[union-attr]
             waveform_model = orchestration_config.signal.waveform_model  # type: ignore[union-attr]
             waveform_arguments = orchestration_config.signal.waveform_arguments  # type: ignore[union-attr]
+            waveform_options = orchestration_config.signal.waveform_options  # type: ignore[union-attr]
             signal_parameters = orchestration_config.signal.parameters  # type: ignore[union-attr]
             minimum_frequency = orchestration_config.signal.minimum_frequency  # type: ignore[union-attr]
             earth_rotation = orchestration_config.signal.earth_rotation  # type: ignore[union-attr]
@@ -211,6 +215,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             detector_resolution=detector_resolution,
             waveform_model=waveform_model,
             waveform_arguments=waveform_arguments,
+            waveform_options=waveform_options,
             signal_parameters=signal_parameters,
             detectors=resolved_detectors,
             duration=duration,
@@ -355,6 +360,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                 "signal": {
                     "waveform_model": self.waveform_model,
                     "waveform_arguments": self.waveform_arguments,
+                    "waveform_options": self.waveform_options,
                     "parameters": self.signal_parameters,
                     "minimum_frequency": self.minimum_frequency,
                     "earth_rotation": self.earth_rotation,
@@ -417,6 +423,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                 sampling_frequency=float(self.sampling_frequency.value),
                 minimum_frequency=self.minimum_frequency,
                 waveform_arguments=self.waveform_arguments,
+                waveform_options=self.waveform_options,
                 earth_rotation=self.earth_rotation,
             )
             strain.metadata.update({"injection_parameters": dict(parameters)})
@@ -447,6 +454,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             parameters,
             sampling_frequency=float(self.sampling_frequency.value),
             minimum_frequency=self.minimum_frequency,
+            waveform_options=self.waveform_options,
             background=background,
             earth_rotation=self.earth_rotation,
         )

--- a/src/gwmock/cli/utils/config.py
+++ b/src/gwmock/cli/utils/config.py
@@ -178,6 +178,14 @@ class SignalConfig(BaseModel):
         alias="waveform-arguments",
         description="Fixed waveform arguments passed to gwmock-signal",
     )
+    waveform_options: dict[str, Any] = Field(
+        default_factory=dict,
+        alias="waveform-options",
+        description=(
+            "Extra waveform options (e.g. LAL dictionary entries such as ModeArray) "
+            "passed to gwmock-signal as its waveform_arguments parameter"
+        ),
+    )
     detectors: list[str] = Field(..., description="Detector names or detector config paths")
     minimum_frequency: float = Field(default=5.0, alias="minimum-frequency", description="Minimum waveform frequency")
     earth_rotation: bool = Field(

--- a/src/gwmock/signal/adapter.py
+++ b/src/gwmock/signal/adapter.py
@@ -341,6 +341,7 @@ class SignalAdapter:
         sampling_frequency: float,
         minimum_frequency: float,
         waveform_arguments: Mapping[str, Any] | None = None,
+        waveform_options: Mapping[str, Any] | None = None,
         background: Mapping[str, Any] | None = None,
         earth_rotation: bool = True,
     ) -> DetectorStrainStack:
@@ -350,7 +351,11 @@ class SignalAdapter:
             parameters: The parameters to use for the simulation.
             sampling_frequency: The sampling frequency to use for the simulation.
             minimum_frequency: The minimum frequency to use for the simulation.
-            waveform_arguments: The waveform arguments to use for the simulation.
+            waveform_arguments: Fixed waveform parameters merged (flat) into the
+                per-event parameters; per-event values win.
+            waveform_options: Extra waveform options (e.g. LAL dictionary
+                entries) forwarded to the backend as its ``waveform_arguments``
+                parameter, without flattening.
             background: Optional background mapping forwarded to the signal backend.
             earth_rotation: Whether to include earth rotation in the simulation.
 
@@ -358,6 +363,13 @@ class SignalAdapter:
             A DetectorStrainStack instance.
         """
         backend_parameters = {**(waveform_arguments or {}), **dict(parameters)}
+        if waveform_options:
+            if "waveform_arguments" in backend_parameters:
+                raise ValueError(
+                    "Specify extra waveform options either via waveform_options or as a "
+                    "waveform_arguments parameter, not both"
+                )
+            backend_parameters["waveform_arguments"] = dict(waveform_options)
         if self._unsupported_params:
             backend_parameters = {k: v for k, v in backend_parameters.items() if k not in self._unsupported_params}
         try:
@@ -375,6 +387,11 @@ class SignalAdapter:
             if not msg.startswith(_prefix):
                 raise
             extras = {k.strip() for k in msg[len(_prefix) :].split(",")}
+            if "waveform_arguments" in extras:
+                raise ValueError(
+                    "The installed gwmock-signal does not support the waveform_arguments "
+                    "parameter required by waveform_options; upgrade gwmock-signal"
+                ) from exc
             new = extras - self._unsupported_params
             if new:
                 logger.warning(
@@ -401,6 +418,7 @@ class SignalAdapter:
         sampling_frequency: float,
         minimum_frequency: float,
         waveform_arguments: Mapping[str, Any] | None = None,
+        waveform_options: Mapping[str, Any] | None = None,
         background: Mapping[str, Any] | None = None,
         earth_rotation: bool = True,
     ) -> TimeSeries:
@@ -410,7 +428,11 @@ class SignalAdapter:
             parameters: The parameters to use for the simulation.
             sampling_frequency: The sampling frequency to use for the simulation.
             minimum_frequency: The minimum frequency to use for the simulation.
-            waveform_arguments: The waveform arguments to use for the simulation.
+            waveform_arguments: Fixed waveform parameters merged (flat) into the
+                per-event parameters; per-event values win.
+            waveform_options: Extra waveform options (e.g. LAL dictionary
+                entries) forwarded to the backend as its ``waveform_arguments``
+                parameter, without flattening.
             background: Optional background mapping forwarded to the signal backend.
             earth_rotation: Whether to include earth rotation in the simulation.
 
@@ -422,6 +444,7 @@ class SignalAdapter:
             sampling_frequency=sampling_frequency,
             minimum_frequency=minimum_frequency,
             waveform_arguments=waveform_arguments,
+            waveform_options=waveform_options,
             background=background,
             earth_rotation=earth_rotation,
         )

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -191,3 +191,25 @@ def test_config_output_file(runner, temp_examples_dir, tmp_path):
     print(content)
     assert "orchestration:" in content
     assert "backend: example1" in content
+
+
+def test_signal_config_parses_waveform_options() -> None:
+    """The waveform-options alias populates SignalConfig.waveform_options."""
+    from gwmock.cli.utils.config import SignalConfig
+
+    config = SignalConfig.model_validate(
+        {
+            "source-type": "bbh",
+            "detectors": ["H1"],
+            "waveform-options": {"ModeArray": [[2, 2], [2, -2]], "PhenomXPrecVersion": 320},
+        }
+    )
+    assert config.waveform_options == {"ModeArray": [[2, 2], [2, -2]], "PhenomXPrecVersion": 320}
+
+
+def test_signal_config_waveform_options_default_empty() -> None:
+    """waveform_options defaults to an empty mapping."""
+    from gwmock.cli.utils.config import SignalConfig
+
+    config = SignalConfig.model_validate({"source-type": "bbh", "detectors": ["H1"]})
+    assert config.waveform_options == {}

--- a/tests/signal/test_adapter.py
+++ b/tests/signal/test_adapter.py
@@ -340,3 +340,92 @@ class TestSimulateStackUnsupportedParams:
 
         with pytest.raises(ValueError, match="mass_1 must be positive"):
             adapter.simulate_stack({"mass_1": -1.0}, sampling_frequency=4.0, minimum_frequency=20.0)
+
+
+class RecordingBackend:
+    """Backend stub that records the parameters it receives."""
+
+    def __init__(self, *, waveform_model: str) -> None:
+        self.waveform_model = waveform_model
+        self.required_params = frozenset({"coa_time"})
+        self.received_params: list[dict] = []
+
+    def simulate(
+        self,
+        params,
+        detector_names,
+        background=None,
+        *,
+        sampling_frequency,
+        minimum_frequency,
+        earth_rotation=True,
+        interpolate_if_offset=True,
+    ):
+        self.received_params.append(dict(params))
+        names = tuple(d if isinstance(d, str) else d.name for d in detector_names)
+        from gwpy.timeseries import TimeSeries as GWpyTimeSeries
+
+        return DetectorStrainStack.from_mapping(
+            names,
+            {name: GWpyTimeSeries([1.0, 2.0], t0=0.0, sample_rate=sampling_frequency) for name in names},
+        )
+
+
+class WaveformArgumentsRejectingBackend(RecordingBackend):
+    """Backend stub predating gwmock-signal's waveform_arguments parameter."""
+
+    def simulate(self, params, detector_names, background=None, **kwargs):
+        if "waveform_arguments" in params:
+            raise ValueError("Unsupported LAL waveform parameters: waveform_arguments")
+        return super().simulate(params, detector_names, background=background, **kwargs)
+
+
+class TestWaveformOptions:
+    def test_options_forwarded_as_waveform_arguments_parameter(self):
+        """waveform_options reach the backend nested, not flattened."""
+        backend = RecordingBackend(waveform_model="IMRPhenomXHM")
+        adapter = _make_adapter_with_backend(backend)
+        options = {"ModeArray": [(2, 2), (2, -2)]}
+        adapter.simulate_stack(
+            {"mass_1": 30.0, "coa_time": 0.0},
+            sampling_frequency=4.0,
+            minimum_frequency=20.0,
+            waveform_options=options,
+        )
+        received = backend.received_params[0]
+        assert received["waveform_arguments"] == options
+        assert "ModeArray" not in received
+
+    def test_options_and_parameter_conflict_raises(self):
+        """Specifying options both ways is rejected."""
+        adapter = _make_adapter_with_backend(RecordingBackend(waveform_model="IMRPhenomXHM"))
+        with pytest.raises(ValueError, match="not both"):
+            adapter.simulate_stack(
+                {"mass_1": 30.0, "coa_time": 0.0, "waveform_arguments": {"ModeArray": [(2, 2)]}},
+                sampling_frequency=4.0,
+                minimum_frequency=20.0,
+                waveform_options={"ModeArray": [(3, 3)]},
+            )
+
+    def test_old_backend_raises_instead_of_dropping_options(self):
+        """A gwmock-signal without waveform_arguments support must not silently drop options."""
+        adapter = _make_adapter_with_backend(WaveformArgumentsRejectingBackend(waveform_model="IMRPhenomXHM"))
+        with pytest.raises(ValueError, match="upgrade gwmock-signal"):
+            adapter.simulate_stack(
+                {"mass_1": 30.0, "coa_time": 0.0},
+                sampling_frequency=4.0,
+                minimum_frequency=20.0,
+                waveform_options={"ModeArray": [(2, 2)]},
+            )
+
+    def test_empty_options_change_nothing(self):
+        """No waveform_arguments key is injected when options are empty."""
+        backend = RecordingBackend(waveform_model="IMRPhenomXHM")
+        adapter = _make_adapter_with_backend(backend)
+        adapter.simulate_stack(
+            {"mass_1": 30.0, "coa_time": 0.0},
+            sampling_frequency=4.0,
+            minimum_frequency=20.0,
+            waveform_options={},
+        )
+        assert "waveform_arguments" not in backend.received_params[0]

--- a/uv.lock
+++ b/uv.lock
@@ -693,8 +693,8 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.16.0" },
     { name = "gwmock-noise", specifier = ">=0.7.1" },
     { name = "gwmock-pop", specifier = ">=0.11.1" },
-    { name = "gwmock-signal", specifier = ">=0.10.0" },
-    { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", specifier = ">=0.10.0" },
+    { name = "gwmock-signal", specifier = ">=0.11.0" },
+    { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", specifier = ">=0.11.0" },
     { name = "h5py", specifier = ">=3.12.1" },
     { name = "psutil", specifier = ">=6.1.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
@@ -758,7 +758,7 @@ wheels = [
 
 [[package]]
 name = "gwmock-signal"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gwpy" },
@@ -766,9 +766,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/25/d8b5832ab2464de1c09069b7ce76d9aff3206e9452f600131afdad03e24d/gwmock_signal-0.10.0.tar.gz", hash = "sha256:c4d3d969c1004f0fac17e4c58f100fbf5b059ef2ceab3ab3a8eb40007d2e0a13", size = 318133, upload-time = "2026-07-11T20:51:00.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/4e/7515e12bd1ab820b73b6d00664bcf185fc4f0a017a367e658d72a5f95882/gwmock_signal-0.11.0.tar.gz", hash = "sha256:2ec31a03319078b42172c7b3849a5e12d35139a6eac1ef6a426a9b5fe21de3e9", size = 327935, upload-time = "2026-07-13T11:50:40.471Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/2d/2b4cda2f32a595fc4707d4941e487e2b4d3bcb787546068b5d89b0f1f89e/gwmock_signal-0.10.0-py3-none-any.whl", hash = "sha256:bb9305a0ab3eb661a8883f5eab087db4a3a5f479a471057c9e4998078932432b", size = 103503, upload-time = "2026-07-11T20:50:59.92Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/f2/dbf9e8acc427937d51ab8b817acf83153c46b46d6065ecc8d9d323baf332/gwmock_signal-0.11.0-py3-none-any.whl", hash = "sha256:b2a765745a497744594f0473295d70b805786a76e4a9644c08a0f40147cd87e9", size = 109428, upload-time = "2026-07-13T11:50:39.022Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Adds a `signal.waveform-options` config field, forwarded to gwmock-signal as its `waveform_arguments` parameter (LAL dictionary entries such as ModeArray) — distinct from the existing `waveform-arguments`, which flat-merges fixed physical parameters into the per-event set.

- Guards: specifying options both ways raises; an old gwmock-signal without `waveform_arguments` support raises an upgrade error instead of silently dropping the options through the unsupported-parameter retry path.
- Recorded in orchestration metadata.
- Requires gwmock-signal >= 0.11.0 (waveform_arguments across all backends: Leuven-Gravity-Institute/gwmock-signal#305, #306, #308, #309, #311).

Verified end-to-end against the real 0.11.0 backend: `waveform-options` `{ModeArray: [(2,2),(2,-2)]}` measurably changes the projected strain. Full signal + cli suites pass (399).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring waveform options in signal generation.
  * Waveform options can now be provided through configuration and are applied consistently across signal modes.
  * Added validation for conflicting waveform settings and clearer errors when the installed signal backend lacks required support.

* **Chores**
  * Updated the minimum supported signal adapter version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->