### PR TITLE
feat: add HTCondor support to the batch submission command

### DIFF
--- a/src/gwmock/cli/batch.py
+++ b/src/gwmock/cli/batch.py
@@ -1,7 +1,7 @@
 # ruff: noqa PLC0415
 
 """
-Command-line tool for creating and submitting batch jobs (Slurm) for gwmock simulations.
+Command-line tool for creating and submitting batch jobs (Slurm, HTCondor) for gwmock simulations.
 """
 
 from __future__ import annotations
@@ -11,9 +11,98 @@ from typing import Annotated, Literal
 
 import typer
 
-SchedulerType = Literal["slurm"]
+SchedulerType = Literal["slurm", "htcondor"]
+
+#: Schedulers this command can generate submit files for.
+VALID_SCHEDULERS: tuple[str, ...] = ("slurm", "htcondor")
+
+#: Command used to submit a generated file to each scheduler.
+_SUBMIT_COMMANDS: dict[str, str] = {"slurm": "sbatch", "htcondor": "condor_submit"}
 
 # pylint: disable=no-member
+
+
+def _default_resources(scheduler: str) -> dict[str, object]:
+    """Return the default resource request block for a scheduler.
+
+    The keys are scheduler-native so they can be emitted verbatim: Slurm uses
+    ``sbatch`` long options, HTCondor uses ``request_*`` submit commands.
+    """
+    if scheduler == "htcondor":
+        return {"request_cpus": 1, "request_memory": "16GB", "request_disk": "4GB"}
+    return {"nodes": 1, "ntasks-per-node": 1, "cpus-per-task": 1, "mem": "16GB"}
+
+
+def _slurm_submit_content(
+    *,
+    job_name: str,
+    out_dir: Path,
+    err_dir: Path,
+    resources: dict,
+    submit_options: dict | None,
+    extra_lines: list[str] | None,
+    config_path: Path,
+) -> str:
+    """Build the contents of a Slurm ``sbatch`` submit script."""
+    lines = [
+        "#!/bin/bash",
+        f"#SBATCH --job-name={job_name}",
+        f"#SBATCH --output={out_dir}/{job_name}.output",
+        f"#SBATCH --error={err_dir}/{job_name}.error",
+        "",
+    ]
+    for key, val in resources.items():
+        lines.append(f"#SBATCH --{key}={val}")
+    if submit_options:
+        for key, val in submit_options.items():
+            lines.append(f"#SBATCH --{key}={val}")
+    lines.append("")
+    if extra_lines:
+        lines.extend(extra_lines)
+        lines.append("")
+    lines.append(f"gwmock simulate {config_path.resolve()}")
+    return "\n".join(lines) + "\n"
+
+
+def _htcondor_wrapper_content(*, extra_lines: list[str] | None, config_path: Path) -> str:
+    """Build the executable wrapper HTCondor runs on the execute node.
+
+    HTCondor submit files cannot carry shell setup, so environment preparation
+    (module loads, ``conda activate``) and the simulation command live in this
+    wrapper, mirroring where ``extra_lines`` sit in the Slurm script.
+    """
+    lines = ["#!/bin/bash"]
+    if extra_lines:
+        lines.extend(extra_lines)
+    lines.append(f"gwmock simulate {config_path.resolve()}")
+    return "\n".join(lines) + "\n"
+
+
+def _htcondor_submit_content(
+    *,
+    job_name: str,
+    wrapper_path: Path,
+    out_dir: Path,
+    err_dir: Path,
+    log_dir: Path,
+    resources: dict,
+    submit_options: dict | None,
+) -> str:
+    """Build the contents of an HTCondor submit description file."""
+    lines = [
+        "universe = vanilla",
+        f"executable = {wrapper_path}",
+        f"output = {out_dir}/{job_name}.output",
+        f"error = {err_dir}/{job_name}.error",
+        f"log = {log_dir}/{job_name}.log",
+    ]
+    for key, val in resources.items():
+        lines.append(f"{key} = {val}")
+    if submit_options:
+        for key, val in submit_options.items():
+            lines.append(f"{key} = {val}")
+    lines.append("queue")
+    return "\n".join(lines) + "\n"
 
 
 def _batch_command_impl(
@@ -56,7 +145,7 @@ def _batch_command_impl(
         Args:
             src_path: Source file path.
             dst_path: Destination file path.
-            scheduler: Name of the scheduler (only `slurm` currently supported).
+            scheduler: Name of the scheduler (`slurm` or `htcondor`).
             job_name: Name of the job.
             account: Cluster account to charge.
             cluster: Cluster or partition to run on.
@@ -72,16 +161,12 @@ def _batch_command_impl(
         # Convert to dict
         config_dict = config.model_dump(by_alias=True, exclude_none=True)
 
-        # Add/override the batch section with default resources and chosen scheduler
+        # Add/override the batch section with default resources and chosen scheduler.
+        # Resource keys are scheduler-native (sbatch options vs HTCondor request_* commands).
         batch_section = {
             "scheduler": scheduler,
             "job-name": job_name,
-            "resources": {
-                "nodes": 1,
-                "ntasks-per-node": 1,
-                "cpus-per-task": 1,
-                "mem": "16GB",
-            },
+            "resources": _default_resources(scheduler),
         }
 
         submit_options = {}
@@ -139,7 +224,9 @@ def _batch_command_impl(
         logger.info("Scheduler set to: %s", scheduler)
         return
 
-    # Regular case: use provided config.yaml to generate submit file
+    # Regular case: use provided config.yaml to generate submit file.
+    # batch_command guarantees config is provided when --get is not used.
+    assert config is not None  # noqa: S101
     if not config.exists():
         logger.error("Configuration file not found: %s", config)
         raise typer.Exit(1)
@@ -154,8 +241,11 @@ def _batch_command_impl(
     batch_section = config_data.batch
 
     scheduler = batch_section.scheduler
-    if scheduler not in ["slurm"]:
-        logger.error("Invalid or missing scheduler in 'batch.scheduler'. Must be 'slurm'.")
+    if scheduler not in VALID_SCHEDULERS:
+        logger.error(
+            "Invalid or missing scheduler in 'batch.scheduler'. Must be one of: %s.",
+            ", ".join(VALID_SCHEDULERS),
+        )
         raise typer.Exit(1)
 
     job_name = batch_section.job_name
@@ -171,61 +261,68 @@ def _batch_command_impl(
     err_dir.mkdir(parents=True, exist_ok=True)
     submit_dir.mkdir(parents=True, exist_ok=True)
 
-    submit_file = submit_dir / f"{job_name}.submit"
+    resources = batch_section.resources
+    submit_options = batch_section.submit
+    extra_lines = batch_section.extra_lines
 
-    # Generate submit file content
+    # Generate submit file content. HTCondor also needs an executable wrapper,
+    # since its submit file cannot carry shell setup (extra_lines) or the command.
+    wrapper_file: Path | None = None
     if scheduler == "slurm":
-        lines = [
-            "#!/bin/bash",
-            f"#SBATCH --job-name={job_name}",
-            f"#SBATCH --output={out_dir}/{job_name}.output",
-            f"#SBATCH --error={err_dir}/{job_name}.error",
-            "",
-        ]
-        resources = batch_section.resources
-        for key, val in resources.items():
-            lines.append(f"#SBATCH --{key}={val}")
-
-        if batch_section.submit:
-            submit_options = batch_section.submit
-            for key, val in submit_options.items():
-                lines.append(f"#SBATCH --{key}={val}")
-
-        lines.append("")
-
-        # Add user-defined extra lines (e.g. conda setup)
-        if batch_section.extra_lines:
-            lines.extend(batch_section.extra_lines)
-            lines.append("")
-
-        lines.append(f"gwmock simulate {config.resolve()}")
-
-    content = "\n".join(lines) + "\n"
+        submit_file = submit_dir / f"{job_name}.submit"
+        content = _slurm_submit_content(
+            job_name=job_name,
+            out_dir=out_dir,
+            err_dir=err_dir,
+            resources=resources,
+            submit_options=submit_options,
+            extra_lines=extra_lines,
+            config_path=config,
+        )
+    else:  # htcondor
+        log_dir = job_dir / "log"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        wrapper_file = submit_dir / f"{job_name}.sh"
+        submit_file = submit_dir / f"{job_name}.sub"
+        content = _htcondor_submit_content(
+            job_name=job_name,
+            wrapper_path=wrapper_file,
+            out_dir=out_dir,
+            err_dir=err_dir,
+            log_dir=log_dir,
+            resources=resources,
+            submit_options=submit_options,
+        )
 
     if submit_file.exists() and not overwrite:
         raise FileExistsError(f"Submit file already exists: {submit_file}. Use --overwrite to overwrite.")
-    submit_file.write_text(content)
-    logger.info("Generated SLURM submit file: %s", submit_file)
+    if wrapper_file is not None:
+        if wrapper_file.exists() and not overwrite:
+            raise FileExistsError(f"Wrapper script already exists: {wrapper_file}. Use --overwrite to overwrite.")
+        wrapper_file.write_text(_htcondor_wrapper_content(extra_lines=extra_lines, config_path=config))
+        wrapper_file.chmod(0o755)
 
-    # Optional detailed logging
+    submit_file.write_text(content)
+
     logger.info("Generated %s submit file: %s", scheduler.upper(), submit_file)
     logger.info("\tscheduler: %s", scheduler)
     logger.info("\tjob-name: %s", job_name)
-    if batch_section.submit:
+    if submit_options:
         for key, val in submit_options.items():
             logger.info("\t%s: %s", key, val)
     for key, val in resources.items():
         logger.info("\t%s: %s", key, val)
-    if batch_section.extra_lines:
-        for line in batch_section.extra_lines:
+    if extra_lines:
+        for line in extra_lines:
             logger.info("\textra-line: %s", line)
 
     # Submit file
     if submit:
-        import subprocess  # pylint: disable=import-outside-toplevel    # nosec B404 # B404: subprocess import is required for job submission to Slurm
+        import subprocess  # pylint: disable=import-outside-toplevel    # nosec B404 # B404: subprocess import is required for job submission
 
-        result = subprocess.run(  # pylint: disable=line-too-long # nosec B603 B607     # B603/B607: sbatch is a trusted system command     # submit_file path is generated and controlled by this tool — no injection risk
-            ["sbatch", str(submit_file)],
+        submit_program = _SUBMIT_COMMANDS[scheduler]
+        result = subprocess.run(  # pylint: disable=line-too-long # nosec B603 B607     # B603/B607: sbatch/condor_submit are trusted system commands     # submit_file path is generated and controlled by this tool — no injection risk
+            [submit_program, str(submit_file)],
             capture_output=True,
             text=True,
             check=False,
@@ -257,7 +354,7 @@ def batch_command(
     ] = None,
     scheduler: Annotated[
         SchedulerType,
-        typer.Option("--scheduler", "-s", help="Batch system (only 'slurm' supported)"),
+        typer.Option("--scheduler", "-s", help="Batch system ('slurm' or 'htcondor')"),
     ] = "slurm",
     job_name: Annotated[
         str,
@@ -301,7 +398,7 @@ def batch_command(
     overwrite: Annotated[bool, typer.Option("--overwrite", help="Overwrite existing files")] = False,
 ) -> None:
     """
-    Prepare and optionally submit gwmock simulations as Slurm batch jobs.
+    Prepare and optionally submit gwmock simulations as Slurm or HTCondor batch jobs.
 
     Two mutually exclusive modes:
 
@@ -323,27 +420,33 @@ def batch_command(
          - batch.submit: account, cluster, time (if provided)
          - batch.extra_lines: custom lines (if provided)
 
-    2. Generate and optionally submit a Slurm job from an existing config:
+    2. Generate and optionally submit a Slurm or HTCondor job from an existing config:
 
        gwmock batch config.yaml
        gwmock batch config.yaml --submit
 
        The config must contain a valid `batch` section with at least:
 
-         - batch.scheduler: slurm
+         - batch.scheduler: slurm | htcondor
          - batch.job-name: <name>
          - globals.working-directory
 
        Optional fields:
 
-         - batch.resources: resource requests (nodes, mem, etc.)
-         - batch.submit: additional sbatch options (account, cluster, time,  etc.)
-         - batch.extra_lines: custom shell lines (environment setup, modules, etc.)
+         - batch.resources: resource requests. Keys are scheduler-native:
+           sbatch options (nodes, mem, ...) for slurm; request_cpus/request_memory/... for htcondor.
+         - batch.submit: extra scheduler-native options (slurm: sbatch --options; htcondor: submit commands).
+         - batch.extra_lines: custom shell lines (environment setup, modules, etc.).
+           For htcondor these go into the executable wrapper the job runs.
+
+       For htcondor a submit description (.sub) plus an executable wrapper (.sh) are written,
+       and submission uses `condor_submit`; for slurm an sbatch script (.submit) is written and
+       submitted with `sbatch`.
 
     Args:
         config: Path to the input config.yaml (ignored when --get is used).
         get: Label of example config to copy (triggers config creation mode).
-        scheduler: Name of the scheduler (only `slurm` currently supported). Only allowed with --get.
+        scheduler: Name of the scheduler (`slurm` or `htcondor`). Only allowed with --get.
         job_name: Name of the job. Only allowed with --get.
         account: Cluster account to charge (passed via --account to sbatch and stored in batch.submit).
             Only allowed with --get.

--- a/src/gwmock/cli/batch.py
+++ b/src/gwmock/cli/batch.py
@@ -7,14 +7,15 @@ Command-line tool for creating and submitting batch jobs (Slurm, HTCondor) for g
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated, Literal, get_args
 
 import typer
 
 SchedulerType = Literal["slurm", "htcondor"]
 
-#: Schedulers this command can generate submit files for.
-VALID_SCHEDULERS: tuple[str, ...] = ("slurm", "htcondor")
+#: Schedulers this command can generate submit files for (derived from
+#: ``SchedulerType`` so there is a single source of truth).
+VALID_SCHEDULERS: tuple[str, ...] = get_args(SchedulerType)
 
 #: Command used to submit a generated file to each scheduler.
 _SUBMIT_COMMANDS: dict[str, str] = {"slurm": "sbatch", "htcondor": "condor_submit"}
@@ -250,7 +251,10 @@ def _batch_command_impl(
 
     job_name = batch_section.job_name
 
-    working_dir = Path(config_data.globals.working_directory)
+    # Resolve to an absolute path so the generated submit files (and, for
+    # HTCondor, the executable wrapper path) stay valid regardless of the
+    # directory a later `--submit` invocation runs from.
+    working_dir = Path(config_data.globals.working_directory).resolve()
     job_dir = working_dir / scheduler
     job_dir.mkdir(parents=True, exist_ok=True)
 
@@ -279,7 +283,7 @@ def _batch_command_impl(
             extra_lines=extra_lines,
             config_path=config,
         )
-    else:  # htcondor
+    elif scheduler == "htcondor":
         log_dir = job_dir / "log"
         log_dir.mkdir(parents=True, exist_ok=True)
         wrapper_file = submit_dir / f"{job_name}.sh"
@@ -293,6 +297,9 @@ def _batch_command_impl(
             resources=resources,
             submit_options=submit_options,
         )
+    else:  # pragma: no cover - unreachable; VALID_SCHEDULERS check above guards this
+        logger.error("Unsupported scheduler: %s", scheduler)
+        raise typer.Exit(1)
 
     if submit_file.exists() and not overwrite:
         raise FileExistsError(f"Submit file already exists: {submit_file}. Use --overwrite to overwrite.")
@@ -321,12 +328,17 @@ def _batch_command_impl(
         import subprocess  # pylint: disable=import-outside-toplevel    # nosec B404 # B404: subprocess import is required for job submission
 
         submit_program = _SUBMIT_COMMANDS[scheduler]
-        result = subprocess.run(  # pylint: disable=line-too-long # nosec B603 B607     # B603/B607: sbatch/condor_submit are trusted system commands     # submit_file path is generated and controlled by this tool — no injection risk
-            [submit_program, str(submit_file)],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        try:
+            result = subprocess.run(  # pylint: disable=line-too-long # nosec B603 B607     # B603/B607: sbatch/condor_submit are trusted system commands     # submit_file path is generated and controlled by this tool — no injection risk
+                [submit_program, str(submit_file)],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            logger.error("Submission command '%s' timed out after 60s.", submit_program)
+            raise typer.Exit(1) from None
 
         if result.returncode == 0:
             logger.info("Job submitted successfully.")

--- a/src/gwmock/cli/utils/config.py
+++ b/src/gwmock/cli/utils/config.py
@@ -311,7 +311,7 @@ class BatchConfig(BaseModel):
     """Batch configuration applying to all simulators."""
 
     scheduler: str = Field(
-        default="slurm", alias="scheduler", description="Name of the scheduler (only `slurm` currently supported)"
+        default="slurm", alias="scheduler", description="Name of the scheduler (`slurm` or `htcondor`)"
     )
     job_name: str = Field(default="gwmock_job", alias="job-name", description="Name of the job")
     resources: dict[str, Any] = Field(

--- a/tests/cli/test_batch.py
+++ b/tests/cli/test_batch.py
@@ -112,7 +112,7 @@ def _make_batch_config(tmp_path: Path, scheduler: str, work_dir: Path) -> Path:
     return cfg_path
 
 
-def _generate(cfg_path: Path, *, submit: bool = False) -> None:
+def _generate(cfg_path: Path, *, submit: bool = False, overwrite: bool = True) -> None:
     _batch_command_impl(
         config=cfg_path,
         get=None,
@@ -124,7 +124,7 @@ def _generate(cfg_path: Path, *, submit: bool = False) -> None:
         extra_lines=None,
         submit=submit,
         output=Path("config.yaml"),
-        overwrite=True,
+        overwrite=overwrite,
     )
 
 
@@ -201,6 +201,29 @@ def test_slurm_submit_uses_sbatch(tmp_path):
     cmd = mock_run.call_args[0][0]
     assert cmd[0] == "sbatch"
     assert cmd[1].endswith("test_job.submit")
+
+
+def test_existing_submit_file_without_overwrite_raises(tmp_path):
+    """A pre-existing .sub is not clobbered without --overwrite."""
+    work_dir = tmp_path / "work"
+    cfg_path = _make_batch_config(tmp_path, "htcondor", work_dir)
+    submit_dir = work_dir / "htcondor" / "submit"
+    submit_dir.mkdir(parents=True)
+    (submit_dir / "test_job.sub").write_text("old")
+    with pytest.raises(FileExistsError, match="Submit file already exists"):
+        _generate(cfg_path, overwrite=False)
+
+
+def test_existing_wrapper_without_overwrite_raises(tmp_path):
+    """A pre-existing HTCondor wrapper .sh is not clobbered without --overwrite."""
+    work_dir = tmp_path / "work"
+    cfg_path = _make_batch_config(tmp_path, "htcondor", work_dir)
+    submit_dir = work_dir / "htcondor" / "submit"
+    submit_dir.mkdir(parents=True)
+    # Only the wrapper exists, so the .sub guard passes and the wrapper guard fires.
+    (submit_dir / "test_job.sh").write_text("old")
+    with pytest.raises(FileExistsError, match="Wrapper script already exists"):
+        _generate(cfg_path, overwrite=False)
 
 
 def test_invalid_scheduler_exits(tmp_path):

--- a/tests/cli/test_batch.py
+++ b/tests/cli/test_batch.py
@@ -1,0 +1,217 @@
+"""Tests for the `gwmock batch` command, covering Slurm and HTCondor generation."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from gwmock.cli.batch import (
+    _batch_command_impl,
+    _default_resources,
+    _htcondor_submit_content,
+    _htcondor_wrapper_content,
+    _slurm_submit_content,
+)
+
+# --- pure content builders -------------------------------------------------
+
+
+def test_default_resources_are_scheduler_native():
+    """Slurm and HTCondor get resource keys in their own dialect."""
+    slurm = _default_resources("slurm")
+    condor = _default_resources("htcondor")
+    assert "mem" in slurm
+    assert "nodes" in slurm
+    assert "request_cpus" in condor
+    assert "request_memory" in condor
+    assert "nodes" not in condor
+
+
+def test_slurm_submit_content():
+    """The Slurm script carries #SBATCH directives, options, extras and the command."""
+    content = _slurm_submit_content(
+        job_name="job1",
+        out_dir=Path("/w/output"),
+        err_dir=Path("/w/error"),
+        resources={"mem": "16GB", "cpus-per-task": 2},
+        submit_options={"account": "acct", "time": "01:00:00"},
+        extra_lines=["module load Python/3.12"],
+        config_path=Path("config.yaml"),
+    )
+    assert content.startswith("#!/bin/bash\n")
+    assert "#SBATCH --job-name=job1" in content
+    assert "#SBATCH --output=/w/output/job1.output" in content
+    assert "#SBATCH --mem=16GB" in content
+    assert "#SBATCH --account=acct" in content
+    assert "module load Python/3.12" in content
+    assert content.rstrip().endswith("gwmock simulate " + str(Path("config.yaml").resolve()))
+
+
+def test_htcondor_wrapper_content():
+    """The wrapper carries env setup then the simulate command."""
+    content = _htcondor_wrapper_content(
+        extra_lines=["conda activate gwmock"],
+        config_path=Path("config.yaml"),
+    )
+    assert content.startswith("#!/bin/bash\n")
+    assert "conda activate gwmock" in content
+    assert content.rstrip().endswith("gwmock simulate " + str(Path("config.yaml").resolve()))
+    # Wrapper must not contain HTCondor submit syntax.
+    assert "universe" not in content
+
+
+def test_htcondor_submit_content():
+    """The submit description carries universe, executable, log, request_* and queue."""
+    content = _htcondor_submit_content(
+        job_name="job1",
+        wrapper_path=Path("/w/submit/job1.sh"),
+        out_dir=Path("/w/output"),
+        err_dir=Path("/w/error"),
+        log_dir=Path("/w/log"),
+        resources={"request_cpus": 1, "request_memory": "16GB"},
+        submit_options={"accounting_group": "ligo.dev"},
+    )
+    assert "universe = vanilla" in content
+    assert "executable = /w/submit/job1.sh" in content
+    assert "output = /w/output/job1.output" in content
+    assert "log = /w/log/job1.log" in content
+    assert "request_cpus = 1" in content
+    assert "request_memory = 16GB" in content
+    assert "accounting_group = ligo.dev" in content
+    assert content.rstrip().endswith("queue")
+    # Must not leak Slurm syntax.
+    assert "#SBATCH" not in content
+
+
+# --- end-to-end generation via --get then submit-file creation -------------
+
+
+def _make_batch_config(tmp_path: Path, scheduler: str, work_dir: Path) -> Path:
+    """Create a batch-ready config from the default example and point it at work_dir."""
+    cfg_path = tmp_path / "config.yaml"
+    _batch_command_impl(
+        config=None,
+        get=Path("default_config"),
+        scheduler=scheduler,
+        job_name="test_job",
+        account=None,
+        cluster=None,
+        time=None,
+        extra_lines=["module load Python/3.12"],
+        submit=False,
+        output=cfg_path,
+        overwrite=True,
+    )
+    data = yaml.safe_load(cfg_path.read_text())
+    data.setdefault("globals", {})["working-directory"] = str(work_dir)
+    cfg_path.write_text(yaml.safe_dump(data))
+    return cfg_path
+
+
+def _generate(cfg_path: Path, *, submit: bool = False) -> None:
+    _batch_command_impl(
+        config=cfg_path,
+        get=None,
+        scheduler="slurm",
+        job_name="gwmock_job",
+        account=None,
+        cluster=None,
+        time=None,
+        extra_lines=None,
+        submit=submit,
+        output=Path("config.yaml"),
+        overwrite=True,
+    )
+
+
+def test_htcondor_generation_writes_sub_and_executable_wrapper(tmp_path):
+    """htcondor produces a .sub description plus an executable wrapper with the command."""
+    work_dir = tmp_path / "work"
+    cfg_path = _make_batch_config(tmp_path, "htcondor", work_dir)
+    _generate(cfg_path)
+
+    submit_dir = work_dir / "htcondor" / "submit"
+    sub_file = submit_dir / "test_job.sub"
+    wrapper = submit_dir / "test_job.sh"
+
+    assert sub_file.exists()
+    sub = sub_file.read_text()
+    assert "universe = vanilla" in sub
+    assert f"executable = {wrapper}" in sub
+    assert "request_cpus = 1" in sub
+    assert sub.rstrip().endswith("queue")
+
+    assert wrapper.exists()
+    assert os.access(wrapper, os.X_OK)
+    wrapper_text = wrapper.read_text()
+    assert "module load Python/3.12" in wrapper_text
+    assert "gwmock simulate" in wrapper_text
+
+
+def test_slurm_generation_still_writes_sbatch_script(tmp_path):
+    """Regression: slurm generation is unchanged (.submit with #SBATCH, no wrapper)."""
+    work_dir = tmp_path / "work"
+    cfg_path = _make_batch_config(tmp_path, "slurm", work_dir)
+    _generate(cfg_path)
+
+    submit_dir = work_dir / "slurm" / "submit"
+    submit_file = submit_dir / "test_job.submit"
+    assert submit_file.exists()
+    content = submit_file.read_text()
+    assert "#SBATCH --job-name=test_job" in content
+    assert "gwmock simulate" in content
+    assert not (submit_dir / "test_job.sh").exists()
+
+
+def test_htcondor_submit_uses_condor_submit(tmp_path):
+    """--submit for htcondor invokes condor_submit on the .sub file."""
+    work_dir = tmp_path / "work"
+    cfg_path = _make_batch_config(tmp_path, "htcondor", work_dir)
+
+    class _Result:
+        returncode = 0
+        stdout = "submitted"
+        stderr = ""
+
+    with patch("subprocess.run", return_value=_Result()) as mock_run:
+        _generate(cfg_path, submit=True)
+
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "condor_submit"
+    assert cmd[1].endswith("test_job.sub")
+
+
+def test_slurm_submit_uses_sbatch(tmp_path):
+    """--submit for slurm invokes sbatch on the .submit file."""
+    work_dir = tmp_path / "work"
+    cfg_path = _make_batch_config(tmp_path, "slurm", work_dir)
+
+    class _Result:
+        returncode = 0
+        stdout = "submitted"
+        stderr = ""
+
+    with patch("subprocess.run", return_value=_Result()) as mock_run:
+        _generate(cfg_path, submit=True)
+
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "sbatch"
+    assert cmd[1].endswith("test_job.submit")
+
+
+def test_invalid_scheduler_exits(tmp_path):
+    """An unknown scheduler in the config is rejected."""
+    import typer
+
+    work_dir = tmp_path / "work"
+    cfg_path = _make_batch_config(tmp_path, "slurm", work_dir)
+    data = yaml.safe_load(cfg_path.read_text())
+    data["batch"]["scheduler"] = "pbs"
+    cfg_path.write_text(yaml.safe_dump(data))
+
+    with pytest.raises(typer.Exit):
+        _generate(cfg_path)


### PR DESCRIPTION
`gwmock batch` could only generate Slurm sbatch scripts. Adds HTCondor as a second scheduler.

- Writes a submit description (.sub) + an executable wrapper (.sh) holding the environment setup (extra_lines) and the `gwmock simulate` command (HTCondor submit files can't carry shell setup), and submits via `condor_submit`.
- Resource/submit keys emit in each scheduler's native dialect; `--get` seeds scheduler-appropriate default resources (request_cpus/request_memory).
- Submit-file generation refactored into pure, tested content builders.
- batch.py had no tests; adds coverage for both schedulers (content, file/wrapper generation, submit-command selection, invalid-scheduler).

Scope: the single-job `gwmock batch` path. HTCondor for the config-editor `/generate-script` chunk/array path is a separate follow-up.

Relevant to GW/ET infrastructure (HTCondor is the LDG/OSG standard scheduler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTCondor support to the `gwmock batch` command alongside Slurm.
  * Generate scheduler-specific batch files, resource settings, and wrapper scripts.
  * Submit jobs using the appropriate scheduler command.
  * Added scheduler selection and validation for batch configurations.

* **Documentation**
  * Updated configuration descriptions and command help to explain supported schedulers and resource settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->