### PR TITLE
feat(reproducibility): recreate the recorded environment on --isolate

### DIFF
--- a/docs/user-guide/reproducibility.md
+++ b/docs/user-guide/reproducibility.md
@@ -5,12 +5,12 @@
 
 ## Schema
 
-Each record is validated at write time and uses schema version `1.2.0`.
+Each record is validated at write time and uses schema version `1.3.0`.
 Consumers must reject unknown major versions.
 
 ```json
 {
-    "schema_version": "1.2.0",
+    "schema_version": "1.3.0",
     "gwmock_version": "x.y.z",
     "subpackage_versions": {
         "gwmock_signal": "x.y.z",
@@ -62,6 +62,11 @@ Consumers must reject unknown major versions.
         "python": "3.12.x",
         "cpu": "...",
         "git_sha": "..."
+    },
+    "environment": {
+        "python": "3.12.5",
+        "python_implementation": "CPython",
+        "packages": { "numpy": "2.0.0", "gwmock": "x.y.z", "...": "..." }
     }
 }
 ```
@@ -97,8 +102,39 @@ index in the population as ordered for the run (by `coa_time` under the default
 ordering), so it is stable for a fixed configuration. Stationary/SGWB segments
 have no discrete events and record an empty list.
 
+`environment` is a full freeze of the environment that produced the run — the
+Python version and the version of every installed distribution (direct and
+transitive) — recorded so the run can be reproduced against exactly those
+dependencies. It is `null` for records written before this field existed.
+
 For the config shape that feeds this record, see
 [Orchestration](orchestration.md) and [Protocol Contracts](protocols.md).
+
+## Exact-dependency reproduction (`--isolate`)
+
+By default, reproducing from metadata runs in your current environment and warns
+if the recorded package versions differ. For bit-for-bit reproduction against
+the exact dependencies of the original run, add `--isolate`:
+
+```bash
+gwmock simulate metadata/ --isolate
+```
+
+This reads the recorded `environment` freeze, builds a cached, isolated
+[uv](https://docs.astral.sh/uv/) virtualenv pinned to those versions (matching
+the recorded Python `major.minor`), and re-runs the reproduction inside it. If
+the current environment already matches, it runs in place; if no environment was
+recorded (older metadata), it warns and runs in place.
+
+Requirements and limits:
+
+- `uv` must be installed, and the recorded package versions must be resolvable
+  from your package index — a run made with editable/dev installs (versions not
+  published to an index) cannot be recreated this way and will fail loudly
+  rather than run in the wrong environment.
+- Environments are cached under `~/.cache/gwmock/reproduction-envs` (override
+  with `GWMOCK_ENV_CACHE`) and keyed by the version set, so repeated
+  reproductions of the same run skip reinstalling.
 
 ## Finding which frame contains a signal
 

--- a/src/gwmock/cli/simulate.py
+++ b/src/gwmock/cli/simulate.py
@@ -10,6 +10,111 @@ from typing import Annotated
 import typer
 
 
