### PR TITLE
feat(reproducibility): replay runs to their resolved dataset versions

### DIFF
--- a/docs/user-guide/reproducibility.md
+++ b/docs/user-guide/reproducibility.md
@@ -18,6 +18,8 @@ Consumers must reject unknown major versions.
         "gwmock_pop": "x.y.z"
     },
     "config": {},
+    "resolved_config": {},
+    "replayable": true,
     "config_sha256": "...",
     "seed": 42,
     "segment_seeds": [123456789, 987654321],
@@ -58,7 +60,20 @@ Consumers must reject unknown major versions.
 }
 ```
 
-`config` stores the resolved configuration snapshot for that run.
+`config` stores the input configuration snapshot for that run (template
+variables expanded). `resolved_config` stores the same config with every
+runtime-resolved external value folded in — for example a `DeepExtractorGlitch`
+whose dataset was downloaded at the repository default is recorded here pinned
+to the concrete Hugging Face commit it actually used. It is `null` when nothing
+needed resolving (a purely parametric run). **Replay prefers `resolved_config`
+over `config`**, so a run that did not explicitly pin its external inputs still
+reproduces the exact resources it used.
+
+`replayable` is `true` unless a declared external-mutable input could not be
+pinned to an immutable version (e.g. an offline dataset with no local cache); a
+`false` run is not bit-for-bit reproducible from its metadata, and replaying it
+emits a warning.
+
 `segment_seeds` stores the deterministic per-segment seeds that `gwmock` derives
 locally. Adapter-backed noise now consumes one shared
 `gwmock_noise.open_stream(...)` iterator per run, so the top-level `seed` is
@@ -81,7 +96,11 @@ gwmock simulate config.yaml
 
 In batch reproduction workflows, pass the generated `*.metadata.json` files
 directly to `gwmock simulate`. Each metadata file carries the exact config
-snapshot and per-segment seeds needed to reproduce that batch independently:
+snapshot and per-segment seeds needed to reproduce that batch independently.
+Because replay reads `resolved_config`, any downloaded dataset (e.g. a
+DeepExtractor glitch dataset) is refetched at the exact version the original run
+used, even if the config never pinned it and the upstream dataset has since
+moved:
 
 ```bash
 # Reproduce specific batches from their metadata files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = [
   "gwmock-signal>=0.11.0",
-  "gwmock-noise>=0.7.2",
+  "gwmock-noise>=0.9.0",
   "gwmock-pop>=0.11.2",
   "typer>=0.19.0",         # Literal-type CLI options; the SPEC 0 floor (0.13) predates them
   "tqdm>=4.67.0",

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -378,6 +378,22 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             },
         }
 
+    def resolved_config(self) -> dict[str, Any]:
+        """Return runtime-resolved config overrides, shaped like OrchestrationConfig.
+
+        Aggregates each sub-adapter's ``resolved_config()`` (only noise today)
+        into an ``OrchestrationConfig``-shaped fragment — e.g.
+        ``{"noise": {"arguments": {"glitches": [...]}}}`` — that a caller deep-
+        merges over the input config to obtain a fully-resolved, replayable
+        config. Returns an empty mapping when nothing needed resolving, so
+        callers can skip writing a resolved layer for a purely parametric run.
+        """
+        resolved: dict[str, Any] = {}
+        noise_resolved = self.noise_adapter.resolved_config() if self.noise_adapter is not None else {}
+        if noise_resolved:
+            resolved["noise"] = {"arguments": noise_resolved}
+        return resolved
+
     def set_batch_context(self, *, batch: Any, output_directory: Path, overwrite: bool) -> None:
         """Resolve per-batch output directories and runtime arguments."""
         if batch.simulator_config.signal is not None:

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -9,6 +9,7 @@ import copy
 import json
 import logging
 import platform
+import re
 import shutil
 import signal
 import subprocess
@@ -39,6 +40,10 @@ from gwmock.cli.utils.utils import handle_signal
 from gwmock.simulator.base import Simulator
 
 logger = logging.getLogger("gwmock")
+
+# A full git commit SHA (SHA-1): the only revision form that immutably pins a
+# downloaded dataset. Branches, tags, and None can all move upstream.
+_COMMIT_SHA_RE = re.compile(r"[0-9a-f]{40}")
 logger.setLevel(logging.DEBUG)
 
 
