### PR TITLE
feat(metadata): record source parameters per frame and add signal->frame lookup

### DIFF
--- a/docs/user-guide/reproducibility.md
+++ b/docs/user-guide/reproducibility.md
@@ -5,12 +5,12 @@
 
 ## Schema
 
-Each record is validated at write time and uses schema version `1.0.0`.
+Each record is validated at write time and uses schema version `1.2.0`.
 Consumers must reject unknown major versions.
 
 ```json
 {
-    "schema_version": "1.0.0",
+    "schema_version": "1.2.0",
     "gwmock_version": "x.y.z",
     "subpackage_versions": {
         "gwmock_signal": "x.y.z",
@@ -34,6 +34,12 @@ Consumers must reject unknown major versions.
         "backend": "module:Class",
         "waveform_model": "IMRPhenomXPHM",
         "detector_network": ["ET1_SARD", "ET2_SARD", "ET3_SARD"],
+        "injections": [
+            {
+                "event_id": 0,
+                "parameters": { "mass_1": 30.0, "coa_time": 1577491218.5 }
+            }
+        ],
         "metadata": {}
     },
     "noise": {
@@ -81,8 +87,38 @@ recorded once and noise continuation no longer appears as one derived seed per
 batch. The subpackage `metadata` objects are preserved as JSON objects without
 gwmock rewriting their internal structure.
 
+`signal.injections` records the source parameters of the signals attributed to
+that batch's frame(s), in injection order. Each entry is
+`{"event_id": <index in the population>, "parameters": {...}}`. A signal is
+attributed to the frame in which it **merges** (its `coa_time` falls inside that
+frame's time segment); a long waveform whose inspiral or ringdown extends into
+adjacent frames is listed only under its merger frame. `event_id` is the event's
+index in the population as ordered for the run (by `coa_time` under the default
+ordering), so it is stable for a fixed configuration. Stationary/SGWB segments
+have no discrete events and record an empty list.
+
 For the config shape that feeds this record, see
 [Orchestration](orchestration.md) and [Protocol Contracts](protocols.md).
+
+## Finding which frame contains a signal
+
+Alongside the per-file `index.yaml`, a run writes `signal_index.yaml` mapping
+each signal's `event_id` to the frame file(s) that contain it. Use
+`gwmock find-signal` to resolve a signal to its frame:
+
+```bash
+# By id (fast path via signal_index.yaml)
+gwmock find-signal --metadata-dir metadata/ --id 42
+
+# By parameter filters (scans the recorded injections); combine with AND
+gwmock find-signal --metadata-dir metadata/ --param mass_1>=30 --param coa_time<1577491300
+
+# Machine-readable
+gwmock find-signal --metadata-dir metadata/ --id 42 --json
+```
+
+Filters accept `==`, `!=`, `>`, `<`, `>=`, `<=`; numeric values are compared
+numerically. The command exits non-zero when no signal matches.
 
 ## Reproducing a run
 

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -133,6 +133,11 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         self._active_overwrite = False
         self._noise_stream: Iterator[dict[str, Any]] | None = None
         self._noise_stream_position = 0
+        # Source parameters of the signals that merge in the current batch, in
+        # injection order: [{"event_id": <population index>, "parameters": {...}}].
+        # An event is attributed to the batch whose segment contains its coa_time.
+        # Recorded into per-batch metadata so a frame's sources are self-describing.
+        self._batch_injections: list[dict[str, Any]] = []
         self._pending_noise_chunk: dict[str, Any] | None = None
 
         super().__init__(
@@ -368,6 +373,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                     "detectors": self.detectors,
                     "network_resolution": self._detector_resolution,
                     "segment_seed": signal_segment_seed,
+                    "injections": list(self._batch_injections),
                 },
                 "noise": {
                     "arguments": self.noise_arguments,
@@ -428,8 +434,10 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             return self._simulate_stationary_signal_segment()
 
         chunks = TimeSeriesList()
+        self._batch_injections = []
         while self.population_index < len(self._population_events):
-            parameters = dict(self._population_events[int(self.population_index)])
+            event_id = int(self.population_index)
+            parameters = dict(self._population_events[event_id])
             coa_time = parameters.get("coa_time")
             end_time_value = float(getattr(self.end_time, "value", self.end_time))
             if coa_time is not None and float(coa_time) >= end_time_value:
@@ -443,6 +451,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                 earth_rotation=self.earth_rotation,
             )
             strain.metadata.update({"injection_parameters": dict(parameters)})
+            self._batch_injections.append({"event_id": event_id, "parameters": dict(parameters)})
             chunks.append(strain)
             self.population_index = cast(int, self.population_index) + 1
             if strain.start_time >= self.end_time:
@@ -453,6 +462,8 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         """Generate one stationary signal chunk spanning the active segment."""
         if self.signal_adapter is None:
             return TimeSeriesList()
+        # A stationary (e.g. SGWB) segment has no discrete source events.
+        self._batch_injections = []
         segment_seed = self._signal_segment_seed()
         self.signal_adapter.set_seed(segment_seed)
         n_samples = round(float(self.duration.value) * float(self.sampling_frequency.value))

--- a/src/gwmock/cli/find_signal.py
+++ b/src/gwmock/cli/find_signal.py
@@ -1,0 +1,52 @@
+# ruff: noqa: PLC0415
+"""CLI command to look up which frame file(s) contain a given simulated signal."""
+
+from __future__ import annotations
+
+import json as _json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+
+def find_signal_command(
+    metadata_dir: Annotated[
+        Path,
+        typer.Option("--metadata-dir", help="Directory with batch metadata files and signal_index.yaml."),
+    ],
+    event_id: Annotated[
+        int | None,
+        typer.Option("--id", help="Signal event id (its index in the coa_time-sorted population)."),
+    ] = None,
+    param: Annotated[
+        list[str] | None,
+        typer.Option("--param", help="Parameter filter, e.g. 'mass_1>=30' (repeatable; combined with AND)."),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Emit results as JSON.")] = False,
+) -> None:
+    """Find the signal frame file(s) that contain a given injected signal.
+
+    Look up by ``--id`` (fast, via ``signal_index.yaml``) and/or by one or more
+    ``--param`` predicates matched against the source parameters recorded in the
+    batch metadata (e.g. ``--param mass_1>=30 --param network_snr>8``).
+    """
+    from gwmock.cli.utils.signal_lookup import find_signals, parse_param_filter
+
+    filters = [parse_param_filter(spec) for spec in (param or [])]
+    if event_id is None and not filters:
+        raise typer.BadParameter("Provide --id and/or at least one --param filter.")
+
+    matches = find_signals(metadata_dir, event_id=event_id, param_filters=filters)
+
+    if json_output:
+        typer.echo(_json.dumps(matches, indent=2, default=str))
+        return
+
+    if not matches:
+        typer.echo("No matching signals found.")
+        raise typer.Exit(code=1)
+
+    for match in matches:
+        frames = ", ".join(match.get("frames") or []) or "(no frame recorded)"
+        typer.echo(f"event {match['event_id']} (coa_time={match.get('coa_time')}) -> {frames}")

--- a/src/gwmock/cli/main.py
+++ b/src/gwmock/cli/main.py
@@ -88,6 +88,7 @@ def register_commands() -> None:
     # Fast imports
     from gwmock.cli.batch import batch_command
     from gwmock.cli.config import config_command
+    from gwmock.cli.find_signal import find_signal_command
     from gwmock.cli.merge import merge_command
     from gwmock.cli.repository.main import repository_app
     from gwmock.cli.simulate import simulate_command
@@ -98,6 +99,7 @@ def register_commands() -> None:
     app.command("config")(config_command)
     app.command("validate")(validate_command)
     app.command("batch")(batch_command)
+    app.command("find-signal")(find_signal_command)
 
     app.add_typer(repository_app, name="repository", help="Manage Zenodo repositories")
 

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -338,6 +338,10 @@ def _build_signal_section(simulator: Simulator, batch: SimulationBatch) -> dict[
             "backend": _backend_path_from_object(simulator.signal_adapter._backend),
             "waveform_model": simulator.waveform_model,
             "detector_network": list(simulator.detectors),
+            # Source parameters of the signals that merge in this batch's frame(s),
+            # in injection order (empty for stationary/SGWB segments). This makes each
+            # frame self-describing and backs the signal->frame lookup.
+            "injections": list(simulator_metadata["orchestration"]["signal"].get("injections", [])),
             "metadata": simulator_metadata["orchestration"]["signal"],
         }
 
@@ -564,6 +568,67 @@ def update_metadata_index(
         raise
 
 
+def update_signal_index(
+    metadata_directory: Path,
+    metadata: dict[str, Any],
+    metadata_file_name: str,
+    encoding: str = "utf-8",
+) -> None:
+    """Update the signal index mapping each injected event to its frame file(s).
+
+    The index (``signal_index.yaml``) maps a signal's ``event_id`` to the signal
+    frame file(s) that contain it plus the batch metadata file, enabling O(1)
+    signal->frame lookup by id. Parameter-based lookup reads the injections
+    recorded in the batch metadata files (their source of truth); this index is
+    only the id shortcut. A batch with no injected signals writes nothing.
+
+    Args:
+        metadata_directory: Directory where metadata and the index live.
+        metadata: The batch metadata record just written.
+        metadata_file_name: File name of that batch metadata record.
+        encoding: File encoding for reading/writing the index file.
+    """
+    injections = (metadata.get("signal") or {}).get("injections") or []
+    index_file = metadata_directory / "signal_index.yaml"
+    if not injections and not index_file.exists():
+        return
+
+    if index_file.exists():
+        try:
+            with index_file.open(encoding=encoding) as f:
+                index = yaml.safe_load(f) or {}
+        except (OSError, yaml.YAMLError) as e:
+            logger.warning("Failed to load signal index: %s. Creating new index.", e)
+            index = {}
+    else:
+        index = {}
+
+    # Drop any entries this batch wrote previously so a re-run or overwrite (which
+    # may now inject different or no events) cannot leave stale id -> frame rows
+    # that the id fast-path would trust.
+    index = {event_id: entry for event_id, entry in index.items() if entry.get("metadata") != metadata_file_name}
+
+    signal_frames = [
+        output["path"] for output in metadata.get("outputs", []) if output.get("kind") == "signal" and "path" in output
+    ]
+    for injection in injections:
+        event_id = injection.get("event_id")
+        if event_id is None:
+            continue
+        index[str(event_id)] = {
+            "frames": signal_frames,
+            "metadata": metadata_file_name,
+            "coa_time": (injection.get("parameters") or {}).get("coa_time"),
+        }
+
+    try:
+        with index_file.open("w") as f:
+            yaml.safe_dump(index, f, default_flow_style=False, sort_keys=True)
+    except (OSError, yaml.YAMLError) as e:
+        logger.error("Failed to save signal index: %s", e)
+        raise
+
+
 def instantiate_simulator(
     simulator_config: SimulatorConfig | OrchestrationConfig,
     simulator_name: str | None = None,
@@ -777,6 +842,9 @@ def save_batch_metadata(
 
     # Update the metadata index for quick lookup
     update_metadata_index(metadata_directory, output_files, metadata_file_name)
+
+    # Update the signal index (event id -> containing frame file(s)) for signal->frame lookup
+    update_signal_index(metadata_directory, metadata, metadata_file_name)
 
 
 def process_batch(

--- a/src/gwmock/cli/utils/metadata.py
+++ b/src/gwmock/cli/utils/metadata.py
@@ -11,7 +11,7 @@ import numpy as np
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-SCHEMA_VERSION = "1.1.0"
+SCHEMA_VERSION = "1.2.0"
 _SCHEMA_VERSION_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
 
@@ -41,6 +41,11 @@ class SignalSection(BaseModel):
     backend: str
     waveform_model: str | None = None
     detector_network: list[str] = Field(default_factory=list)
+    # Source parameters of the signals that merge in this batch's frame(s), in
+    # injection order: [{"event_id": int, "parameters": {...}}]. An event is
+    # attributed to the frame its coa_time falls in; content extending into
+    # adjacent frames is not cross-listed. Empty for stationary/SGWB segments.
+    injections: list[dict[str, Any]] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/src/gwmock/cli/utils/signal_lookup.py
+++ b/src/gwmock/cli/utils/signal_lookup.py
@@ -1,0 +1,146 @@
+"""Look up which frame file(s) contain a given simulated signal.
+
+Signals are recorded per batch in the metadata files (``signal.injections``,
+the source of truth) and mirrored into ``signal_index.yaml`` for O(1) lookup by
+``event_id``. Parameter-based lookup scans the injections in the metadata files.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import operator
+import re
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Relative tolerance for numeric == / != filters, so representation noise (e.g.
+# a float round-tripped through JSON) does not cause a scientifically-equal
+# value to be missed. Ordering operators stay exact.
+_EQUALITY_REL_TOL = 1.0e-9
+
+# Two-character operators must be tried before one-character ones.
+_OPERATORS: dict[str, Callable[[Any, Any], bool]] = {
+    ">=": operator.ge,
+    "<=": operator.le,
+    "!=": operator.ne,
+    "==": operator.eq,
+    ">": operator.gt,
+    "<": operator.lt,
+    "=": operator.eq,
+}
+_FILTER_RE = re.compile(r"^\s*(?P<key>[^<>=!\s]+)\s*(?P<op>>=|<=|!=|==|>|<|=)\s*(?P<value>.+?)\s*$")
+
+
+def parse_param_filter(spec: str) -> tuple[str, str, Any]:
+    """Parse a ``key OP value`` filter such as ``mass_1>=30`` or ``approximant==IMRPhenomXPHM``."""
+    match = _FILTER_RE.match(spec)
+    if not match:
+        raise ValueError(f"Invalid parameter filter '{spec}'; expected key OP value (e.g. mass_1>=30).")
+    return match.group("key"), match.group("op"), _coerce(match.group("value"))
+
+
+def _coerce(raw: str) -> Any:
+    """Coerce a filter value to float when possible, otherwise keep it as a string."""
+    try:
+        return float(raw)
+    except ValueError:
+        return raw
+
+
+def _matches(parameters: dict[str, Any], filters: list[tuple[str, str, Any]]) -> bool:
+    """Return whether an event's parameters satisfy every filter predicate."""
+    for key, op, value in filters:
+        if key not in parameters:
+            return False
+        try:
+            if not _compare(parameters[key], op, value):
+                return False
+        except TypeError:
+            # Mismatched types (e.g. numeric op on a string parameter) never match.
+            return False
+    return True
+
+
+def _compare(actual: Any, op: str, value: Any) -> bool:
+    """Apply one filter operator, using a tolerance for numeric equality tests."""
+    if op in ("==", "=", "!=") and isinstance(actual, (int, float)) and isinstance(value, (int, float)):
+        close = math.isclose(actual, value, rel_tol=_EQUALITY_REL_TOL, abs_tol=0.0)
+        return not close if op == "!=" else close
+    return _OPERATORS[op](actual, value)
+
+
+def _iter_metadata_files(metadata_directory: Path) -> Iterator[Path]:
+    yield from sorted(metadata_directory.glob("*.metadata.json"))
+
+
+def find_signals(
+    metadata_directory: Path | str,
+    *,
+    event_id: int | None = None,
+    param_filters: list[tuple[str, str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Return the signals matching an id and/or parameter filters with their frame file(s).
+
+    With only ``event_id`` set, the fast ``signal_index.yaml`` path is used. When
+    parameter filters are supplied, the batch metadata files are scanned (their
+    ``signal.injections`` are the source of truth). Each result is a mapping with
+    ``event_id``, ``frames`` (signal frame paths), ``metadata`` (batch metadata
+    file name), and ``coa_time``; parameter-filtered results also carry
+    ``parameters``.
+    """
+    metadata_directory = Path(metadata_directory)
+    param_filters = param_filters or []
+    results: list[dict[str, Any]] = []
+
+    if event_id is not None and not param_filters:
+        index_file = metadata_directory / "signal_index.yaml"
+        if not index_file.exists():
+            return results
+        with index_file.open(encoding="utf-8") as f:
+            index = yaml.safe_load(f) or {}
+        entry = index.get(str(event_id))
+        if entry:
+            results.append(
+                {
+                    "event_id": event_id,
+                    "frames": entry.get("frames", []),
+                    "metadata": entry.get("metadata"),
+                    "coa_time": entry.get("coa_time"),
+                }
+            )
+        return results
+
+    for meta_path in _iter_metadata_files(metadata_directory):
+        try:
+            with meta_path.open(encoding="utf-8") as f:
+                metadata = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        injections = (metadata.get("signal") or {}).get("injections") or []
+        if not injections:
+            continue
+        frames = [
+            output["path"]
+            for output in metadata.get("outputs", [])
+            if output.get("kind") == "signal" and "path" in output
+        ]
+        for injection in injections:
+            if event_id is not None and injection.get("event_id") != event_id:
+                continue
+            parameters = injection.get("parameters") or {}
+            if not _matches(parameters, param_filters):
+                continue
+            results.append(
+                {
+                    "event_id": injection.get("event_id"),
+                    "frames": frames,
+                    "metadata": meta_path.name,
+                    "parameters": parameters,
+                    "coa_time": parameters.get("coa_time"),
+                }
+            )
+    return results

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -313,7 +313,7 @@ def test_simulate_command_runs_adapter_orchestration(monkeypatch, tmp_path: Path
     assert (tmp_path / "output" / "signal" / "signal-1.gwf").exists()
     _assert_noise_outputs_exist(tmp_path / "output" / "noise")
     metadata = yaml.safe_load((tmp_path / "metadata" / "orchestration-0.metadata.json").read_text())
-    assert metadata["schema_version"] == "1.1.0"
+    assert metadata["schema_version"] == "1.2.0"
     assert metadata["config"]["orchestration"]["population"]["backend"] == FAKE_POPULATION_BACKEND
     assert metadata["config"]["orchestration"]["signal"]["backend"] == FAKE_SIGNAL_BACKEND
     assert metadata["config"]["orchestration"]["noise"]["backend"] == FAKE_NOISE_BACKEND
@@ -340,6 +340,46 @@ def test_simulate_command_runs_adapter_orchestration(monkeypatch, tmp_path: Path
             "seed": derive_seed(7, "noise", "stream"),
         }
     ]
+
+
+def test_orchestration_records_injections_and_signal_lookup(monkeypatch, tmp_path: Path):
+    """End-to-end: source parameters are recorded per frame and are looked up (#12)."""
+    from gwmock.cli.utils.signal_lookup import find_signals, parse_param_filter
+
+    FakeNoiseAdapter.stream_open_calls.clear()
+    config = _fake_orchestration_config(tmp_path, source_type="bbh")
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.safe_dump(config.model_dump(by_alias=True, exclude_none=True), sort_keys=False))
+    monkeypatch.setattr("gwmock.cli.adapter_orchestration.DetectorStrainStack.write", _write_signal_file)
+
+    _simulate_impl(str(config_file), overwrite=True, metadata=True)
+
+    metadata_dir = tmp_path / "metadata"
+
+    # Part A: each batch's metadata records the source parameters of its signal(s).
+    batch0 = yaml.safe_load((metadata_dir / "orchestration-0.metadata.json").read_text())
+    injections0 = batch0["signal"]["injections"]
+    assert [inj["event_id"] for inj in injections0] == [0]
+    assert injections0[0]["parameters"]["detector_frame_mass_1"] == 30.0
+    assert injections0[0]["parameters"]["coa_time"] == 100.5
+
+    batch1 = yaml.safe_load((metadata_dir / "orchestration-1.metadata.json").read_text())
+    assert [inj["event_id"] for inj in batch1["signal"]["injections"]] == [1]
+
+    # Part B: signal_index.yaml maps each event id to its containing frame(s).
+    index = yaml.safe_load((metadata_dir / "signal_index.yaml").read_text())
+    assert set(index) == {"0", "1"}
+    assert any("signal-0.gwf" in frame for frame in index["0"]["frames"])
+
+    # Lookup by id (fast path) resolves to the right frame.
+    by_id = find_signals(metadata_dir, event_id=1)
+    assert len(by_id) == 1
+    assert any("signal-1.gwf" in frame for frame in by_id[0]["frames"])
+
+    # Lookup by parameter filter scans the recorded injections.
+    heavy = find_signals(metadata_dir, param_filters=[parse_param_filter("detector_frame_mass_1>=31")])
+    assert [match["event_id"] for match in heavy] == [1]
+    assert any("signal-1.gwf" in frame for frame in heavy[0]["frames"])
 
 
 def _fake_multi_detector_config(working_directory: str) -> Config:

--- a/tests/cli/test_signal_lookup.py
+++ b/tests/cli/test_signal_lookup.py
@@ -1,0 +1,193 @@
+"""Unit tests for signal->frame lookup (issue #12, Part B)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from gwmock.cli.main import app
+from gwmock.cli.simulate_utils import update_signal_index
+from gwmock.cli.utils.signal_lookup import find_signals, parse_param_filter
+
+runner = CliRunner()
+
+
+def _write_batch(directory: Path, index: int, injections: list[dict], frames: list[str]) -> None:
+    """Write a minimal batch metadata file plus its signal-index entry."""
+    metadata = {
+        "signal": {"injections": injections},
+        "outputs": [{"kind": "signal", "path": frame} for frame in frames]
+        + [{"kind": "noise", "path": f"noise-{index}.npy"}],
+    }
+    name = f"orchestration-{index}.metadata.json"
+    (directory / name).write_text(json.dumps(metadata))
+    update_signal_index(directory, metadata, name)
+
+
+@pytest.fixture
+def metadata_dir(tmp_path: Path) -> Path:
+    _write_batch(
+        tmp_path,
+        0,
+        [{"event_id": 0, "parameters": {"detector_frame_mass_1": 30.0, "coa_time": 100.5}}],
+        ["signal/signal-0.gwf"],
+    )
+    _write_batch(
+        tmp_path,
+        1,
+        [{"event_id": 1, "parameters": {"detector_frame_mass_1": 31.0, "coa_time": 104.5}}],
+        ["signal/signal-1.gwf"],
+    )
+    return tmp_path
+
+
+# --- parse_param_filter ----------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        ("mass_1>=30", ("mass_1", ">=", 30.0)),
+        ("mass_1 <= 40", ("mass_1", "<=", 40.0)),
+        ("coa_time>100.5", ("coa_time", ">", 100.5)),
+        ("approximant==IMRPhenomXPHM", ("approximant", "==", "IMRPhenomXPHM")),
+        ("n!=2", ("n", "!=", 2.0)),
+    ],
+)
+def test_parse_param_filter(spec: str, expected: tuple) -> None:
+    assert parse_param_filter(spec) == expected
+
+
+def test_parse_param_filter_rejects_garbage() -> None:
+    with pytest.raises(ValueError, match="Invalid parameter filter"):
+        parse_param_filter("mass_1")
+
+
+# --- find_signals ----------------------------------------------------------- #
+
+
+def test_signal_index_written(metadata_dir: Path) -> None:
+    index = yaml.safe_load((metadata_dir / "signal_index.yaml").read_text())
+    assert set(index) == {"0", "1"}
+    assert index["0"]["frames"] == ["signal/signal-0.gwf"]
+    assert index["0"]["coa_time"] == 100.5
+    assert index["1"]["metadata"] == "orchestration-1.metadata.json"
+
+
+def test_find_by_id_uses_index(metadata_dir: Path) -> None:
+    matches = find_signals(metadata_dir, event_id=1)
+    assert len(matches) == 1
+    assert matches[0]["frames"] == ["signal/signal-1.gwf"]
+    assert matches[0]["metadata"] == "orchestration-1.metadata.json"
+
+
+def test_find_by_id_missing_returns_empty(metadata_dir: Path) -> None:
+    assert find_signals(metadata_dir, event_id=99) == []
+
+
+def test_find_by_param_filter_scans_metadata(metadata_dir: Path) -> None:
+    matches = find_signals(metadata_dir, param_filters=[parse_param_filter("detector_frame_mass_1>=31")])
+    assert [m["event_id"] for m in matches] == [1]
+    assert matches[0]["frames"] == ["signal/signal-1.gwf"]
+    assert matches[0]["parameters"]["detector_frame_mass_1"] == 31.0
+
+
+def test_find_by_multiple_filters_are_anded(metadata_dir: Path) -> None:
+    matches = find_signals(
+        metadata_dir,
+        param_filters=[parse_param_filter("detector_frame_mass_1>=30"), parse_param_filter("coa_time<104")],
+    )
+    assert [m["event_id"] for m in matches] == [0]
+
+
+def test_signal_index_drops_stale_entries_on_rerun(tmp_path: Path) -> None:
+    """Re-running a batch with different/no injections must not leave stale id rows."""
+    # First run: batch 0 injects events 0 and 1.
+    meta_a = {
+        "signal": {
+            "injections": [
+                {"event_id": 0, "parameters": {"coa_time": 100.0}},
+                {"event_id": 1, "parameters": {"coa_time": 101.0}},
+            ]
+        },
+        "outputs": [{"kind": "signal", "path": "signal/signal-0.gwf"}],
+    }
+    update_signal_index(tmp_path, meta_a, "orchestration-0.metadata.json")
+    assert set(yaml.safe_load((tmp_path / "signal_index.yaml").read_text())) == {"0", "1"}
+
+    # Re-run the same batch, now injecting only event 0. Event 1's stale row must go.
+    meta_b = {
+        "signal": {"injections": [{"event_id": 0, "parameters": {"coa_time": 100.0}}]},
+        "outputs": [{"kind": "signal", "path": "signal/signal-0.gwf"}],
+    }
+    update_signal_index(tmp_path, meta_b, "orchestration-0.metadata.json")
+    index = yaml.safe_load((tmp_path / "signal_index.yaml").read_text())
+    assert set(index) == {"0"}
+    assert find_signals(tmp_path, event_id=1) == []
+
+
+def test_signal_index_clears_entries_when_batch_reruns_with_no_injections(tmp_path: Path) -> None:
+    """A batch that previously injected but now injects nothing clears its rows."""
+    meta = {
+        "signal": {"injections": [{"event_id": 5, "parameters": {"coa_time": 1.0}}]},
+        "outputs": [{"kind": "signal", "path": "signal/signal-0.gwf"}],
+    }
+    update_signal_index(tmp_path, meta, "orchestration-0.metadata.json")
+    assert "5" in yaml.safe_load((tmp_path / "signal_index.yaml").read_text())
+
+    empty = {"signal": {"injections": []}, "outputs": []}
+    update_signal_index(tmp_path, empty, "orchestration-0.metadata.json")
+    assert yaml.safe_load((tmp_path / "signal_index.yaml").read_text()) == {}
+
+
+def test_equality_filter_uses_tolerance(tmp_path: Path) -> None:
+    """Numeric == tolerates representation noise; != is its complement."""
+    _write_batch(
+        tmp_path,
+        0,
+        [{"event_id": 0, "parameters": {"mass_1": 30.0}}],
+        ["signal/signal-0.gwf"],
+    )
+    # Stored 30.0 vs a query value differing only by float noise still matches ==.
+    assert [m["event_id"] for m in find_signals(tmp_path, param_filters=[("mass_1", "==", 30.0 + 1e-12)])] == [0]
+    assert find_signals(tmp_path, param_filters=[("mass_1", "!=", 30.0 + 1e-12)]) == []
+
+
+def test_find_id_and_param_combined(metadata_dir: Path) -> None:
+    # event 0's mass is 30, so an id=0 + mass>=31 filter matches nothing.
+    assert find_signals(metadata_dir, event_id=0, param_filters=[parse_param_filter("detector_frame_mass_1>=31")]) == []
+
+
+# --- CLI -------------------------------------------------------------------- #
+
+
+def test_cli_find_signal_by_id(metadata_dir: Path) -> None:
+    result = runner.invoke(app, ["find-signal", "--metadata-dir", str(metadata_dir), "--id", "0"])
+    assert result.exit_code == 0
+    assert "signal/signal-0.gwf" in result.stdout
+    assert "event 0" in result.stdout
+
+
+def test_cli_find_signal_by_param_json(metadata_dir: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["find-signal", "--metadata-dir", str(metadata_dir), "--param", "detector_frame_mass_1>=31", "--json"],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert [m["event_id"] for m in payload] == [1]
+
+
+def test_cli_find_signal_requires_a_query(metadata_dir: Path) -> None:
+    result = runner.invoke(app, ["find-signal", "--metadata-dir", str(metadata_dir)])
+    assert result.exit_code != 0
+
+
+def test_cli_find_signal_no_match_exits_nonzero(metadata_dir: Path) -> None:
+    result = runner.invoke(app, ["find-signal", "--metadata-dir", str(metadata_dir), "--id", "99"])
+    assert result.exit_code == 1
+    assert "No matching signals" in result.stdout

--- a/tests/cli/utils/test_metadata.py
+++ b/tests/cli/utils/test_metadata.py
@@ -59,7 +59,7 @@ def test_metadata_record_uses_versioned_json_schema(tmp_path: Path) -> None:
     metadata_path = tmp_path / "metadata" / "mock-0.metadata.json"
     record = load_metadata_record(metadata_path)
 
-    assert record.schema_version == "1.1.0"
+    assert record.schema_version == "1.2.0"
     assert record.config_sha256 == compute_file_hash(config_file)
     assert record.seed == 42
     assert record.outputs[0].path == "output/data.json"


### PR DESCRIPTION
## Summary

Fixes #12. Signal source parameters were never persisted, and there was no way
to find which frame file contains a given signal.

- **Record injections** — `AdapterOrchestrator` tracks the signals that merge in
  each batch (`event_id` = population index + full source-parameter dict) and
  writes them to the batch metadata under `signal.injections` (new
  `SignalSection` field; `SCHEMA_VERSION` 1.1.0 → 1.2.0). An event is attributed
  to the frame its `coa_time` falls in; content extending into adjacent frames is
  not cross-listed. Stationary/SGWB segments record an empty list.
- **Signal index** — each run writes `signal_index.yaml` mapping `event_id` →
  containing frame file(s); rebuilt per batch so re-runs/overwrites cannot leave
  stale rows.
- **Lookup** — new `find_signals()` util and `gwmock find-signal` CLI resolve a
  signal by `--id` (fast path) and/or `--param key OP value` predicates (numeric
  `==`/`!=` use a tolerance; ordering ops exact), with `--json`.

## Testing

- New `tests/cli/test_signal_lookup.py` (19 tests) + an end-to-end orchestration
  test asserting per-frame injections, `signal_index.yaml`, and lookup by id and
  by parameter.
- Full suite: 713 passed, 23 skipped. Ruff clean.
- Reviewed by a second agent: 2 HIGH (stale index; cross-frame attribution) + 2
  LOW — stale-index and float-equality fixed; cross-frame attribution resolved by
  the documented merges-in-frame semantic; id-stability wording clarified.

## Note

Consumers must still reject unknown *major* schema versions; the added field is
a backward-compatible minor bump (1.1.0 → 1.2.0).

Fixes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `find-signal` to locate simulated signal frames by event ID or parameter filters.
  * Added human-readable and JSON output, with clear handling when no matches are found.
  * Simulation metadata now records signal injection details and supports signal-to-frame lookup.

* **Documentation**
  * Updated reproducibility guidance for schema version 1.2.0, signal injections, frame attribution, filtering, and lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->