+def _resolve_recorded_environment(config_file_names_list: list[str]) -> dict | None:
+    """Return the single environment freeze recorded across the given metadata.
+
+    Globs JSON and YAML metadata for directories and parses either form. Returns
+    ``None`` when no metadata records an environment. Raises ``ValueError`` when
+    the metadata span more than one distinct environment, since a single
+    isolated environment cannot reproduce them all.
+    """
+    import yaml  # pylint: disable=import-outside-toplevel
+    from pathlib import Path  # pylint: disable=import-outside-toplevel
+
+    from gwmock.cli.utils.environment import environment_key  # pylint: disable=import-outside-toplevel
+
+    candidates: list[Path] = []
+    for name in config_file_names_list:
+        path = Path(name)
+        if path.is_dir():
+            candidates.extend(sorted(path.glob("*.metadata.json")) + sorted(path.glob("*.metadata.yaml")))
+        else:
+            candidates.append(path)
+
+    environments: dict[str, dict] = {}
+    for candidate in candidates:
+        try:
+            with candidate.open(encoding="utf-8") as handle:
+                metadata = yaml.safe_load(handle)  # also parses JSON
+        except (OSError, yaml.YAMLError):
+            continue
+        if not isinstance(metadata, dict):
+            continue
+        environment = metadata.get("environment")
+        if environment:
+            environments[environment_key(environment)] = environment
+
+    if len(environments) > 1:
+        raise ValueError(
+            "The provided metadata span multiple recorded environments; "
+            "reproduce each environment's metadata separately with --isolate."
+        )
+    return next(iter(environments.values()), None)
+
+
+def _maybe_isolate(
+    config_file_names_list: list[str],
+    *,
+    isolate: bool,
+    output_dir: str | None,
+    overwrite: bool,
+    author: str | None,
+    email: str | None,
+    dry_run: bool = False,
+) -> None:
+    """Recreate the recorded environment and re-run inside it when it differs.
+
+    No-op unless ``--isolate`` is set and we are not already the re-executed
+    child. Runs in place (with a note) when no environment was recorded or the
+    current one already matches. Otherwise builds the isolated environment,
+    re-runs the reproduction there, and exits with the child's status.
+    """
+    import logging  # pylint: disable=import-outside-toplevel
+    import os  # pylint: disable=import-outside-toplevel
+
+    import typer  # pylint: disable=import-outside-toplevel
+
+    from gwmock.cli.utils.environment import (  # pylint: disable=import-outside-toplevel
+        ISOLATION_ENV_VAR,
+        capture_environment,
+        environments_match,
+        reproduce_in_isolated_environment,
+    )
+
+    logger = logging.getLogger("gwmock")
+    if not isolate or os.environ.get(ISOLATION_ENV_VAR):
+        return
+
+    try:
+        recorded = _resolve_recorded_environment(config_file_names_list)
+    except ValueError as error:
+        raise typer.BadParameter(str(error)) from error
+    if recorded is None:
+        logger.warning(
+            "--isolate: the metadata records no environment freeze (older run); running in the current environment."
+        )
+        return
+    if environments_match(recorded, capture_environment()):
+        logger.info("--isolate: current environment already matches the recorded one; running in place.")
+        return
+
+    child_args = ["simulate", *config_file_names_list]
+    if output_dir:
+        child_args += ["--output-dir", output_dir]
+    if overwrite:
+        child_args.append("--overwrite")
+    if author:
+        child_args += ["--author", author]
+    if email:
+        child_args += ["--email", email]
+    if dry_run:
+        child_args.append("--dry-run")
+
+    logger.info("--isolate: recreating the recorded environment and re-running the reproduction inside it.")
+    exit_code = reproduce_in_isolated_environment(recorded, child_args)
+    raise typer.Exit(exit_code)
+
+
 def _simulate_impl(  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
     config_file_names: str | list[str],
     output_dir: str | None = None,
@@ -19,6 +124,7 @@ def _simulate_impl(  # pylint: disable=too-many-locals, too-many-branches, too-m
     author: str | None = None,
     email: str | None = None,
     dry_run: bool = False,
+    isolate: bool = False,
 ) -> None:
     """Internal implementation of simulate command that accepts both str and list[str].
 
@@ -84,6 +190,18 @@ def _simulate_impl(  # pylint: disable=too-many-locals, too-many-branches, too-m
         # ===== Create plan (unified approach: both modes create same data structure) =====
         if is_metadata:
             logger.info("Reproduction mode: %d metadata file(s)", len(config_file_names_list))
+
+            # Optionally recreate the recorded environment and re-run inside it
+            # before doing any work in the (possibly mismatched) current one.
+            _maybe_isolate(
+                config_file_names_list,
+                isolate=isolate,
+                output_dir=output_dir,
+                overwrite=overwrite,
+                author=author,
+                email=email,
+                dry_run=dry_run,
+            )
 
             metadata_paths = [Path(f) for f in config_file_names_list]
 
@@ -197,6 +315,14 @@ def simulate_command(
     author: Annotated[str | None, typer.Option("--author", help="Author name for the simulation.")] = None,
     email: Annotated[str | None, typer.Option("--email", help="Author email for the simulation.")] = None,
     dry_run: Annotated[bool, typer.Option("--dry-run", help="Validate the plan without executing.")] = False,
+    isolate: Annotated[
+        bool,
+        typer.Option(
+            "--isolate",
+            help="Reproduction mode: recreate the metadata's recorded environment in an "
+            "isolated (uv) virtualenv and re-run inside it for exact-dependency reproducibility.",
+        ),
+    ] = False,
 ) -> None:
     """Generate gravitational wave simulation data using specified simulators.
 
@@ -241,4 +367,5 @@ def simulate_command(
         author=author,
         email=email,
         dry_run=dry_run,
+        isolate=isolate,
     )

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -28,6 +28,7 @@ from tqdm import tqdm
 from gwmock.cli.adapter_orchestration import AdapterOrchestrationResult, AdapterOrchestrator
 from gwmock.cli.utils.checkpoint import CheckpointManager
 from gwmock.cli.utils.config import OrchestrationConfig, SimulatorConfig, resolve_class_path
+from gwmock.cli.utils.environment import capture_environment
 from gwmock.cli.utils.hash import compute_content_hash, compute_file_hash
 from gwmock.cli.utils.metadata import save_metadata_record
 from gwmock.cli.utils.simulation_plan import (
@@ -807,6 +808,7 @@ def save_batch_metadata(
         noise=_build_noise_section(simulator, batch),
         outputs=_build_output_records(simulator, batch, batch_data, output_files),
         host=_get_host_metadata(),
+        environment=capture_environment(),
     )
 
     # Add output files to metadata for easy discovery

--- a/src/gwmock/cli/utils/environment.py
+++ b/src/gwmock/cli/utils/environment.py
@@ -14,6 +14,7 @@ import importlib.metadata
 import logging
 import os
 import platform
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -52,10 +53,32 @@ def capture_environment() -> dict[str, Any]:
     }
 
 
+# A recorded pin must be a plain distribution name and version — never an
+# option like ``--index-url``. Metadata files are shared for reproduction, so
+# their contents are untrusted input that ends up as `uv pip install` arguments.
+_DIST_NAME_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$")
+_VERSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+!-]*$")
+
+
 def environment_requirements(snapshot: dict[str, Any]) -> list[str]:
-    """Return sorted ``name==version`` requirement strings for a snapshot."""
+    """Return sorted, validated ``name==version`` requirement strings for a snapshot.
+
+    Every package name and version is checked against strict distribution-name
+    and version syntax; a pin that does not match (e.g. an option-shaped key such
+    as ``--index-url``) raises ``ValueError`` rather than being forwarded to the
+    installer, so a tampered metadata file cannot inject installer options.
+    """
     packages = snapshot.get("packages") or {}
-    return [f"{name}=={version}" for name, version in sorted(packages.items())]
+    requirements: list[str] = []
+    for name, version in sorted(packages.items()):
+        if not (isinstance(name, str) and _DIST_NAME_RE.match(name)):
+            raise ValueError(f"Refusing to reproduce: invalid package name {name!r} in recorded environment.")
+        if not (isinstance(version, str) and _VERSION_RE.match(version)):
+            raise ValueError(
+                f"Refusing to reproduce: invalid version {version!r} for package {name!r} in recorded environment."
+            )
+        requirements.append(f"{name}=={version}")
+    return requirements
 
 
 def diff_environment(recorded: dict[str, Any], installed: dict[str, Any]) -> list[tuple[str, str, str | None]]:
@@ -164,8 +187,10 @@ def build_isolated_environment(
         requirements = environment_requirements(snapshot)
         if requirements:
             logger.info("Installing %d recorded package versions into the reproduction environment", len(requirements))
+            # The trailing "--" makes uv treat every requirement as a positional
+            # package spec, never an option, as a second guard against injection.
             subprocess.run(  # noqa: S603
-                [uv_executable, "pip", "install", "--python", str(python_bin), *requirements], check=True
+                [uv_executable, "pip", "install", "--python", str(python_bin), "--", *requirements], check=True
             )
 
         marker.write_text("ready\n")

--- a/src/gwmock/cli/utils/environment.py
+++ b/src/gwmock/cli/utils/environment.py
@@ -1,0 +1,194 @@
+"""Capture, compare, and recreate the software environment of a run.
+
+Reproducing a simulation bit-for-bit requires the same dependency versions.
+These helpers record a full environment freeze into metadata and, on request,
+rebuild that environment in an isolated, cached uv virtualenv so a reproduction
+can re-execute against the exact dependencies the original run used.
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import importlib.metadata
+import logging
+import os
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from filelock import FileLock
+
+logger = logging.getLogger("gwmock")
+
+#: Set in the child process so a recreated environment never re-isolates.
+ISOLATION_ENV_VAR = "GWMOCK_ISOLATED"
+#: Overrides the default cache location for recreated environments.
+CACHE_ENV_VAR = "GWMOCK_ENV_CACHE"
+
+
+@functools.lru_cache(maxsize=1)
+def capture_environment() -> dict[str, Any]:
+    """Return a freeze of the active environment: Python version and every dist.
+
+    Cached because the environment does not change during a run, so per-batch
+    metadata writes reuse a single scan of the installed distributions.
+    """
+    packages: dict[str, str] = {}
+    for dist in importlib.metadata.distributions():
+        name = dist.metadata["Name"]
+        if not name:
+            continue
+        version = dist.version
+        # Distributions are keyed case-insensitively; keep the first seen version
+        # and normalise the name to its canonical (lower) form for stable diffs.
+        packages.setdefault(name.lower(), version)
+    return {
+        "python": platform.python_version(),
+        "python_implementation": platform.python_implementation(),
+        "packages": dict(sorted(packages.items())),
+    }
+
+
+def environment_requirements(snapshot: dict[str, Any]) -> list[str]:
+    """Return sorted ``name==version`` requirement strings for a snapshot."""
+    packages = snapshot.get("packages") or {}
+    return [f"{name}=={version}" for name, version in sorted(packages.items())]
+
+
+def diff_environment(recorded: dict[str, Any], installed: dict[str, Any]) -> list[tuple[str, str, str | None]]:
+    """Return ``(package, recorded_version, installed_version)`` for every mismatch.
+
+    A package recorded but absent from the installed environment yields an
+    installed version of ``None``. Packages only present in the installed
+    environment are ignored: they cannot have influenced the recorded run.
+    """
+    recorded_packages = recorded.get("packages") or {}
+    installed_packages = installed.get("packages") or {}
+    mismatches: list[tuple[str, str, str | None]] = []
+    for name, recorded_version in sorted(recorded_packages.items()):
+        installed_version = installed_packages.get(name)
+        if installed_version != recorded_version:
+            mismatches.append((name, recorded_version, installed_version))
+    return mismatches
+
+
+def environments_match(recorded: dict[str, Any], installed: dict[str, Any]) -> bool:
+    """Return whether the installed environment is identical to the recorded freeze.
+
+    Requires the exact same package set — same names and versions, and no extra
+    installed packages, since extras can change optional imports, plugin/backend
+    resolution, or entry points — plus the same Python ``major.minor``. (The
+    laxer :func:`diff_environment`, which ignores installed-only extras, backs
+    the advisory drift warning, not this exact-reproduction gate.)
+    """
+    if (recorded.get("packages") or {}) != (installed.get("packages") or {}):
+        return False
+    return _python_minor(recorded.get("python")) == _python_minor(installed.get("python"))
+
+
+def _python_minor(version: str | None) -> str | None:
+    """Return the ``major.minor`` prefix of a Python version string."""
+    if not version:
+        return None
+    return ".".join(version.split(".")[:2])
+
+
+def environment_key(snapshot: dict[str, Any]) -> str:
+    """Return a stable short hash identifying a recreatable environment.
+
+    Keyed by the Python ``major.minor`` plus the full sorted requirement set, so
+    two runs with the same dependencies reuse one cached virtualenv.
+    """
+    payload = "\n".join([_python_minor(snapshot.get("python")) or "", *environment_requirements(snapshot)])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def default_cache_root() -> Path:
+    """Return the directory under which recreated environments are cached."""
+    override = os.environ.get(CACHE_ENV_VAR)
+    if override:
+        return Path(override)
+    return Path.home() / ".cache" / "gwmock" / "reproduction-envs"
+
+
+def build_isolated_environment(
+    snapshot: dict[str, Any],
+    cache_root: Path | None = None,
+    *,
+    uv_executable: str | None = None,
+) -> Path:
+    """Create (or reuse) a cached uv virtualenv pinned to ``snapshot``.
+
+    The env is keyed by :func:`environment_key`, so repeated reproductions of the
+    same run reuse it. Returns the path to the environment's Python interpreter.
+    Raises ``RuntimeError`` if uv is unavailable and ``CalledProcessError`` if
+    provisioning or installing the recorded versions fails (e.g. a dev/editable
+    version that is not published to an index).
+    """
+    cache_root = Path(cache_root) if cache_root is not None else default_cache_root()
+    uv_executable = uv_executable or shutil.which("uv")
+    if uv_executable is None:
+        raise RuntimeError(
+            "uv is required to build an isolated reproduction environment. "
+            "Install uv (https://docs.astral.sh/uv/) or rerun without --isolate."
+        )
+
+    key = environment_key(snapshot)
+    env_dir = cache_root / key
+    python_bin = env_dir / "bin" / "python"
+    marker = env_dir / ".gwmock-ready"
+    if marker.exists() and python_bin.exists():
+        logger.info("Reusing cached reproduction environment at %s", env_dir)
+        return python_bin
+
+    cache_root.mkdir(parents=True, exist_ok=True)
+    # Serialize concurrent builds of the same environment (e.g. parallel
+    # reproductions of one run) so they cannot rmtree/install over each other.
+    with FileLock(str(cache_root / f"{key}.lock")):
+        if marker.exists() and python_bin.exists():  # another process built it while we waited
+            logger.info("Reusing cached reproduction environment at %s", env_dir)
+            return python_bin
+        if env_dir.exists():
+            shutil.rmtree(env_dir)  # remove a partial build
+
+        venv_command = [uv_executable, "venv", str(env_dir)]
+        python_minor = _python_minor(snapshot.get("python"))
+        if python_minor:
+            venv_command += ["--python", python_minor]
+        logger.info("Creating reproduction environment (python %s) at %s", python_minor or "current", env_dir)
+        subprocess.run(venv_command, check=True)  # noqa: S603
+
+        requirements = environment_requirements(snapshot)
+        if requirements:
+            logger.info("Installing %d recorded package versions into the reproduction environment", len(requirements))
+            subprocess.run(  # noqa: S603
+                [uv_executable, "pip", "install", "--python", str(python_bin), *requirements], check=True
+            )
+
+        marker.write_text("ready\n")
+    return python_bin
+
+
+def reproduce_in_isolated_environment(
+    snapshot: dict[str, Any],
+    argv: list[str],
+    cache_root: Path | None = None,
+) -> int:
+    """Recreate the recorded environment and re-run ``gwmock`` inside it.
+
+    ``argv`` is the original ``gwmock`` argument vector (``sys.argv[1:]``); the
+    ``--isolate`` flag is stripped so the child does not attempt to isolate
+    again, and ``ISOLATION_ENV_VAR`` is set as a second guard. Returns the child
+    process's exit code.
+    """
+    python_bin = build_isolated_environment(snapshot, cache_root)
+    child_gwmock = python_bin.parent / "gwmock"
+    command = [str(child_gwmock), *[argument for argument in argv if argument != "--isolate"]]
+    child_env = dict(os.environ)
+    child_env[ISOLATION_ENV_VAR] = "1"
+    logger.info("Re-running reproduction in the isolated environment: %s", " ".join(command))
+    completed = subprocess.run(command, env=child_env, check=False)  # noqa: S603
+    return completed.returncode

--- a/src/gwmock/cli/utils/metadata.py
+++ b/src/gwmock/cli/utils/metadata.py
@@ -11,7 +11,7 @@ import numpy as np
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-SCHEMA_VERSION = "1.2.0"
+SCHEMA_VERSION = "1.3.0"
 _SCHEMA_VERSION_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
 
@@ -93,6 +93,10 @@ class MetadataRecord(BaseModel):
     noise: NoiseSection | None = None
     outputs: list[OutputRecord] = Field(default_factory=list)
     host: HostRecord
+    # Full environment freeze (Python version + every installed distribution's
+    # version) enabling exact-dependency reproduction into an isolated venv.
+    # Null for records written before this field existed.
+    environment: dict[str, Any] | None = None
 
     model_config = ConfigDict(extra="allow")
 

--- a/src/gwmock/cli/utils/simulation_plan.py
+++ b/src/gwmock/cli/utils/simulation_plan.py
@@ -255,6 +255,7 @@ def create_batch_metadata(  # noqa: PLR0913
     noise: dict[str, Any] | None = None,
     outputs: list[dict[str, Any]] | None = None,
     host: dict[str, Any] | None = None,
+    environment: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Create metadata for a simulation batch.
 
@@ -328,6 +329,7 @@ def create_batch_metadata(  # noqa: PLR0913
             "cpu": "unknown",
             "git_sha": None,
         },
+        "environment": environment,
         # Compatibility fields kept while CLI reproduction still consumes them.
         "simulator_name": simulator_name,
         "batch_index": batch_index,
@@ -508,12 +510,38 @@ def create_plan_from_metadata_files(
         plan.add_batch(batch)
 
     _warn_version_mismatches(plan.batches, get_dependency_versions())
+    _warn_environment_drift(plan.batches)
 
     logger.info(
         "Created simulation plan from %d metadata files",
         len(metadata_files),
     )
     return plan
+
+
+def _warn_environment_drift(batches: list[SimulationBatch]) -> None:
+    """Warn once if the current environment differs from the recorded freeze.
+
+    Points the user at ``--isolate`` for exact-dependency reproduction. Uses the
+    first batch that recorded a full environment; older metadata without one is
+    skipped (the coarser gwmock-family check above still applies).
+    """
+    from gwmock.cli.utils.environment import capture_environment, diff_environment  # noqa: PLC0415
+
+    for batch in batches:
+        recorded = (batch.batch_metadata or {}).get("environment")
+        if not recorded:
+            continue
+        mismatches = diff_environment(recorded, capture_environment())
+        if mismatches:
+            examples = ", ".join(name for name, _, _ in mismatches[:3])
+            logger.warning(
+                "%d package(s) differ from the environment recorded in the metadata (e.g. %s). "
+                "Re-run with 'gwmock simulate --isolate' to reproduce against the exact recorded dependencies.",
+                len(mismatches),
+                examples,
+            )
+        return
 
 
 def _warn_version_mismatches(

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -313,12 +313,15 @@ def test_simulate_command_runs_adapter_orchestration(monkeypatch, tmp_path: Path
     assert (tmp_path / "output" / "signal" / "signal-1.gwf").exists()
     _assert_noise_outputs_exist(tmp_path / "output" / "noise")
     metadata = yaml.safe_load((tmp_path / "metadata" / "orchestration-0.metadata.json").read_text())
-    assert metadata["schema_version"] == "1.2.0"
+    assert metadata["schema_version"] == "1.3.0"
     assert metadata["config"]["orchestration"]["population"]["backend"] == FAKE_POPULATION_BACKEND
     assert metadata["config"]["orchestration"]["signal"]["backend"] == FAKE_SIGNAL_BACKEND
     assert metadata["config"]["orchestration"]["noise"]["backend"] == FAKE_NOISE_BACKEND
     assert metadata["population"]["source_type"] == source_type
     assert metadata["signal"]["detector_network"] == ["H1"]
+    # Full environment freeze is recorded for exact-dependency reproduction (#11).
+    assert metadata["environment"]["packages"]["gwmock"]
+    assert metadata["environment"]["python"].count(".") >= 2
     assert {output["kind"] for output in metadata["outputs"]} == {"signal", "noise"}
     assert metadata["segment_seeds"] == [derive_seed(7, "signal", 0)]
     assert metadata["simulator_config"]["population"]["backend"] == FAKE_POPULATION_BACKEND

--- a/tests/cli/test_simulate_isolate.py
+++ b/tests/cli/test_simulate_isolate.py
@@ -1,0 +1,142 @@
+"""Tests for --isolate reproduction wiring in the simulate command (issue #11)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+import typer
+import yaml
+
+from gwmock.cli import simulate as simulate_mod
+from gwmock.cli.simulate import _maybe_isolate, _resolve_recorded_environment
+
+
+def _write_metadata(path: Path, name: str, environment: dict | None) -> None:
+    payload: dict = {"schema_version": "1.3.0"}
+    if environment is not None:
+        payload["environment"] = environment
+    text = yaml.safe_dump(payload) if name.endswith(".yaml") else json.dumps(payload)
+    (path / name).write_text(text)
+
+
+def test_resolve_recorded_environment_finds_first_available(tmp_path: Path) -> None:
+    _write_metadata(tmp_path, "orchestration-0.metadata.json", None)
+    _write_metadata(tmp_path, "orchestration-1.metadata.json", {"python": "3.12.5", "packages": {"numpy": "2.0.0"}})
+    assert _resolve_recorded_environment([str(tmp_path)]) == {"python": "3.12.5", "packages": {"numpy": "2.0.0"}}
+
+
+def test_resolve_recorded_environment_reads_yaml_metadata(tmp_path: Path) -> None:
+    env = {"python": "3.12.5", "packages": {"numpy": "2.0.0"}}
+    _write_metadata(tmp_path, "orchestration-0.metadata.yaml", env)
+    assert _resolve_recorded_environment([str(tmp_path)]) == env
+
+
+def test_resolve_recorded_environment_none_when_absent(tmp_path: Path) -> None:
+    _write_metadata(tmp_path, "orchestration-0.metadata.json", None)
+    assert _resolve_recorded_environment([str(tmp_path)]) is None
+
+
+def test_resolve_recorded_environment_rejects_mixed_environments(tmp_path: Path) -> None:
+    _write_metadata(tmp_path, "orchestration-0.metadata.json", {"python": "3.12.5", "packages": {"numpy": "2.0.0"}})
+    _write_metadata(tmp_path, "orchestration-1.metadata.json", {"python": "3.12.5", "packages": {"numpy": "1.26.0"}})
+    with pytest.raises(ValueError, match="multiple recorded environments"):
+        _resolve_recorded_environment([str(tmp_path)])
+
+
+def test_maybe_isolate_noop_without_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {"n": 0}
+    monkeypatch.setattr(
+        "gwmock.cli.utils.environment.reproduce_in_isolated_environment",
+        lambda *a, **k: called.__setitem__("n", called["n"] + 1),
+    )
+    _maybe_isolate([str(tmp_path)], isolate=False, output_dir=None, overwrite=False, author=None, email=None)
+    assert called["n"] == 0
+
+
+def test_maybe_isolate_noop_when_already_isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GWMOCK_ISOLATED", "1")
+    called = {"n": 0}
+    monkeypatch.setattr(
+        "gwmock.cli.utils.environment.reproduce_in_isolated_environment",
+        lambda *a, **k: called.__setitem__("n", called["n"] + 1),
+    )
+    _maybe_isolate([str(tmp_path)], isolate=True, output_dir=None, overwrite=False, author=None, email=None)
+    assert called["n"] == 0
+
+
+def test_maybe_isolate_warns_when_no_environment_recorded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.delenv("GWMOCK_ISOLATED", raising=False)
+    _write_metadata(tmp_path, "orchestration-0.metadata.json", None)
+    with caplog.at_level(logging.WARNING, logger="gwmock"):
+        _maybe_isolate([str(tmp_path)], isolate=True, output_dir=None, overwrite=False, author=None, email=None)
+    assert "no environment freeze" in caplog.text
+
+
+def test_maybe_isolate_runs_in_place_when_matching(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GWMOCK_ISOLATED", raising=False)
+    env = {"python": "3.12.5", "packages": {"numpy": "2.0.0"}}
+    _write_metadata(tmp_path, "orchestration-0.metadata.json", env)
+    monkeypatch.setattr("gwmock.cli.utils.environment.capture_environment", lambda: env)
+    called = {"n": 0}
+    monkeypatch.setattr(
+        "gwmock.cli.utils.environment.reproduce_in_isolated_environment",
+        lambda *a, **k: called.__setitem__("n", called["n"] + 1),
+    )
+    _maybe_isolate([str(tmp_path)], isolate=True, output_dir=None, overwrite=False, author=None, email=None)
+    assert called["n"] == 0  # matching env: no re-exec
+
+
+def test_maybe_isolate_reexecs_on_mismatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GWMOCK_ISOLATED", raising=False)
+    recorded = {"python": "3.12.5", "packages": {"numpy": "2.0.0"}}
+    _write_metadata(tmp_path, "orchestration-0.metadata.json", recorded)
+    monkeypatch.setattr(
+        "gwmock.cli.utils.environment.capture_environment",
+        lambda: {"python": "3.12.5", "packages": {"numpy": "1.26.0"}},
+    )
+    captured: dict = {}
+
+    def fake_reproduce(snapshot, argv, cache_root=None):
+        captured["snapshot"] = snapshot
+        captured["argv"] = argv
+        return 3
+
+    monkeypatch.setattr("gwmock.cli.utils.environment.reproduce_in_isolated_environment", fake_reproduce)
+
+    with pytest.raises(typer.Exit) as exc:
+        _maybe_isolate([str(tmp_path)], isolate=True, output_dir="out", overwrite=True, author="A", email=None)
+
+    assert exc.value.exit_code == 3
+    assert captured["snapshot"] == recorded
+    assert captured["argv"] == ["simulate", str(tmp_path), "--output-dir", "out", "--overwrite", "--author", "A"]
+
+
+def test_maybe_isolate_propagates_dry_run_to_child(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A --dry-run reproduction must stay a dry run inside the isolated environment."""
+    monkeypatch.delenv("GWMOCK_ISOLATED", raising=False)
+    recorded = {"python": "3.12.5", "packages": {"numpy": "2.0.0"}}
+    _write_metadata(tmp_path, "orchestration-0.metadata.json", recorded)
+    monkeypatch.setattr(
+        "gwmock.cli.utils.environment.capture_environment",
+        lambda: {"python": "3.12.5", "packages": {"numpy": "1.26.0"}},
+    )
+    captured: dict = {}
+    monkeypatch.setattr(
+        "gwmock.cli.utils.environment.reproduce_in_isolated_environment",
+        lambda snapshot, argv, cache_root=None: captured.setdefault("argv", argv) or 0,
+    )
+    with pytest.raises(typer.Exit):
+        _maybe_isolate(
+            [str(tmp_path)], isolate=True, output_dir=None, overwrite=False, author=None, email=None, dry_run=True
+        )
+    assert "--dry-run" in captured["argv"]
+
+
+def test_maybe_isolate_reads_module_symbols_live(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Guard: _maybe_isolate imports environment lazily, so monkeypatching works."""
+    assert hasattr(simulate_mod, "_maybe_isolate")

--- a/tests/cli/utils/test_environment.py
+++ b/tests/cli/utils/test_environment.py
@@ -38,6 +38,17 @@ def test_environment_requirements_are_sorted_pins() -> None:
     assert reqs == ["astropy==6.1.0", "numpy==2.0.0"]
 
 
+def test_environment_requirements_reject_option_shaped_names() -> None:
+    """A tampered metadata pin that looks like an installer option is refused."""
+    with pytest.raises(ValueError, match="invalid package name"):
+        environment_requirements({"packages": {"--index-url": "http://evil.example"}})
+
+
+def test_environment_requirements_reject_bad_version() -> None:
+    with pytest.raises(ValueError, match="invalid version"):
+        environment_requirements({"packages": {"numpy": "2.0.0; rm -rf /"}})
+
+
 def test_diff_environment_reports_mismatch_and_missing_only() -> None:
     recorded = _snapshot(numpy="2.0.0", astropy="6.1.0")
     installed = _snapshot(numpy="1.26.0", scipy="1.14.0")  # numpy differs, astropy missing, scipy extra
@@ -89,6 +100,9 @@ def test_build_isolated_environment_creates_and_installs(tmp_path: Path, monkeyp
     install_call = next(c for c in calls if "install" in c)
     assert "numpy==2.0.0" in install_call
     assert "astropy==6.1.0" in install_call
+    # Pins follow a "--" so uv can never parse a pin as an option.
+    assert "--" in install_call
+    assert install_call.index("--") < install_call.index("numpy==2.0.0")
 
 
 def test_build_isolated_environment_reuses_cached(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/utils/test_environment.py
+++ b/tests/cli/utils/test_environment.py
@@ -1,0 +1,143 @@
+"""Tests for environment capture and isolated-environment recreation (issue #11)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gwmock.cli.utils import environment as env_mod
+from gwmock.cli.utils.environment import (
+    ISOLATION_ENV_VAR,
+    build_isolated_environment,
+    capture_environment,
+    diff_environment,
+    environment_key,
+    environment_requirements,
+    environments_match,
+    reproduce_in_isolated_environment,
+)
+
+
+def _snapshot(python: str = "3.12.5", **packages: str) -> dict:
+    return {"python": python, "packages": dict(packages)}
+
+
+# --- pure helpers ----------------------------------------------------------- #
+
+
+def test_capture_environment_includes_python_and_self() -> None:
+    env = capture_environment()
+    assert env["python"].count(".") >= 2
+    assert "gwmock" in env["packages"]
+
+
+def test_environment_requirements_are_sorted_pins() -> None:
+    reqs = environment_requirements(_snapshot(numpy="2.0.0", astropy="6.1.0"))
+    assert reqs == ["astropy==6.1.0", "numpy==2.0.0"]
+
+
+def test_diff_environment_reports_mismatch_and_missing_only() -> None:
+    recorded = _snapshot(numpy="2.0.0", astropy="6.1.0")
+    installed = _snapshot(numpy="1.26.0", scipy="1.14.0")  # numpy differs, astropy missing, scipy extra
+    diff = diff_environment(recorded, installed)
+    assert ("numpy", "2.0.0", "1.26.0") in diff
+    assert ("astropy", "6.1.0", None) in diff
+    assert all(name != "scipy" for name, _, _ in diff)  # extras ignored
+
+
+def test_environments_match_requires_versions_and_python_minor() -> None:
+    a = _snapshot("3.12.5", numpy="2.0.0")
+    assert environments_match(a, _snapshot("3.12.9", numpy="2.0.0"))  # patch differs, minor same
+    assert not environments_match(a, _snapshot("3.11.9", numpy="2.0.0"))  # minor differs
+    assert not environments_match(a, _snapshot("3.12.5", numpy="1.26.0"))  # package differs
+    # Extra installed packages break exactness (can change imports/plugins/entry points).
+    assert not environments_match(a, _snapshot("3.12.5", numpy="2.0.0", scipy="1.14.0"))
+
+
+def test_environment_key_is_stable_and_sensitive() -> None:
+    base = _snapshot("3.12.5", numpy="2.0.0")
+    assert environment_key(base) == environment_key(_snapshot("3.12.9", numpy="2.0.0"))  # patch ignored
+    assert environment_key(base) != environment_key(_snapshot("3.12.5", numpy="2.0.1"))
+    assert environment_key(base) != environment_key(_snapshot("3.11.5", numpy="2.0.0"))
+
+
+# --- build_isolated_environment --------------------------------------------- #
+
+
+def test_build_isolated_environment_creates_and_installs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command, check=False, **_kwargs):
+        calls.append(command)
+        if "venv" in command:  # materialise the interpreter the builder expects
+            env_dir = Path(command[command.index("venv") + 1])
+            (env_dir / "bin").mkdir(parents=True, exist_ok=True)
+            (env_dir / "bin" / "python").write_text("")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+    snapshot = _snapshot("3.12.5", numpy="2.0.0", astropy="6.1.0")
+
+    python_bin = build_isolated_environment(snapshot, cache_root=tmp_path, uv_executable="/usr/bin/uv")
+
+    assert python_bin.exists()
+    venv_call = next(c for c in calls if "venv" in c)
+    assert "--python" in venv_call
+    assert "3.12" in venv_call
+    install_call = next(c for c in calls if "install" in c)
+    assert "numpy==2.0.0" in install_call
+    assert "astropy==6.1.0" in install_call
+
+
+def test_build_isolated_environment_reuses_cached(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = {"n": 0}
+
+    def fake_run(command, check=False, **_kwargs):
+        runs["n"] += 1
+        if "venv" in command:
+            env_dir = Path(command[command.index("venv") + 1])
+            (env_dir / "bin").mkdir(parents=True, exist_ok=True)
+            (env_dir / "bin" / "python").write_text("")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+    snapshot = _snapshot("3.12.5", numpy="2.0.0")
+
+    build_isolated_environment(snapshot, cache_root=tmp_path, uv_executable="/usr/bin/uv")
+    runs_after_first = runs["n"]
+    build_isolated_environment(snapshot, cache_root=tmp_path, uv_executable="/usr/bin/uv")
+
+    assert runs["n"] == runs_after_first  # second call reused the cached env, ran nothing
+
+
+def test_build_isolated_environment_without_uv_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(env_mod.shutil, "which", lambda _name: None)
+    with pytest.raises(RuntimeError, match="uv is required"):
+        build_isolated_environment(_snapshot(), cache_root=tmp_path)
+
+
+# --- reproduce_in_isolated_environment -------------------------------------- #
+
+
+def test_reproduce_reexecs_child_with_guard(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    python_bin = tmp_path / "bin" / "python"
+    python_bin.parent.mkdir(parents=True)
+    python_bin.write_text("")
+    monkeypatch.setattr(env_mod, "build_isolated_environment", lambda *a, **k: python_bin)
+
+    captured: dict = {}
+
+    def fake_run(command, env=None, check=False, **_kwargs):
+        captured["command"] = command
+        captured["env"] = env
+        return SimpleNamespace(returncode=7)
+
+    monkeypatch.setattr(env_mod.subprocess, "run", fake_run)
+
+    code = reproduce_in_isolated_environment(_snapshot(), ["simulate", "metadata/", "--isolate", "--overwrite"])
+
+    assert code == 7
+    assert captured["command"] == [str(tmp_path / "bin" / "gwmock"), "simulate", "metadata/", "--overwrite"]
+    assert captured["env"][ISOLATION_ENV_VAR] == "1"

--- a/tests/cli/utils/test_metadata.py
+++ b/tests/cli/utils/test_metadata.py
@@ -59,7 +59,7 @@ def test_metadata_record_uses_versioned_json_schema(tmp_path: Path) -> None:
     metadata_path = tmp_path / "metadata" / "mock-0.metadata.json"
     record = load_metadata_record(metadata_path)
 
-    assert record.schema_version == "1.2.0"
+    assert record.schema_version == "1.3.0"
     assert record.config_sha256 == compute_file_hash(config_file)
     assert record.seed == 42
     assert record.outputs[0].path == "output/data.json"


### PR DESCRIPTION
## Summary

Fixes #11. Reproducing from metadata could silently run against different
dependency versions than the original run.

- **Record** a full environment freeze — Python version + every installed
  distribution (direct *and* transitive) — in each metadata record (new
  `environment` field; `SCHEMA_VERSION` 1.2.0 → 1.3.0).
- **`gwmock simulate <metadata> --isolate`** reads that freeze, builds a cached,
  isolated **uv** virtualenv pinned to it (matching the recorded Python
  `major.minor`, keyed by the version set so repeated reproductions reuse it),
  and re-execs the reproduction inside it. Runs in place if the current
  environment already matches **exactly** (extra installed packages count as a
  mismatch); warns + runs in place if no environment was recorded (older
  metadata). `--dry-run` is propagated to the isolated child.
- **Without `--isolate`**, reproduction warns when the recorded environment
  differs and points at `--isolate`.
- Concurrent builds of the same environment are serialized with a file lock. uv
  absence or unresolvable recorded versions **fail loudly** rather than run in
  the wrong environment.

## Testing

- New `tests/cli/utils/test_environment.py` (capture/diff/match/key/build/re-exec)
  and `tests/cli/test_simulate_isolate.py` (flag wiring, YAML/mixed metadata,
  match/mismatch, dry-run propagation).
- Full suite: 733 passed, 23 skipped. Ruff clean. End-to-end orchestration run
  asserts the freeze lands in written metadata.
- Reviewed by a second agent: 2 HIGH (dry-run dropped; extra-package match) + 2
  MED (YAML metadata ignored; mixed environments) fixed; build concurrency
  hardened with a file lock.

## Limitation

Recreation needs `uv` and the recorded versions must be resolvable from your
index; a run made with editable/dev installs cannot be recreated this way and
fails loudly rather than running in the wrong environment.

Fixes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--isolate` to reproduce simulations using the recorded Python and package environment.
  * Simulation metadata now records environment details for more precise reproducibility.
  * Added caching and reuse of isolated environments when dependencies match.

* **Documentation**
  * Updated reproducibility guidance and metadata schema to version 1.3.0.
  * Documented isolation requirements, fallback behavior, and environment constraints.

* **Bug Fixes**
  * Added warnings for environment differences during reproduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->