### PR TITLE
fix(logging): stop claiming total_duration was not set when it was

### DIFF
--- a/src/gwmock/mixin/time_series.py
+++ b/src/gwmock/mixin/time_series.py
@@ -155,7 +155,15 @@ class TimeSeriesMixin:  # pylint: disable=too-few-public-methods,too-many-instan
             logger.info("Setting max_samples to %s based on total_duration and duration.", self.max_samples)
         else:
             self._total_duration = self.duration * self.max_samples
-            logger.info("total_duration not set, using duration * max_samples = %s seconds.", self.total_duration.value)
+            # total_duration was not passed to this simulator directly. That does
+            # not mean the user never set it: the orchestrator resolves a config
+            # total_duration into max_samples upstream and forwards only that, so
+            # claiming "total_duration not set" here misleads. Report the derived
+            # value factually instead.
+            logger.info(
+                "Resolved total_duration to %s seconds (duration * max_samples).",
+                self.total_duration.value,
+            )
 
     @property
     def end_time(self) -> Quantity:

--- a/tests/mixin/test_time_series_mixin.py
+++ b/tests/mixin/test_time_series_mixin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -66,6 +67,30 @@ class TestTimeSeriesMixin:
         assert simulator.sampling_frequency == Quantity(2048, unit="Hz")
         assert simulator.num_of_channels == num_of_channels
         assert simulator.dtype == np.float32
+
+    def test_total_duration_derived_message_is_not_misleading(self, caplog):
+        """Deriving total_duration from max_samples must not claim it was 'not set'.
+
+        Regression for #133: orchestration resolves a config total_duration into
+        max_samples and forwards only that, so this simulator receives no
+        total_duration and derives it here. The log must report the derived value
+        factually rather than asserting the user never set it.
+        """
+        with caplog.at_level(logging.INFO, logger="gwmock"):
+            simulator = MockTimeSeriesSimulator(max_samples=3, duration=2, sampling_frequency=100)
+
+        assert simulator.total_duration == Quantity(6, unit="s")
+        assert "total_duration not set" not in caplog.text
+        assert "Resolved total_duration to 6" in caplog.text
+
+    def test_total_duration_explicit_reports_set(self, caplog):
+        """An explicitly provided total_duration is reported as set and pins max_samples."""
+        with caplog.at_level(logging.INFO, logger="gwmock"):
+            simulator = MockTimeSeriesSimulator(duration=2, total_duration=8, sampling_frequency=100)
+
+        assert simulator.total_duration == Quantity(8, unit="s")
+        assert "Total duration set to" in caplog.text
+        assert "total_duration not set" not in caplog.text
 
     def test_init_with_detectors(self):
         """Test initialization with detectors list."""


### PR DESCRIPTION
## Summary

Fixes #133. During orchestrated simulations the log printed

`total_duration not set, using duration * max_samples = ... seconds.`

even when `total_duration` **was** set in the config. Root cause: the
orchestrator resolves a config `total_duration` into `max_samples` upstream
(`AdapterOrchestrator.from_config`) and forwards only `max_samples` to the
simulator, so `TimeSeriesMixin` received no `total_duration` and hit its
derive-from-`max_samples` branch — logging a message that asserted the user
never set it. The frame count was always correct; only the message lied.

Report the derived value factually instead:

`Resolved total_duration to N seconds (duration * max_samples).`

## Testing

- New regression tests in `tests/mixin/test_time_series_mixin.py`: the derived
  path no longer logs "not set" and reports the correct value; an explicit
  `total_duration` still logs "Total duration set to …".
- Verified end-to-end: a config-driven `AdapterOrchestrator` with
  `total_duration=16.0` now logs "Resolved total_duration to 16.0 seconds …"
  (no "not set").
- `tests/mixin/` + orchestration suite: 47 passed. Ruff clean.

Fixes #133