@@ -191,6 +196,84 @@ def _build_config_payload(batch: SimulationBatch, simulator: Simulator) -> dict[
         simulators[batch.simulator_name] = batch.simulator_config.model_dump(by_alias=True, exclude_none=True)
 
     return cast(dict[str, Any], expand_template_variables(base_payload, simulator))
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> None:
+    """Recursively merge ``override`` into ``base`` in place.
+
+    Nested mappings merge key-by-key; every other value (including lists)
+    replaces wholesale, so a resolved ``glitches`` list supersedes the input
+    one rather than being concatenated with it.
+    """
+    for key, value in override.items():
+        existing = base.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            _deep_merge(existing, value)
+        else:
+            base[key] = value
+
+
+def _unresolved_external_inputs(fragment: dict[str, Any]) -> list[str]:
+    """Return labels for resolved entries not pinned to an immutable version.
+
+    A glitch entry that carries a ``revision`` key names a dataset-backed model.
+    It is only reproducible when that revision is a full commit SHA: ``None``
+    means resolution failed (e.g. an offline Hub with no cache), and a symbolic
+    ref such as a branch or tag (``"main"``) still moves upstream. Both are
+    reported as unresolved so the run is marked non-replayable.
+    """
+    unresolved: list[str] = []
+    noise_arguments = fragment.get("noise", {}).get("arguments", {})
+    for entry in noise_arguments.get("glitches", []) or []:
+        if isinstance(entry, dict) and "revision" in entry and not _is_pinned_revision(entry["revision"]):
+            unresolved.append(f"glitch:{entry.get('kind', 'unknown')}")
+    return unresolved
+
+
+def _is_pinned_revision(revision: Any) -> bool:
+    """Return whether a dataset revision is an immutable full commit SHA.
+
+    A 40-character hex string is a git commit SHA and cannot move; anything else
+    — ``None`` or a symbolic ref like a branch or tag — can point at different
+    content later, so it does not pin the run.
+    """
+    return isinstance(revision, str) and _COMMIT_SHA_RE.fullmatch(revision) is not None
+
+
+def _build_resolved_config(
+    simulator: Simulator,
+    input_payload: dict[str, Any],
+) -> tuple[dict[str, Any] | None, bool]:
+    """Build the fully-resolved, replayable config for this batch.
+
+    Overlays each adapter's runtime-resolved values (e.g. a pinned dataset
+    revision) onto the template-expanded input config. Returns
+    ``(resolved_payload, replayable)`` — ``resolved_payload`` is ``None`` when
+    nothing needed resolving (a purely parametric run), and ``replayable`` is
+    ``False`` when a declared external-mutable input could not be pinned.
+    """
+    resolved_config_fn = getattr(simulator, "resolved_config", None)
+    if not callable(resolved_config_fn):
+        return None, True
+    fragment = cast(dict[str, Any], resolved_config_fn())
+    if not fragment:
+        return None, True
+
+    orchestration = input_payload.get("orchestration")
+    if not isinstance(orchestration, dict):
+        return None, True
+
+    unresolved = _unresolved_external_inputs(fragment)
+    if unresolved:
+        logger.warning(
+            "Could not pin external-mutable input(s) %s to an immutable version; "
+            "this run's metadata is marked non-replayable and is not bit-reproducible.",
+            ", ".join(unresolved),
+        )
+
+    resolved_payload = copy.deepcopy(input_payload)
+    _deep_merge(resolved_payload["orchestration"], fragment)
+    return resolved_payload, not unresolved
 
 
 def _resolve_seed(simulator: Simulator, batch: SimulationBatch) -> int | None:
@@ -636,6 +719,8 @@ def save_batch_metadata(
     state_to_save = pre_batch_state if pre_batch_state is not None else simulator.state
 
     seed = _resolve_seed(simulator, batch)
+    config_payload = _build_config_payload(batch, simulator)
+    resolved_config, replayable = _build_resolved_config(simulator, config_payload)
     metadata = create_batch_metadata(
         simulator_name=batch.simulator_name,
         batch_index=batch.batch_index,
@@ -646,7 +731,9 @@ def save_batch_metadata(
         source=batch.source,
         author=batch.author,
         email=batch.email,
-        config_payload=_build_config_payload(batch, simulator),
+        config_payload=config_payload,
+        resolved_config=resolved_config,
+        replayable=replayable,
         config_sha256=batch.config_sha256,
         seed=seed,
         segment_seeds=_resolve_segment_seeds(simulator, batch, seed),

--- a/src/gwmock/cli/utils/simulation_plan.py
+++ b/src/gwmock/cli/utils/simulation_plan.py
@@ -245,6 +245,8 @@ def create_batch_metadata(  # noqa: PLR0913
     timestamp: datetime.datetime | None = None,
     *,
     config_payload: dict[str, Any] | None = None,
+    resolved_config: dict[str, Any] | None = None,
+    replayable: bool = True,
     config_sha256: str | None = None,
     seed: int | None = None,
     segment_seeds: list[int] | None = None,
@@ -303,6 +305,15 @@ def create_batch_metadata(  # noqa: PLR0913
             "gwmock_pop": dependency_versions.get("gwmock-pop") or dependency_versions.get("gwmock_pop"),
         },
         "config": base_config,
+        # Fully-resolved, replayable config: the input config with every runtime-
+        # resolved external value (e.g. a pinned dataset revision) folded in.
+        # Replay prefers this over "config" so an unpinned run still reproduces
+        # the exact resources it used. None when nothing needed resolving.
+        "resolved_config": resolved_config,
+        # False when a declared external-mutable input could not be pinned to an
+        # immutable id (e.g. an offline dataset with no cache); such a run is not
+        # bit-reproducible from its metadata.
+        "replayable": replayable,
         "config_sha256": derived_config_sha256,
         "seed": seed,
         "segment_seeds": segment_seeds or [],
@@ -438,7 +449,17 @@ def create_plan_from_metadata_files(
 
         metadata = parse_batch_metadata(metadata_file)
 
-        metadata_config = metadata.get("config")
+        # Prefer the fully-resolved config so an unpinned run replays to the exact
+        # external resources it used (e.g. a pinned dataset revision); fall back to
+        # the raw input config when no resolved layer was recorded.
+        resolved_config = metadata.get("resolved_config")
+        metadata_config = resolved_config if isinstance(resolved_config, dict) else metadata.get("config")
+        if metadata.get("replayable") is False:
+            logger.warning(
+                "Metadata %s is marked non-replayable (an external-mutable input could not be "
+                "pinned to an immutable version); reproduction is not bit-for-bit.",
+                metadata_file,
+            )
 
         # Reconstruct configs from metadata
         try:

--- a/src/gwmock/noise/adapter.py
+++ b/src/gwmock/noise/adapter.py
@@ -273,6 +273,10 @@ class NoiseAdapter:
             backend: The backend to use.
         """
         self._backend = backend
+        # Glitch models built for the active stream, retained so their resolved,
+        # config-shaped state (e.g. a pinned dataset revision) can be reported
+        # for replayable metadata. None until a stream with glitches is opened.
+        self._glitch_models: list[Any] | None = None
 
     @classmethod
     def from_backend(cls, backend: BaseNoiseSimulator | NoiseSimulator | Any | None = None) -> NoiseAdapter:
@@ -690,6 +694,11 @@ class NoiseAdapter:
         Returns:
             The protocol-compatible backend.
         """
+        # Reset any glitch models from a previous stream so resolved_config()
+        # never reports stale models when this adapter is reused for a later
+        # stream that has no glitches.
+        self._glitch_models = None
+
         normalized_psd_files = _coerce_path_mapping(psd_files)
         normalized_csd_files = _coerce_path_mapping(csd_files)
         normalized_psd_schedule = _coerce_path_schedule(psd_schedule)
@@ -746,9 +755,28 @@ class NoiseAdapter:
                     sampling_frequency=sampling_frequency,
                     seed=seed,
                 )
-            simulator = InjectGlitches(simulator, normalize_glitch_models(resolved_glitches))
+            glitch_models = normalize_glitch_models(resolved_glitches)
+            self._glitch_models = glitch_models
+            simulator = InjectGlitches(simulator, glitch_models)
 
         return simulator
+
+    def resolved_config(self) -> dict[str, Any]:
+        """Return the runtime-resolved, config-shaped noise arguments.
+
+        Currently reports the glitch models with every external, mutable
+        dependency pinned to an immutable id (e.g. a DeepExtractor dataset
+        pinned to a concrete Hugging Face commit). Each model is resolved and
+        re-serialized, so the returned entries round-trip back through
+        ``normalize_glitch_models`` on replay and reproduce the exact resources
+        the run used. Returns an empty mapping when the active stream has no
+        glitches, so a caller can treat "nothing resolved" uniformly.
+        """
+        if not self._glitch_models:
+            return {}
+        for model in self._glitch_models:
+            model.resolve()
+        return {"glitches": [model.serialize() for model in self._glitch_models]}
 
 
 class _ChunkNoiseSimulator:

--- a/src/gwmock/noise/adapter.py
+++ b/src/gwmock/noise/adapter.py
@@ -277,6 +277,11 @@ class NoiseAdapter:
         # config-shaped state (e.g. a pinned dataset revision) can be reported
         # for replayable metadata. None until a stream with glitches is opened.
         self._glitch_models: list[Any] | None = None
+        # Memoized resolved_config() payload for the active stream, so per-batch
+        # metadata writes across one open_stream() reuse a single resolution
+        # (and one pinned revision) instead of re-resolving every batch. Reset
+        # whenever the stream is (re)configured.
+        self._resolved_config_cache: dict[str, Any] | None = None
 
     @classmethod
     def from_backend(cls, backend: BaseNoiseSimulator | NoiseSimulator | Any | None = None) -> NoiseAdapter:
@@ -698,6 +703,7 @@ class NoiseAdapter:
         # never reports stale models when this adapter is reused for a later
         # stream that has no glitches.
         self._glitch_models = None
+        self._resolved_config_cache = None
 
         normalized_psd_files = _coerce_path_mapping(psd_files)
         normalized_csd_files = _coerce_path_mapping(csd_files)
@@ -770,13 +776,18 @@ class NoiseAdapter:
         re-serialized, so the returned entries round-trip back through
         ``normalize_glitch_models`` on replay and reproduce the exact resources
         the run used. Returns an empty mapping when the active stream has no
-        glitches, so a caller can treat "nothing resolved" uniformly.
+        glitches, so a caller can treat "nothing resolved" uniformly. The result
+        is memoized for the active stream so repeated per-batch metadata writes
+        do not re-resolve.
         """
+        if self._resolved_config_cache is not None:
+            return self._resolved_config_cache
         if not self._glitch_models:
             return {}
         for model in self._glitch_models:
             model.resolve()
-        return {"glitches": [model.serialize() for model in self._glitch_models]}
+        self._resolved_config_cache = {"glitches": [model.serialize() for model in self._glitch_models]}
+        return self._resolved_config_cache
 
 
 class _ChunkNoiseSimulator:

--- a/tests/cli/test_resolved_config_replay.py
+++ b/tests/cli/test_resolved_config_replay.py
@@ -64,6 +64,24 @@ def test_noise_adapter_resolved_config_resolves_and_serializes_glitches() -> Non
     assert resolved == {"glitches": [{"kind": "deepextractor", "rate": 0.5, "revision": COMMIT_SHA}]}
 
 
+def test_noise_adapter_resolved_config_is_memoized_per_stream() -> None:
+    """Repeated calls reuse one resolution; reconfiguring the stream invalidates it."""
+    adapter = NoiseAdapter.from_backend()
+    model = _FakeGlitchModel(resolved=COMMIT_SHA)
+    adapter._glitch_models = [model]
+
+    first = adapter.resolved_config()
+    second = adapter.resolved_config()
+
+    assert first is second  # same cached object, no recomputation
+    assert model.resolve_calls == 1
+
+    # Reconfiguring a stream clears the cache (mirrors _configure_default_stream_backend).
+    adapter._glitch_models = None
+    adapter._resolved_config_cache = None
+    assert adapter.resolved_config() == {}
+
+
 def test_noise_adapter_resolved_config_empty_without_glitches() -> None:
     """A stream with no glitches resolves to an empty mapping, not an error."""
     adapter = NoiseAdapter.from_backend()

--- a/tests/cli/test_resolved_config_replay.py
+++ b/tests/cli/test_resolved_config_replay.py
@@ -1,0 +1,366 @@
+"""Resolved-config metadata layer and replay preference (A of the A+B design).
+
+Covers the gwmock-core half of dataset-version reproducibility: runtime-resolved
+values (e.g. a pinned Hugging Face dataset revision) are folded into a
+``resolved_config`` metadata layer that replay prefers over the raw input
+``config``, so an *unpinned* run still replays to the exact resources it used.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gwmock.cli.simulate_utils import (
+    _build_resolved_config,
+    _deep_merge,
+    _unresolved_external_inputs,
+)
+from gwmock.cli.utils.simulation_plan import (
+    create_batch_metadata,
+    create_plan_from_metadata_files,
+)
+from gwmock.noise.adapter import NoiseAdapter
+
+COMMIT_SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+class _FakeGlitchModel:
+    """Minimal stand-in for a dataset-backed glitch model.
+
+    Mirrors the gwmock-noise contract used by the resolved-config producer:
+    ``resolve()`` pins an external version and ``serialize()`` emits a
+    config-shaped dict carrying the resolved ``revision``.
+    """
+
+    def __init__(self, *, resolved: str | None) -> None:
+        self._resolved = resolved
+        self.resolve_calls = 0
+
+    def resolve(self) -> str | None:
+        self.resolve_calls += 1
+        return self._resolved
+
+    def serialize(self) -> dict[str, Any]:
+        return {"kind": "deepextractor", "rate": 0.5, "revision": self._resolved}
+
+
+# --- NoiseAdapter.resolved_config() ---------------------------------------- #
+
+
+def test_noise_adapter_resolved_config_resolves_and_serializes_glitches() -> None:
+    """resolved_config() pins every glitch model and returns their serialized form."""
+    adapter = NoiseAdapter.from_backend()
+    model = _FakeGlitchModel(resolved=COMMIT_SHA)
+    adapter._glitch_models = [model]
+
+    resolved = adapter.resolved_config()
+
+    assert model.resolve_calls == 1
+    assert resolved == {"glitches": [{"kind": "deepextractor", "rate": 0.5, "revision": COMMIT_SHA}]}
+
+
+def test_noise_adapter_resolved_config_empty_without_glitches() -> None:
+    """A stream with no glitches resolves to an empty mapping, not an error."""
+    adapter = NoiseAdapter.from_backend()
+    assert adapter.resolved_config() == {}
+
+
+def test_deepextractor_resolved_config_pins_commit_end_to_end(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real, unpinned DeepExtractor glitch resolves to a concrete SHA via the adapter.
+
+    Exercises the full producer path with the Hugging Face Hub mocked: open a
+    stream with an unpinned DeepExtractor glitch, then read resolved_config() and
+    confirm it records the concrete commit the cache resolved to — the exact
+    value replay would refetch.
+    """
+    from types import SimpleNamespace
+
+    import numpy as np
+    from gwmock_noise.glitches import deepextractor as de
+
+    # Synthetic dataset laid out under the Hub cache's snapshots/<sha>/ path.
+    snapshot_dir = tmp_path / "datasets--tomdooney--x" / "snapshots" / COMMIT_SHA
+    snapshot_dir.mkdir(parents=True)
+    label_order = np.array(list(reversed(de.GLITCH_CLASS_NAMES)))
+    n_rows = 2 * label_order.size
+    rng = np.random.default_rng(0)
+    labels = np.zeros((n_rows, label_order.size))
+    for row in range(n_rows):
+        labels[row, row % label_order.size] = 1.0
+    np.save(snapshot_dir / de.SAMPLES_FILENAME, rng.normal(size=(n_rows, 256)))
+    np.save(snapshot_dir / de.LABELS_FILENAME, labels)
+    np.save(snapshot_dir / de.LABEL_ORDER_FILENAME, label_order)
+
+    psd_file = tmp_path / "psd.txt"
+    freqs = np.linspace(0.0, 4096.0, 129)
+    np.savetxt(psd_file, np.column_stack((freqs, np.ones_like(freqs))))
+
+    def fake_download(*, repo_id, filename, repo_type, revision=None, local_files_only=False):
+        return str(snapshot_dir / filename)
+
+    monkeypatch.setattr(de, "_load_hf_hub", lambda: SimpleNamespace(hf_hub_download=fake_download))
+
+    adapter = NoiseAdapter.from_backend()
+    glitch = {
+        "kind": "deepextractor",
+        "rate": 0.5,
+        "amplitude_distribution": {"distribution": "lognormal", "mean": 1.0, "std": 0.0},
+        "psd_file": str(psd_file),
+        "snr": 10.0,
+        # Deliberately unpinned: reproducibility must still capture the commit.
+    }
+
+    adapter.open_stream(chunk_duration=8.0, sampling_frequency=256.0, detectors=["H1"], seed=11, glitches=[glitch])
+
+    resolved = adapter.resolved_config()
+    assert resolved["glitches"][0]["kind"] == "deepextractor"
+    assert resolved["glitches"][0]["revision"] == COMMIT_SHA
+    assert _unresolved_external_inputs({"noise": {"arguments": resolved}}) == []
+
+
+def test_reusing_adapter_without_glitches_clears_stale_models() -> None:
+    """A later glitch-free stream must not leave a previous stream's models visible."""
+    adapter = NoiseAdapter.from_backend()
+    blip = {
+        "kind": "blip",
+        "rate": 1.0,
+        "amplitude_distribution": {"distribution": "lognormal", "mean": 1e-21, "std": 0.0},
+        "width": 0.01,
+    }
+
+    adapter.open_stream(chunk_duration=8.0, sampling_frequency=256.0, detectors=["H1"], seed=11, glitches=[blip])
+    assert adapter.resolved_config() != {}
+
+    # Reopen with a component but no glitches; the earlier models must be gone.
+    adapter.open_stream(
+        chunk_duration=8.0,
+        sampling_frequency=256.0,
+        detectors=["H1"],
+        seed=11,
+        spectral_lines=[{"frequency": 60.0, "amplitude": 1e-23}],
+    )
+    assert adapter.resolved_config() == {}
+
+
+def test_open_stream_captures_real_glitch_models_for_resolved_config() -> None:
+    """Opening a stream with glitches captures the built models for resolved_config().
+
+    Uses a parametric blip (no external dataset) to exercise the real capture and
+    serialization wiring without a network dependency.
+    """
+    adapter = NoiseAdapter.from_backend()
+    blip = {
+        "kind": "blip",
+        "rate": 1.0,
+        "amplitude_distribution": {"distribution": "lognormal", "mean": 1e-21, "std": 0.0},
+        "width": 0.01,
+    }
+
+    adapter.open_stream(chunk_duration=8.0, sampling_frequency=256.0, detectors=["H1"], seed=11, glitches=[blip])
+
+    resolved = adapter.resolved_config()
+    assert resolved["glitches"][0]["kind"] == "blip"
+    # A parametric model has no external version, so nothing is flagged unresolved.
+    assert _unresolved_external_inputs({"noise": {"arguments": resolved}}) == []
+
+
+# --- helpers ---------------------------------------------------------------- #
+
+
+def test_deep_merge_replaces_lists_and_merges_dicts() -> None:
+    """Nested dicts merge key-by-key; lists replace wholesale."""
+    base = {"a": {"x": 1, "y": 2}, "list": [1, 2, 3]}
+    _deep_merge(base, {"a": {"y": 20, "z": 30}, "list": [9]})
+    assert base == {"a": {"x": 1, "y": 20, "z": 30}, "list": [9]}
+
+
+def test_unresolved_external_inputs_requires_a_full_commit_sha() -> None:
+    """Only a full commit SHA pins the run; None and symbolic refs are unresolved."""
+    parametric = {"noise": {"arguments": {"glitches": [{"kind": "blip"}]}}}
+
+    def _fragment(revision: Any) -> dict[str, Any]:
+        return {"noise": {"arguments": {"glitches": [{"kind": "deepextractor", "revision": revision}]}}}
+
+    # A 40-char hex commit SHA is immutable -> pinned.
+    assert _unresolved_external_inputs(_fragment(COMMIT_SHA)) == []
+    # None (resolution failed) and symbolic refs (branch/tag, still move) are not.
+    assert _unresolved_external_inputs(_fragment(None)) == ["glitch:deepextractor"]
+    assert _unresolved_external_inputs(_fragment("main")) == ["glitch:deepextractor"]
+    assert _unresolved_external_inputs(_fragment("v1.0")) == ["glitch:deepextractor"]
+    # A parametric model has no external revision to pin.
+    assert _unresolved_external_inputs(parametric) == []
+
+
+# --- _build_resolved_config ------------------------------------------------- #
+
+
+class _StubSimulator:
+    """Simulator exposing only the resolved_config() contract."""
+
+    def __init__(self, fragment: dict[str, Any]) -> None:
+        self._fragment = fragment
+
+    def resolved_config(self) -> dict[str, Any]:
+        return self._fragment
+
+
+def _input_payload(revision: Any) -> dict[str, Any]:
+    return {
+        "globals": {},
+        "orchestration": {
+            "noise": {
+                "backend": "DefaultNoiseSimulator",
+                "arguments": {
+                    "detectors": ["H1"],
+                    "seed": 7,
+                    "glitches": [{"kind": "deepextractor", "rate": 0.5, "revision": revision}],
+                },
+            }
+        },
+    }
+
+
+def test_build_resolved_config_folds_in_pinned_revision() -> None:
+    """The resolved payload overlays the pinned revision, preserving other args."""
+    fragment = {"noise": {"arguments": {"glitches": [{"kind": "deepextractor", "rate": 0.5, "revision": COMMIT_SHA}]}}}
+    payload = _input_payload(revision=None)
+
+    resolved, replayable = _build_resolved_config(_StubSimulator(fragment), payload)
+
+    assert replayable is True
+    assert resolved is not None
+    args = resolved["orchestration"]["noise"]["arguments"]
+    assert args["glitches"][0]["revision"] == COMMIT_SHA
+    # Untouched arguments survive the merge.
+    assert args["seed"] == 7
+    assert args["detectors"] == ["H1"]
+    # The input payload is not mutated.
+    assert payload["orchestration"]["noise"]["arguments"]["glitches"][0]["revision"] is None
+
+
+def test_build_resolved_config_marks_unresolved_non_replayable(caplog: pytest.LogCaptureFixture) -> None:
+    """An external input that cannot be pinned is flagged non-replayable, with a warning."""
+    fragment = {"noise": {"arguments": {"glitches": [{"kind": "deepextractor", "rate": 0.5, "revision": None}]}}}
+    payload = _input_payload(revision=None)
+
+    with caplog.at_level(logging.WARNING):
+        resolved, replayable = _build_resolved_config(_StubSimulator(fragment), payload)
+
+    assert replayable is False
+    assert resolved is not None
+    assert "non-replayable" in caplog.text
+
+
+def test_build_resolved_config_none_when_nothing_resolves() -> None:
+    """A simulator with no resolved_config(), or an empty fragment, records no layer."""
+
+    class _NoContract:
+        pass
+
+    assert _build_resolved_config(_NoContract(), _input_payload(revision=None)) == (None, True)
+    assert _build_resolved_config(_StubSimulator({}), _input_payload(revision=None)) == (None, True)
+
+
+# --- replay prefers resolved_config ----------------------------------------- #
+
+
+def _write_metadata(path: Path, *, config_revision: Any, resolved_revision: Any, replayable: bool) -> Path:
+    """Write a valid batch metadata file whose config and resolved_config diverge."""
+    from gwmock.cli.utils.config import GlobalsConfig, OrchestrationConfig
+
+    def _orchestration(revision: Any) -> dict[str, Any]:
+        return {
+            "globals": {},
+            "orchestration": {
+                "noise": {
+                    "backend": "DefaultNoiseSimulator",
+                    "arguments": {
+                        "detectors": ["H1"],
+                        "seed": 7,
+                        "glitches": [{"kind": "deepextractor", "rate": 0.5, "revision": revision}],
+                    },
+                }
+            },
+        }
+
+    simulator_config = OrchestrationConfig(
+        noise={"backend": "DefaultNoiseSimulator", "arguments": {"detectors": ["H1"], "seed": 7}}
+    )
+    metadata = create_batch_metadata(
+        simulator_name="noise",
+        batch_index=0,
+        simulator_config=simulator_config,
+        globals_config=GlobalsConfig(),
+        config_payload=_orchestration(config_revision),
+        resolved_config=_orchestration(resolved_revision) if resolved_revision is not None else None,
+        replayable=replayable,
+    )
+    file = path / "noise-0.metadata.json"
+    file.write_text(json.dumps(metadata))
+    return file
+
+
+def test_replay_prefers_resolved_config(tmp_path: Path) -> None:
+    """Replay reconstructs the plan from resolved_config, not the unpinned input config."""
+    metadata_file = _write_metadata(tmp_path, config_revision=None, resolved_revision=COMMIT_SHA, replayable=True)
+
+    plan = create_plan_from_metadata_files([metadata_file], tmp_path / "ckpt")
+
+    glitches = plan.batches[0].simulator_config.noise.arguments["glitches"]
+    assert glitches[0]["revision"] == COMMIT_SHA
+
+
+def test_replay_falls_back_to_config_without_resolved_layer(tmp_path: Path) -> None:
+    """With no resolved_config, replay uses the input config (legacy behavior)."""
+    metadata_file = _write_metadata(tmp_path, config_revision="main", resolved_revision=None, replayable=True)
+
+    plan = create_plan_from_metadata_files([metadata_file], tmp_path / "ckpt")
+
+    glitches = plan.batches[0].simulator_config.noise.arguments["glitches"]
+    assert glitches[0]["revision"] == "main"
+
+
+def test_replay_warns_when_non_replayable(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Replaying a run marked non-replayable warns that it is not bit-for-bit."""
+    metadata_file = _write_metadata(tmp_path, config_revision=None, resolved_revision=None, replayable=False)
+
+    with caplog.at_level(logging.WARNING):
+        create_plan_from_metadata_files([metadata_file], tmp_path / "ckpt")
+
+    assert "non-replayable" in caplog.text
+
+
+# --- schema ----------------------------------------------------------------- #
+
+
+def test_create_batch_metadata_records_resolved_layer_and_flag() -> None:
+    """create_batch_metadata surfaces resolved_config and replayable in the schema."""
+    from gwmock.cli.utils.config import GlobalsConfig, OrchestrationConfig
+
+    globals_config = GlobalsConfig()
+    simulator_config = OrchestrationConfig(
+        noise={"backend": "DefaultNoiseSimulator", "arguments": {"detectors": ["H1"]}}
+    )
+    resolved = {
+        "orchestration": {"noise": {"arguments": {"glitches": [{"kind": "deepextractor", "revision": COMMIT_SHA}]}}}
+    }
+
+    metadata = create_batch_metadata(
+        simulator_name="noise",
+        batch_index=0,
+        simulator_config=simulator_config,
+        globals_config=globals_config,
+        resolved_config=resolved,
+        replayable=False,
+    )
+
+    assert metadata["resolved_config"] == resolved
+    assert metadata["replayable"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -691,7 +691,7 @@ release = [
 [package.metadata]
 requires-dist = [
     { name = "filelock", specifier = ">=3.16.0" },
-    { name = "gwmock-noise", specifier = ">=0.7.2" },
+    { name = "gwmock-noise", specifier = ">=0.9.0" },
     { name = "gwmock-pop", specifier = ">=0.11.2" },
     { name = "gwmock-signal", specifier = ">=0.11.0" },
     { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", specifier = ">=0.11.0" },
@@ -723,7 +723,7 @@ release = [{ name = "git-cliff", specifier = ">=2.13.1" }]
 
 [[package]]
 name = "gwmock-noise"
-version = "0.7.2"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "h5py" },
@@ -733,9 +733,9 @@ dependencies = [
     { name = "scipy" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/eb/3c573c2e8df1ba5e1c942d46632e5477f64d35f2b543b9c655f5490f7532/gwmock_noise-0.7.2.tar.gz", hash = "sha256:fbd1eae57a51e970c5805e8a390878f6907a0d307b70328701b5c065f936f1c9", size = 761291, upload-time = "2026-07-14T02:01:20.844Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/f8/b7362ea5ee11a27ece96103c248225699d2d666d46d75186b10b7b5a709d/gwmock_noise-0.9.0.tar.gz", hash = "sha256:0fcaf0de000f1ebd3b2d63822d3d8d585e2b2926c5e1808e69d215c482678d4b", size = 781492, upload-time = "2026-07-23T08:57:19.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/2e/67c61a6f64619a7d400b293407b343fe7540c4989d7a8587d1536bb71e10/gwmock_noise-0.7.2-py3-none-any.whl", hash = "sha256:dc24a2e0fb462fe23d418e64c70f65c6a861af253b3c527cb1b98e46a7f6b841", size = 532186, upload-time = "2026-07-14T02:01:19.486Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/37c8d6994ba27fd4dba3cc5422e3e899d04be83487b06a7c91319dcc5926/gwmock_noise-0.9.0-py3-none-any.whl", hash = "sha256:bb36302a61a852c2a14d0b2ec5b6420e2516c8e998463f0cce6958d3bb65aa95", size = 541678, upload-time = "2026-07-23T08:57:18.134Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Completes the A+B data-versioning design (gwmock-noise producer side shipped in
v0.9.0). Replay reconstructed each batch only from the **input** config,
discarding all runtime-resolved state — so a run using a HuggingFace-backed
`DeepExtractorGlitch` that was **not** explicitly pinned could not be
reproduced once the upstream dataset moved.

Adds a replayable `resolved_config` metadata layer:

- **Backend contract** — adapters may expose `resolved_config()`. The noise
  adapter retains its glitch models and returns them resolved (pinned to a
  concrete HF commit SHA) and re-serialized; the orchestrator aggregates these
  into an `OrchestrationConfig`-shaped fragment.
- **Producer** — save-time deep-merges that fragment over the template-expanded
  input config into `metadata.resolved_config`, and records a `replayable`
  flag that is `false` (with a warning) when an external-mutable input is not
  pinned to an **immutable full commit SHA** (a branch/tag/`None` does not
  count).
- **Replay** — prefers `resolved_config` over `config`, so an unpinned run
  replays to the exact resources it used; falls back to `config` for legacy
  metadata and warns when replaying a non-replayable run.

Parametric-only runs are unaffected (`resolved_config` is `null`,
`replayable: true`). Signal/population producers can adopt the same contract
later.

## Reproducibility

An unpinned DeepExtractor run now records the concrete commit it used and
refetches exactly that on replay — bit-reproducible for a fixed
(version, config, seed) even as the upstream dataset moves.

## Testing

- New `tests/cli/test_resolved_config_replay.py` (14 tests): adapter
  `resolved_config()`, deep-merge, SHA/symbolic/None pin predicate, build +
  replayable flag + warning, replay preference/fallback, and an end-to-end
  real-DeepExtractor pin with the Hub mocked (no network).
- Full suite: 690 passed, 23 skipped. Ruff clean.
- Reviewed by a second agent; 1 HIGH (symbolic-ref false-positive) + 1 LOW
  (stale models on adapter reuse) found, fixed, re-confirmed closed.

## Dependency

Bumps `gwmock-noise>=0.9.0` for the glitch `resolve()`/`serialize()` contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added resolved configuration metadata that records runtime-pinned external inputs.
  - Replays now prefer resolved configurations to reproduce runs using the exact versions originally used.
  - Added replayability status to run metadata.

- **Bug Fixes**
  - Runs with mutable or unpinned external inputs are now identified as non-replayable and produce a warning instead of implying bit-for-bit reproducibility.

- **Documentation**
  - Updated reproducibility guidance and metadata examples to explain resolved configurations, replay behavior, and replayability warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->