### PR TITLE
fix: detect unsupported-parameter errors from any signal backend

### DIFF
--- a/src/gwmock/signal/adapter.py
+++ b/src/gwmock/signal/adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Callable, Mapping, Sequence
 from functools import lru_cache
 from pathlib import Path
@@ -13,6 +14,12 @@ from gwmock_signal import CustomDetector, DetectorStrainStack, Network, resolve_
 from gwmock.data.time_series.time_series import TimeSeries
 
 logger = logging.getLogger("gwmock")
+
+#: gwmock-signal raises ``ValueError("Unsupported <backend> waveform parameters: a, b")``
+#: when a backend rejects parameters it does not recognise. The backend token varies
+#: (``LAL``, ``ripple``, ``PyCBC``), so match any of them and capture the comma-separated
+#: parameter list that follows.
+_UNSUPPORTED_PARAMS_RE = re.compile(r"^Unsupported .+? waveform parameters:\s*(.*)$")
 
 _DEFAULT_WAVEFORM_MODEL = "IMRPhenomXPHM"
 _LEGACY_SINGLE_DETECTOR_ALIASES = {
@@ -382,11 +389,10 @@ class SignalAdapter:
                 earth_rotation=earth_rotation,
             )
         except ValueError as exc:
-            _prefix = "Unsupported LAL waveform parameters:"
-            msg = str(exc)
-            if not msg.startswith(_prefix):
+            match = _UNSUPPORTED_PARAMS_RE.match(str(exc))
+            if match is None:
                 raise
-            extras = {k.strip() for k in msg[len(_prefix) :].split(",")}
+            extras = {token.strip() for token in match.group(1).split(",") if token.strip()}
             if "waveform_arguments" in extras:
                 raise ValueError(
                     "The installed gwmock-signal does not support the waveform_arguments "

--- a/tests/signal/test_adapter.py
+++ b/tests/signal/test_adapter.py
@@ -243,10 +243,11 @@ class TestSignalAdapter:
 
 
 class FailingBackend:
-    """Backend that raises 'Unsupported LAL waveform parameters' on the first call."""
+    """Backend that raises 'Unsupported <backend> waveform parameters' on the first call."""
 
-    def __init__(self, *, waveform_model: str) -> None:
+    def __init__(self, *, waveform_model: str, backend_label: str = "LAL") -> None:
         self.waveform_model = waveform_model
+        self.backend_label = backend_label
         self.required_params = frozenset({"coa_time"})
         self.call_count = 0
         self.received_params: list[dict] = []
@@ -265,7 +266,7 @@ class FailingBackend:
         self.call_count += 1
         self.received_params.append(dict(params))
         if "redshift" in params or "lambda_1" in params:
-            raise ValueError("Unsupported LAL waveform parameters: lambda_1, redshift")
+            raise ValueError(f"Unsupported {self.backend_label} waveform parameters: lambda_1, redshift")
         names = tuple(d if isinstance(d, str) else d.name for d in detector_names)
         from gwpy.timeseries import TimeSeries as GWpyTimeSeries
 
@@ -289,9 +290,13 @@ def _make_adapter_with_backend(backend):
 class TestSimulateStackUnsupportedParams:
     """Verify catch-parse-retry for 'Unsupported LAL waveform parameters' errors."""
 
-    def test_unsupported_params_trigger_warning_and_retry(self):
-        """On first failure the adapter logs a WARNING and retries without bad keys."""
-        backend = FailingBackend(waveform_model="IMRPhenomXPHM")
+    @pytest.mark.parametrize("backend_label", ["LAL", "ripple", "PyCBC"])
+    def test_unsupported_params_trigger_warning_and_retry(self, backend_label):
+        """On first failure the adapter logs a WARNING and retries without bad keys.
+
+        The parse works for every backend's error prefix, not only LAL.
+        """
+        backend = FailingBackend(waveform_model="IMRPhenomXPHM", backend_label=backend_label)
         adapter = _make_adapter_with_backend(backend)
 
         params = {"mass_1": 1.4, "redshift": 0.05, "lambda_1": 300.0, "coa_time": 0.0}
@@ -374,9 +379,13 @@ class RecordingBackend:
 class WaveformArgumentsRejectingBackend(RecordingBackend):
     """Backend stub predating gwmock-signal's waveform_arguments parameter."""
 
+    def __init__(self, *, waveform_model: str, backend_label: str = "LAL") -> None:
+        super().__init__(waveform_model=waveform_model)
+        self.backend_label = backend_label
+
     def simulate(self, params, detector_names, background=None, **kwargs):
         if "waveform_arguments" in params:
-            raise ValueError("Unsupported LAL waveform parameters: waveform_arguments")
+            raise ValueError(f"Unsupported {self.backend_label} waveform parameters: waveform_arguments")
         return super().simulate(params, detector_names, background=background, **kwargs)
 
 
@@ -407,9 +416,15 @@ class TestWaveformOptions:
                 waveform_options={"ModeArray": [(3, 3)]},
             )
 
-    def test_old_backend_raises_instead_of_dropping_options(self):
-        """A gwmock-signal without waveform_arguments support must not silently drop options."""
-        adapter = _make_adapter_with_backend(WaveformArgumentsRejectingBackend(waveform_model="IMRPhenomXHM"))
+    @pytest.mark.parametrize("backend_label", ["LAL", "ripple", "PyCBC"])
+    def test_old_backend_raises_instead_of_dropping_options(self, backend_label):
+        """A gwmock-signal without waveform_arguments support must not silently drop options.
+
+        The upgrade error is raised regardless of which backend rejected it.
+        """
+        adapter = _make_adapter_with_backend(
+            WaveformArgumentsRejectingBackend(waveform_model="IMRPhenomXHM", backend_label=backend_label)
+        )
         with pytest.raises(ValueError, match="upgrade gwmock-signal"):
             adapter.simulate_stack(
                 {"mass_1": 30.0, "coa_time": 0.0},


### PR DESCRIPTION
The adapter's catch-parse-retry (and the waveform_options upgrade error) only matched the LAL error prefix (`"Unsupported LAL waveform parameters:"`), so a ripple or PyCBC backend rejecting a parameter re-raised the raw `ValueError` instead of stripping+retrying the unsupported population params or emitting the upgrade guidance.

- Match any `"Unsupported <backend> waveform parameters:"` prefix via regex, capturing the comma-separated list (also drops empty tokens).
- Tests parametrised over LAL / ripple / PyCBC for both the strip+retry path and the waveform_options upgrade error.

Follow-up to #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)