### PR TITLE
feat(signal): add a batched entry point so gwmock can simulate on device

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = [
-  "gwmock-signal>=0.11.2",
+  "gwmock-signal>=0.12.0", # 0.12.0 first exports the on-device entry points simulate_segments needs
   "gwmock-noise>=0.10.0",
   "gwmock-pop>=0.11.4",
   "typer>=0.19.0",         # Literal-type CLI options; the SPEC 0 floor (0.13) predates them
@@ -36,7 +36,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-sgwb = ["gwmock-signal[sgwb]>=0.11.2"]
+sgwb = ["gwmock-signal[sgwb]>=0.12.0"]
+# The on-device (GPU) signal path. Without this extra `SignalAdapter.simulate_segments` raises,
+# because gwmock-signal's batched entry points need JAX and ripple, which the base install omits.
+jax = ["gwmock-signal[jax]>=0.12.0"]
 
 [dependency-groups]
 dev = [

--- a/src/gwmock/signal/adapter.py
+++ b/src/gwmock/signal/adapter.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 from gwmock_signal import CustomDetector, DetectorStrainStack, Network, resolve_simulator_backend
 
 from gwmock.data.time_series.time_series import TimeSeries
@@ -52,11 +53,17 @@ _LEGACY_SINGLE_DETECTOR_ALIASES = {
 DetectorSpec = str | CustomDetector
 
 
+#: Marks a registry name generated for a *callable* waveform model rather than a real approximant.
+#: The device path tests for it to reject callables with an explanation, so the prefix has one
+#: definition rather than being spelled out at both the producing and the consuming end.
+_CALLABLE_WAVEFORM_PREFIX = "__gwmock_custom__"
+
+
 def _callable_waveform_registry_key(func: Callable[..., Any]) -> str:
     """Return a unique registry name for *func* on a ``WaveformFactory`` instance."""
     qual = getattr(func, "__qualname__", type(func).__name__)
     mod = getattr(func, "__module__", "")
-    return f"__gwmock_custom__{mod}:{qual}__{id(func):#x}"
+    return f"{_CALLABLE_WAVEFORM_PREFIX}{mod}:{qual}__{id(func):#x}"
 
 
 def _register_callable_waveform(backend: Any, registry_key: str, factory: Callable[..., Any]) -> None:
@@ -363,27 +370,35 @@ class SignalAdapter:
         """Transpose a sequence of per-event parameter mappings into arrays.
 
         The orchestration layer holds one mapping per event, while the batched device path takes one
-        array per parameter. Only keys present in *every* event are kept: a parameter some events
-        lack cannot become a column, and silently filling a default would put a fabricated value into
-        a simulation.
+        array per parameter. Every event must therefore carry the same keys.
+
+        A ragged catalogue is rejected rather than reduced to the shared keys. Dropping a key that
+        only some events carry does not avoid fabricating physics, it fabricates it wholesale: if one
+        event omits ``spin_1z``, intersecting removes the column entirely and the backend default is
+        then applied to *every* event, silently. A loader that emits ragged events is malformed, and
+        saying so is the only outcome that does not quietly alter the simulation.
 
         Args:
             events: Per-event parameter mappings, as the population loader yields them.
 
         Returns:
-            One entry per shared key, each a list of that key's value across events, in order.
+            One entry per key, each a list of that key's value across events, in order.
 
         Raises:
-            ValueError: If *events* is empty, or if no key is shared by all of them.
+            ValueError: If *events* is empty, or if the events do not all carry the same keys.
         """
         if not events:
             raise ValueError("events must be non-empty to build a batch.")
-        shared = set(events[0])
-        for event in events[1:]:
-            shared &= set(event)
-        if not shared:
-            raise ValueError("no parameter is present in every event, so no batch column can be built.")
-        return {key: [event[key] for event in events] for key in sorted(shared)}
+        expected = set(events[0])
+        for index, event in enumerate(events[1:], start=1):
+            if set(event) != expected:
+                absent = sorted(expected - set(event))
+                extra = sorted(set(event) - expected)
+                raise ValueError(
+                    f"every event must carry the same parameters, but event {index} differs from the "
+                    f"first: missing {absent or 'nothing'}, unexpected {extra or 'nothing'}."
+                )
+        return {key: [event[key] for event in events] for key in sorted(expected)}
 
     def simulate_segments(
         self,
@@ -395,6 +410,7 @@ class SignalAdapter:
         start_time: float,
         end_time: float,
         waveform_arguments: Mapping[str, Any] | None = None,
+        earth_rotation: bool = True,
         n_chirp_mass_bins: int = 1,
         chunk_size: int | None = None,
     ) -> list[DetectorStrainStack]:
@@ -408,6 +424,15 @@ class SignalAdapter:
         per-event path must keep working unchanged for the LAL and PyCBC backends, which have no
         batched form.
 
+        .. warning::
+
+           **This path always generates with Ripple**, whatever backend the adapter was configured
+           with, because Ripple is the only JAX implementation and therefore the only batchable one.
+           The approximant carries over, but its implementation does not: an adapter configured for
+           LAL that runs here gets Ripple's version of the same approximant, which agrees closely but
+           not bit-for-bit. To keep that from being silent, an approximant Ripple does not implement
+           is rejected rather than substituted -- see :meth:`_device_approximant`.
+
         Args:
             parameters: Canonical catalogue parameters as a struct-of-arrays — one array per
                 parameter, aligned across parameters. See :meth:`events_to_struct_of_arrays`.
@@ -418,6 +443,7 @@ class SignalAdapter:
             start_time: GPS start of the first segment.
             end_time: GPS end of the span to tile.
             waveform_arguments: Fixed parameters merged into the catalogue; per-event values win.
+            earth_rotation: Whether to include earth rotation, as on :meth:`simulate_stack`.
             n_chirp_mass_bins: Generate heavier events on shorter grids. Bounds buffer length at the
                 cost of exact reproducibility against a single grid.
             chunk_size: Events per batched call. ``None`` lets gwmock-signal size it from device
@@ -450,12 +476,15 @@ class SignalAdapter:
                 f"{', '.join(missing)}. Unlike the per-event path it does not accept aliases, so "
                 f"e.g. 'mass1' must be given as 'detector_frame_mass_1'."
             )
-        lengths = {name: len(values) for name, values in merged.items() if isinstance(values, (list, tuple))}
+        # Sized by np.ndim rather than isinstance, so NumPy and JAX columns are checked too. Testing
+        # for list/tuple alone let an ndarray of the wrong length through to fail inside batching,
+        # where the message no longer names the parameter.
+        lengths = {name: len(values) for name, values in merged.items() if np.ndim(values) > 0}
         if len(set(lengths.values())) > 1:
             raise ValueError(f"catalogue parameters disagree in length: {lengths}")
 
         return simulate_cbc_catalogue(
-            self._waveform_model_name(),
+            self._device_approximant(),
             list(self._network.detector_names),
             sampling_frequency=sampling_frequency,
             minimum_frequency=minimum_frequency,
@@ -463,31 +492,60 @@ class SignalAdapter:
             segment_duration=segment_duration,
             start_time=start_time,
             end_time=end_time,
+            earth_rotation=earth_rotation,
             n_chirp_mass_bins=n_chirp_mass_bins,
             chunk_size=chunk_size,
         )
 
-    def _waveform_model_name(self) -> str:
-        """Return the approximant name the batched path should generate.
+    def _device_approximant(self) -> str:
+        """Return the approximant to generate on device, or explain why there is not one.
 
         The batched entry point takes an approximant *name*, while the per-event path goes through
-        the backend's own waveform registry. Reading it back off the backend keeps one source of
-        truth for what is being simulated.
+        the backend's own waveform registry, so the name has to be read back off the backend. That is
+        the public ``waveform_model`` property, which is the contract every simulator in
+        gwmock-signal exposes -- deliberately not a search across candidate attributes, since a
+        backend that grew a similarly-named attribute for another purpose would then be picked up
+        silently.
+
+        Two things cannot cross to the device path, and both are rejected here rather than left to
+        fail further in:
+
+        * A **callable** waveform model, which the per-event path supports by registering it under a
+          generated key. Ripple cannot execute arbitrary Python, and the key would otherwise be
+          handed over as if it were an approximant name.
+        * An approximant **Ripple does not implement**. Substituting the nearest one would change the
+          waveform without saying so, which is the failure this whole method exists to prevent.
 
         Returns:
-            The approximant name.
+            The approximant name, known to be one Ripple implements.
 
         Raises:
-            RuntimeError: If the backend does not expose one.
+            RuntimeError: If the backend exposes no usable approximant name.
+            ValueError: If the model is a callable, or Ripple has no such approximant.
         """
-        for attribute in ("waveform_model", "_waveform_model", "approximant"):
-            value = getattr(self._backend, attribute, None)
-            if isinstance(value, str) and value:
-                return value
-        raise RuntimeError(
-            "Could not determine the approximant name from the signal backend, which the device "
-            "path requires. Pass a string waveform-model rather than a callable."
-        )
+        from gwmock_signal.waveform.backends.ripple import RippleBackend  # noqa: PLC0415
+
+        name = getattr(self._backend, "waveform_model", None)
+        if not isinstance(name, str) or not name:
+            raise RuntimeError(
+                f"The signal backend {type(self._backend).__name__} exposes no 'waveform_model' "
+                f"string, which the device path needs to select an approximant."
+            )
+        if name.startswith(_CALLABLE_WAVEFORM_PREFIX):
+            raise ValueError(
+                "This adapter was built with a callable waveform model, which the device path "
+                "cannot run: Ripple generates from its own compiled approximants, not from Python "
+                "callbacks. Use a string approximant, or the per-event path."
+            )
+        available = RippleBackend().available_approximants()
+        if name not in available:
+            raise ValueError(
+                f"Ripple does not implement the approximant '{name}', and the device path always "
+                f"generates with Ripple. It is rejected rather than substituted, because silently "
+                f"generating a different waveform than the one configured would corrupt the "
+                f"simulation. Available: {', '.join(sorted(available))}."
+            )
+        return name
 
     def simulate_stack(
         self,

--- a/src/gwmock/signal/adapter.py
+++ b/src/gwmock/signal/adapter.py
@@ -21,6 +21,21 @@ logger = logging.getLogger("gwmock")
 #: parameter list that follows.
 _UNSUPPORTED_PARAMS_RE = re.compile(r"^Unsupported .+? waveform parameters:\s*(.*)$")
 
+#: Canonical parameter names the on-device batched path requires, with no aliases accepted.
+#:
+#: The per-event path forwards whatever it is given and lets the backend resolve aliases
+#: (``mass1`` for ``detector_frame_mass_1``, and so on). The batched path does not: it reads these
+#: names directly from a struct-of-arrays, so a missing or aliased key would surface as a
+#: ``KeyError`` from inside a jitted kernel rather than as a statement about the input.
+_DEVICE_REQUIRED_PARAMETERS = (
+    "coa_time",
+    "declination",
+    "detector_frame_mass_1",
+    "detector_frame_mass_2",
+    "polarization_angle",
+    "right_ascension",
+)
+
 _DEFAULT_WAVEFORM_MODEL = "IMRPhenomXPHM"
 _LEGACY_SINGLE_DETECTOR_ALIASES = {
     "E1_triangle_sardinia": ("ET-Triangle-Sardinia", "ET1_SARD"),
@@ -340,6 +355,139 @@ class SignalAdapter:
             The resolved public detector network.
         """
         return self._network
+
+    @staticmethod
+    def events_to_struct_of_arrays(
+        events: Sequence[Mapping[str, Any]],
+    ) -> dict[str, Any]:
+        """Transpose a sequence of per-event parameter mappings into arrays.
+
+        The orchestration layer holds one mapping per event, while the batched device path takes one
+        array per parameter. Only keys present in *every* event are kept: a parameter some events
+        lack cannot become a column, and silently filling a default would put a fabricated value into
+        a simulation.
+
+        Args:
+            events: Per-event parameter mappings, as the population loader yields them.
+
+        Returns:
+            One entry per shared key, each a list of that key's value across events, in order.
+
+        Raises:
+            ValueError: If *events* is empty, or if no key is shared by all of them.
+        """
+        if not events:
+            raise ValueError("events must be non-empty to build a batch.")
+        shared = set(events[0])
+        for event in events[1:]:
+            shared &= set(event)
+        if not shared:
+            raise ValueError("no parameter is present in every event, so no batch column can be built.")
+        return {key: [event[key] for event in events] for key in sorted(shared)}
+
+    def simulate_segments(
+        self,
+        parameters: Mapping[str, Any],
+        *,
+        sampling_frequency: float,
+        minimum_frequency: float,
+        segment_duration: float,
+        start_time: float,
+        end_time: float,
+        waveform_arguments: Mapping[str, Any] | None = None,
+        n_chirp_mass_bins: int = 1,
+        chunk_size: int | None = None,
+    ) -> list[DetectorStrainStack]:
+        """Generate a whole catalogue on device and return it as fixed-duration segments.
+
+        The device counterpart of :meth:`simulate_stack`. That method takes one event and returns one
+        stack; this takes the catalogue as a struct-of-arrays and returns the assembled segments, so
+        the per-event Python loop disappears and the waveforms are generated under one ``vmap``.
+
+        Kept as a separate entry point rather than folded into :meth:`simulate_stack`, because the
+        per-event path must keep working unchanged for the LAL and PyCBC backends, which have no
+        batched form.
+
+        Args:
+            parameters: Canonical catalogue parameters as a struct-of-arrays — one array per
+                parameter, aligned across parameters. See :meth:`events_to_struct_of_arrays`.
+            sampling_frequency: Sample rate in Hz.
+            minimum_frequency: Low-frequency cutoff in Hz. Note that with a tapered cutoff this is
+                where the waveform reaches full amplitude, not where its content begins.
+            segment_duration: Duration of each output segment in seconds.
+            start_time: GPS start of the first segment.
+            end_time: GPS end of the span to tile.
+            waveform_arguments: Fixed parameters merged into the catalogue; per-event values win.
+            n_chirp_mass_bins: Generate heavier events on shorter grids. Bounds buffer length at the
+                cost of exact reproducibility against a single grid.
+            chunk_size: Events per batched call. ``None`` lets gwmock-signal size it from device
+                memory, which is the safer default.
+
+        Returns:
+            One :class:`~gwmock_signal.DetectorStrainStack` per segment, in time order.
+
+        Raises:
+            ValueError: If a required canonical parameter is missing, or the arrays disagree in
+                length.
+            RuntimeError: If the installed gwmock-signal does not export the device path.
+        """
+        try:
+            # Imported here, not at module scope: an older gwmock-signal without this export would
+            # otherwise break `import gwmock.signal.adapter` outright, taking the per-event path down
+            # with it. Locally, only the device path fails, and it says why.
+            from gwmock_signal import simulate_cbc_catalogue  # noqa: PLC0415
+        except ImportError as exc:  # pragma: no cover - depends on the installed version
+            raise RuntimeError(
+                "The installed gwmock-signal does not export simulate_cbc_catalogue, which the "
+                "device path needs. Upgrade gwmock-signal, and install it with the [jax] extra."
+            ) from exc
+
+        merged = {**(waveform_arguments or {}), **dict(parameters)}
+        missing = [name for name in _DEVICE_REQUIRED_PARAMETERS if name not in merged]
+        if missing:
+            raise ValueError(
+                f"The device path needs these canonical parameters, which are absent: "
+                f"{', '.join(missing)}. Unlike the per-event path it does not accept aliases, so "
+                f"e.g. 'mass1' must be given as 'detector_frame_mass_1'."
+            )
+        lengths = {name: len(values) for name, values in merged.items() if isinstance(values, (list, tuple))}
+        if len(set(lengths.values())) > 1:
+            raise ValueError(f"catalogue parameters disagree in length: {lengths}")
+
+        return simulate_cbc_catalogue(
+            self._waveform_model_name(),
+            list(self._network.detector_names),
+            sampling_frequency=sampling_frequency,
+            minimum_frequency=minimum_frequency,
+            parameters=merged,
+            segment_duration=segment_duration,
+            start_time=start_time,
+            end_time=end_time,
+            n_chirp_mass_bins=n_chirp_mass_bins,
+            chunk_size=chunk_size,
+        )
+
+    def _waveform_model_name(self) -> str:
+        """Return the approximant name the batched path should generate.
+
+        The batched entry point takes an approximant *name*, while the per-event path goes through
+        the backend's own waveform registry. Reading it back off the backend keeps one source of
+        truth for what is being simulated.
+
+        Returns:
+            The approximant name.
+
+        Raises:
+            RuntimeError: If the backend does not expose one.
+        """
+        for attribute in ("waveform_model", "_waveform_model", "approximant"):
+            value = getattr(self._backend, attribute, None)
+            if isinstance(value, str) and value:
+                return value
+        raise RuntimeError(
+            "Could not determine the approximant name from the signal backend, which the device "
+            "path requires. Pass a string waveform-model rather than a callable."
+        )
 
     def simulate_stack(
         self,

--- a/src/gwmock/signal/adapter.py
+++ b/src/gwmock/signal/adapter.py
@@ -476,6 +476,20 @@ class SignalAdapter:
                 f"{', '.join(missing)}. Unlike the per-event path it does not accept aliases, so "
                 f"e.g. 'mass1' must be given as 'detector_frame_mass_1'."
             )
+        # The required parameters are per-event by definition, so each must be a column. A scalar is
+        # rejected rather than broadcast: it means every event shares one value, and for `coa_time`
+        # that is every signal landing at the same instant. Left unchecked it surfaces from inside
+        # batching as "too many indices for array: array is 0-dimensional".
+        #
+        # Only the required ones. A scalar elsewhere is the documented way to fix a parameter across
+        # the catalogue -- `f_ref=20.0` via waveform_arguments -- so scalars stay legal in general.
+        scalars = [name for name in _DEVICE_REQUIRED_PARAMETERS if np.ndim(merged[name]) == 0]
+        if scalars:
+            raise ValueError(
+                f"These parameters vary per event and must be given as arrays, but were scalars: "
+                f"{', '.join(scalars)}. To hold one fixed across the catalogue, repeat it per event."
+            )
+
         # Sized by np.ndim rather than isinstance, so NumPy and JAX columns are checked too. Testing
         # for list/tuple alone let an ndarray of the wrong length through to fail inside batching,
         # where the message no longer names the parameter.
@@ -523,8 +537,6 @@ class SignalAdapter:
             RuntimeError: If the backend exposes no usable approximant name.
             ValueError: If the model is a callable, or Ripple has no such approximant.
         """
-        from gwmock_signal.waveform.backends.ripple import RippleBackend  # noqa: PLC0415
-
         name = getattr(self._backend, "waveform_model", None)
         if not isinstance(name, str) or not name:
             raise RuntimeError(
@@ -537,6 +549,11 @@ class SignalAdapter:
                 "cannot run: Ripple generates from its own compiled approximants, not from Python "
                 "callbacks. Use a string approximant, or the per-event path."
             )
+
+        # Imported only once the cheap checks pass, so both of the above stay reachable -- and
+        # therefore testable, and covered in CI -- in an installation without the [jax] extra.
+        from gwmock_signal.waveform.backends.ripple import RippleBackend  # noqa: PLC0415
+
         available = RippleBackend().available_approximants()
         if name not in available:
             raise ValueError(

--- a/tests/signal/test_adapter_batch.py
+++ b/tests/signal/test_adapter_batch.py
@@ -71,14 +71,24 @@ class TestEventsToStructOfArrays:
         events = [{"a": 1.0, "b": 2.0}, {"a": 3.0, "b": 4.0}]
         assert SignalAdapter.events_to_struct_of_arrays(events) == {"a": [1.0, 3.0], "b": [2.0, 4.0]}
 
-    def test_drops_keys_missing_from_any_event(self):
-        """A key some events lack cannot become a column.
+    def test_rejects_events_whose_keys_differ(self):
+        """A ragged catalogue is an error, not something to reduce to the shared keys.
 
-        Filling a default would put a fabricated value into a simulation, which is worse than the
-        clear failure the caller gets downstream when a required parameter turns out to be absent.
+        Intersecting would be the more forgiving choice and the wrong one: dropping a key that only
+        some events carry does not avoid fabricating physics, it fabricates it for the whole batch,
+        because the backend default then applies to every event with nothing said.
         """
-        events = [{"a": 1.0, "only_first": 9.0}, {"a": 2.0}]
-        assert SignalAdapter.events_to_struct_of_arrays(events) == {"a": [1.0, 2.0]}
+        events = [{"a": 1.0, "spin_1z": 0.4}, {"a": 2.0}]
+        with pytest.raises(ValueError, match="same parameters") as raised:
+            SignalAdapter.events_to_struct_of_arrays(events)
+        assert "spin_1z" in str(raised.value), "the message must name the parameter that went missing"
+
+    def test_names_the_offending_event_and_both_directions(self):
+        """The message points at which event differs, and how, so a loader bug is locatable."""
+        events = [{"a": 1.0}, {"a": 2.0}, {"a": 3.0, "surprise": 0.0}]
+        with pytest.raises(ValueError, match="event 2") as raised:
+            SignalAdapter.events_to_struct_of_arrays(events)
+        assert "surprise" in str(raised.value)
 
     def test_rejects_an_empty_catalogue(self):
         """No events means no batch, and saying so beats returning an empty mapping."""
@@ -86,8 +96,8 @@ class TestEventsToStructOfArrays:
             SignalAdapter.events_to_struct_of_arrays([])
 
     def test_rejects_events_with_no_key_in_common(self):
-        """With nothing shared there is no column to build, which is a caller error."""
-        with pytest.raises(ValueError, match="no parameter is present in every event"):
+        """Wholly disjoint events are the extreme case of ragged, and fail the same way."""
+        with pytest.raises(ValueError, match="same parameters"):
             SignalAdapter.events_to_struct_of_arrays([{"a": 1.0}, {"b": 2.0}])
 
 
@@ -130,23 +140,135 @@ class TestSimulateSegmentsValidation:
                 end_time=_START + _SPAN,
             )
 
-    def test_waveform_arguments_are_merged_and_overridden_by_the_catalogue(self):
-        """Fixed arguments fill gaps; per-event values win, as on the per-event path.
+    def test_ragged_numpy_columns_are_rejected(self):
+        """Length validation must cover arrays, not only lists and tuples.
 
-        Checked through the failure message rather than by generating: supplying the missing
-        parameters via ``waveform_arguments`` must satisfy the same validation.
+        An ``ndarray`` of the wrong length used to pass this check and fail deep inside batching,
+        where the error no longer names the parameter at fault.
         """
-        adapter = _adapter()
-        parameters = {"coa_time": [_START + 1.0], "right_ascension": [0.3]}
-        with pytest.raises(ValueError, match="declination"):
-            adapter.simulate_segments(
+        parameters = SignalAdapter.events_to_struct_of_arrays(_events(3))
+        parameters = {key: np.asarray(value) for key, value in parameters.items()}
+        parameters["coa_time"] = parameters["coa_time"][:2]
+        with pytest.raises(ValueError, match="disagree in length"):
+            _adapter().simulate_segments(
                 parameters,
                 sampling_frequency=_FS,
                 minimum_frequency=30.0,
                 segment_duration=_SEGMENT,
                 start_time=_START,
                 end_time=_START + _SPAN,
-                waveform_arguments={"detector_frame_mass_1": [1.4], "detector_frame_mass_2": [1.35]},
+            )
+
+
+class TestForwardingToTheBatchedCall:
+    """What the adapter actually hands to ``simulate_cbc_catalogue``.
+
+    These stub out the generation but still resolve the approximant, which instantiates
+    ``RippleBackend``, so they need the ``[jax]`` extra.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _require_device_stack(self):
+        pytest.importorskip("jax", reason="the [jax] extra is not installed")
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+
+    def test_a_catalogue_value_overrides_the_same_key_in_waveform_arguments(self, monkeypatch):
+        """Fixed arguments fill gaps; per-event values win where both supply a key.
+
+        Asserted on what actually reaches ``simulate_cbc_catalogue`` rather than through a failure
+        message. A message-based check would pass for any implementation that merges the two
+        mappings in *either* order, so it could not detect the precedence being backwards -- which is
+        the only thing this test is for.
+        """
+        captured = {}
+
+        def _capture(*args, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        monkeypatch.setattr("gwmock_signal.simulate_cbc_catalogue", _capture)
+
+        adapter = _adapter()
+        parameters = SignalAdapter.events_to_struct_of_arrays(_events(2))
+        adapter.simulate_segments(
+            parameters,
+            sampling_frequency=_FS,
+            minimum_frequency=30.0,
+            segment_duration=_SEGMENT,
+            start_time=_START,
+            end_time=_START + _SPAN,
+            waveform_arguments={"detector_frame_mass_1": [99.0, 99.0], "f_ref": 20.0},
+        )
+        merged = captured["parameters"]
+        assert merged["detector_frame_mass_1"] == [1.4, 1.4], "the catalogue must win over a fixed value"
+        assert merged["f_ref"] == 20.0, "a fixed key absent from the catalogue must still be passed"
+
+    def test_earth_rotation_reaches_the_batched_call(self, monkeypatch):
+        """The flag must be forwarded, not silently left at the gwmock-signal default.
+
+        Without this the setting would be honoured on the per-event path and ignored here, so the
+        two paths would disagree for anyone who turns it off.
+        """
+        captured = {}
+        monkeypatch.setattr("gwmock_signal.simulate_cbc_catalogue", lambda *a, **k: captured.update(k) or [])
+
+        _adapter().simulate_segments(
+            SignalAdapter.events_to_struct_of_arrays(_events(2)),
+            sampling_frequency=_FS,
+            minimum_frequency=30.0,
+            segment_duration=_SEGMENT,
+            start_time=_START,
+            end_time=_START + _SPAN,
+            earth_rotation=False,
+        )
+        assert captured["earth_rotation"] is False
+
+
+class TestDeviceApproximant:
+    """Which configured models can and cannot cross to the device path."""
+
+    @pytest.fixture(autouse=True)
+    def _require_device_stack(self):
+        pytest.importorskip("jax", reason="the [jax] extra is not installed")
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+
+    def test_an_approximant_ripple_lacks_is_rejected_not_substituted(self):
+        """Generating a different waveform than the one configured would corrupt the simulation."""
+        adapter = SignalAdapter.from_source_type(
+            source_type="bns", waveform_model="SEOBNRv4", detectors=["ET-Triangle-Sardinia"]
+        )
+        with pytest.raises(ValueError, match="does not implement the approximant 'SEOBNRv4'") as raised:
+            adapter.simulate_segments(
+                SignalAdapter.events_to_struct_of_arrays(_events(2)),
+                sampling_frequency=_FS,
+                minimum_frequency=30.0,
+                segment_duration=_SEGMENT,
+                start_time=_START,
+                end_time=_START + _SPAN,
+            )
+        assert "IMRPhenomD" in str(raised.value), "the message must list what is available instead"
+
+    def test_a_callable_waveform_model_is_rejected_with_its_own_message(self):
+        """A callable is registered under a generated key, which is not an approximant name.
+
+        Left unchecked that key reaches Ripple as if it were one, and the failure talks about an
+        unsupported approximant named ``__gwmock_custom__...`` rather than about the callable.
+        """
+
+        def custom(*args, **kwargs):  # pragma: no cover - never called
+            raise AssertionError("the device path must not reach the callable")
+
+        adapter = SignalAdapter.from_source_type(
+            source_type="bns", waveform_model=custom, detectors=["ET-Triangle-Sardinia"]
+        )
+        with pytest.raises(ValueError, match="callable waveform model"):
+            adapter.simulate_segments(
+                SignalAdapter.events_to_struct_of_arrays(_events(2)),
+                sampling_frequency=_FS,
+                minimum_frequency=30.0,
+                segment_duration=_SEGMENT,
+                start_time=_START,
+                end_time=_START + _SPAN,
             )
 
 

--- a/tests/signal/test_adapter_batch.py
+++ b/tests/signal/test_adapter_batch.py
@@ -140,6 +140,53 @@ class TestSimulateSegmentsValidation:
                 end_time=_START + _SPAN,
             )
 
+    def test_a_scalar_required_parameter_is_rejected(self):
+        """A per-event parameter given once is not a column, whatever it would broadcast to.
+
+        Verified to be a real failure rather than a hypothetical: passing ``coa_time`` as a scalar
+        reaches batching and raises ``too many indices for array: array is 0-dimensional``, which
+        names neither the parameter nor the mistake.
+        """
+        parameters = SignalAdapter.events_to_struct_of_arrays(_events(2))
+        parameters["coa_time"] = _START
+        with pytest.raises(ValueError, match="must be given as arrays") as raised:
+            _adapter().simulate_segments(
+                parameters,
+                sampling_frequency=_FS,
+                minimum_frequency=30.0,
+                segment_duration=_SEGMENT,
+                start_time=_START,
+                end_time=_START + _SPAN,
+            )
+        assert "coa_time" in str(raised.value)
+
+    def test_a_scalar_stays_legal_for_a_parameter_that_is_not_per_event(self):
+        """Only the required per-event names are forced to be arrays.
+
+        Fixing a value across the catalogue with a scalar -- ``f_ref=20.0`` -- is the documented use
+        of ``waveform_arguments``, so the new check must not sweep it up.
+
+        The assertion is the *absence* of the scalar rejection rather than a specific exception,
+        because what happens after validation differs by installation: with the extra the
+        approximant is resolved and rejected as unknown, without it the Ripple import fails first.
+        Both mean validation was cleared, which is the whole claim.
+        """
+        parameters = SignalAdapter.events_to_struct_of_arrays(_events(2))
+        adapter = SignalAdapter.from_source_type(
+            source_type="bns", waveform_model="NotARippleApproximant", detectors=["ET-Triangle-Sardinia"]
+        )
+        with pytest.raises(Exception) as raised:  # noqa: PT011 - see the docstring
+            adapter.simulate_segments(
+                parameters,
+                sampling_frequency=_FS,
+                minimum_frequency=30.0,
+                segment_duration=_SEGMENT,
+                start_time=_START,
+                end_time=_START + _SPAN,
+                waveform_arguments={"f_ref": 20.0},
+            )
+        assert "must be given as arrays" not in str(raised.value), "a scalar f_ref must not be rejected"
+
     def test_ragged_numpy_columns_are_rejected(self):
         """Length validation must cover arrays, not only lists and tuples.
 
@@ -224,29 +271,12 @@ class TestForwardingToTheBatchedCall:
         assert captured["earth_rotation"] is False
 
 
-class TestDeviceApproximant:
-    """Which configured models can and cannot cross to the device path."""
+class TestDeviceApproximantWithoutTheExtra:
+    """Model rejections that do not need Ripple, and so must stay reachable without the extra.
 
-    @pytest.fixture(autouse=True)
-    def _require_device_stack(self):
-        pytest.importorskip("jax", reason="the [jax] extra is not installed")
-        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
-
-    def test_an_approximant_ripple_lacks_is_rejected_not_substituted(self):
-        """Generating a different waveform than the one configured would corrupt the simulation."""
-        adapter = SignalAdapter.from_source_type(
-            source_type="bns", waveform_model="SEOBNRv4", detectors=["ET-Triangle-Sardinia"]
-        )
-        with pytest.raises(ValueError, match="does not implement the approximant 'SEOBNRv4'") as raised:
-            adapter.simulate_segments(
-                SignalAdapter.events_to_struct_of_arrays(_events(2)),
-                sampling_frequency=_FS,
-                minimum_frequency=30.0,
-                segment_duration=_SEGMENT,
-                start_time=_START,
-                end_time=_START + _SPAN,
-            )
-        assert "IMRPhenomD" in str(raised.value), "the message must list what is available instead"
+    ``_device_approximant`` runs these before importing ``RippleBackend`` precisely so they hold in
+    a base installation. Placing them here rather than behind ``importorskip`` is the assertion.
+    """
 
     def test_a_callable_waveform_model_is_rejected_with_its_own_message(self):
         """A callable is registered under a generated key, which is not an approximant name.
@@ -270,6 +300,31 @@ class TestDeviceApproximant:
                 start_time=_START,
                 end_time=_START + _SPAN,
             )
+
+
+class TestDeviceApproximant:
+    """Which configured models can and cannot cross to the device path."""
+
+    @pytest.fixture(autouse=True)
+    def _require_device_stack(self):
+        pytest.importorskip("jax", reason="the [jax] extra is not installed")
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+
+    def test_an_approximant_ripple_lacks_is_rejected_not_substituted(self):
+        """Generating a different waveform than the one configured would corrupt the simulation."""
+        adapter = SignalAdapter.from_source_type(
+            source_type="bns", waveform_model="SEOBNRv4", detectors=["ET-Triangle-Sardinia"]
+        )
+        with pytest.raises(ValueError, match="does not implement the approximant 'SEOBNRv4'") as raised:
+            adapter.simulate_segments(
+                SignalAdapter.events_to_struct_of_arrays(_events(2)),
+                sampling_frequency=_FS,
+                minimum_frequency=30.0,
+                segment_duration=_SEGMENT,
+                start_time=_START,
+                end_time=_START + _SPAN,
+            )
+        assert "IMRPhenomD" in str(raised.value), "the message must list what is available instead"
 
 
 class TestSimulateSegmentsOnDevice:

--- a/tests/signal/test_adapter_batch.py
+++ b/tests/signal/test_adapter_batch.py
@@ -1,0 +1,217 @@
+"""Tests for the batched (on-device) entry point on the gwmock-side adapter.
+
+gwmock's orchestration generates one event at a time: ``cli/adapter_orchestration.py`` loops over
+population events calling ``simulate``, producing a strain per event. That is the only shape the
+LAL and PyCBC backends offer, and it is why gwmock could not run a GPU simulation at all — the
+batched path in gwmock-signal had no caller here.
+
+``simulate_segments`` is the batched counterpart: catalogue in as a struct-of-arrays, assembled
+segments out. It is deliberately a *second* entry point rather than a change to ``simulate_stack``,
+because the per-event path has to keep working unchanged for backends with no batched form.
+
+The tests that actually generate waveforms need the ``[jax]`` extra and are skipped without it; the
+input-handling tests do not, and run everywhere.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from gwmock.signal.adapter import SignalAdapter
+
+_FS = 2048.0
+_START = 1400000000.0
+_SEGMENT = 64.0
+_SPAN = 256.0
+
+
+def _events(n: int = 4) -> list[dict[str, float]]:
+    """Return *n* BNS events with every canonical parameter the device path requires."""
+    rng = np.random.default_rng(0)
+    return [
+        {
+            "detector_frame_mass_1": 1.4,
+            "detector_frame_mass_2": 1.35,
+            "luminosity_distance": float(distance),
+            "inclination": float(inclination),
+            "coa_phase": float(phase),
+            "right_ascension": float(ascension),
+            "declination": float(declination),
+            "polarization_angle": float(polarization),
+            "coa_time": float(coalescence),
+            "spin_1z": 0.0,
+            "spin_2z": 0.0,
+        }
+        for distance, inclination, phase, ascension, declination, polarization, coalescence in zip(
+            rng.uniform(200.0, 2000.0, n),
+            rng.uniform(0.0, np.pi, n),
+            rng.uniform(0.0, 2 * np.pi, n),
+            rng.uniform(0.0, 2 * np.pi, n),
+            np.arcsin(rng.uniform(-1.0, 1.0, n)),
+            rng.uniform(0.0, np.pi, n),
+            _START + np.sort(rng.uniform(0.0, _SPAN, n)),
+            strict=True,
+        )
+    ]
+
+
+def _adapter() -> SignalAdapter:
+    """An adapter on the bundled ET triangle preset, which resolves to CustomDetector instances."""
+    return SignalAdapter.from_source_type(
+        source_type="bns", waveform_model="IMRPhenomD", detectors=["ET-Triangle-Sardinia"]
+    )
+
+
+class TestEventsToStructOfArrays:
+    """Transposing per-event mappings into the columns the batched path takes."""
+
+    def test_transposes_shared_keys_in_event_order(self):
+        """Each column holds one key's value across events, in the order given."""
+        events = [{"a": 1.0, "b": 2.0}, {"a": 3.0, "b": 4.0}]
+        assert SignalAdapter.events_to_struct_of_arrays(events) == {"a": [1.0, 3.0], "b": [2.0, 4.0]}
+
+    def test_drops_keys_missing_from_any_event(self):
+        """A key some events lack cannot become a column.
+
+        Filling a default would put a fabricated value into a simulation, which is worse than the
+        clear failure the caller gets downstream when a required parameter turns out to be absent.
+        """
+        events = [{"a": 1.0, "only_first": 9.0}, {"a": 2.0}]
+        assert SignalAdapter.events_to_struct_of_arrays(events) == {"a": [1.0, 2.0]}
+
+    def test_rejects_an_empty_catalogue(self):
+        """No events means no batch, and saying so beats returning an empty mapping."""
+        with pytest.raises(ValueError, match="non-empty"):
+            SignalAdapter.events_to_struct_of_arrays([])
+
+    def test_rejects_events_with_no_key_in_common(self):
+        """With nothing shared there is no column to build, which is a caller error."""
+        with pytest.raises(ValueError, match="no parameter is present in every event"):
+            SignalAdapter.events_to_struct_of_arrays([{"a": 1.0}, {"b": 2.0}])
+
+
+class TestSimulateSegmentsValidation:
+    """Input checks that run before any device work, so they need no extra installed."""
+
+    def test_missing_canonical_parameters_are_named(self):
+        """The message must list what is absent and say aliases are not accepted.
+
+        The batched path reads canonical names straight from the struct-of-arrays, so an alias such
+        as ``mass1`` would otherwise surface as a ``KeyError`` from inside a jitted kernel rather
+        than as a statement about the input.
+        """
+        parameters = {"mass1": [1.4], "mass2": [1.35]}
+        with pytest.raises(ValueError, match="detector_frame_mass_1") as raised:
+            _adapter().simulate_segments(
+                parameters,
+                sampling_frequency=_FS,
+                minimum_frequency=30.0,
+                segment_duration=_SEGMENT,
+                start_time=_START,
+                end_time=_START + _SPAN,
+            )
+        message = str(raised.value)
+        assert "coa_time" in message
+        assert "alias" in message.lower()
+
+    def test_ragged_columns_are_rejected(self):
+        """Columns of different lengths cannot describe one catalogue."""
+        events = _events(3)
+        parameters = SignalAdapter.events_to_struct_of_arrays(events)
+        parameters["coa_time"] = parameters["coa_time"][:2]
+        with pytest.raises(ValueError, match="disagree in length"):
+            _adapter().simulate_segments(
+                parameters,
+                sampling_frequency=_FS,
+                minimum_frequency=30.0,
+                segment_duration=_SEGMENT,
+                start_time=_START,
+                end_time=_START + _SPAN,
+            )
+
+    def test_waveform_arguments_are_merged_and_overridden_by_the_catalogue(self):
+        """Fixed arguments fill gaps; per-event values win, as on the per-event path.
+
+        Checked through the failure message rather than by generating: supplying the missing
+        parameters via ``waveform_arguments`` must satisfy the same validation.
+        """
+        adapter = _adapter()
+        parameters = {"coa_time": [_START + 1.0], "right_ascension": [0.3]}
+        with pytest.raises(ValueError, match="declination"):
+            adapter.simulate_segments(
+                parameters,
+                sampling_frequency=_FS,
+                minimum_frequency=30.0,
+                segment_duration=_SEGMENT,
+                start_time=_START,
+                end_time=_START + _SPAN,
+                waveform_arguments={"detector_frame_mass_1": [1.4], "detector_frame_mass_2": [1.35]},
+            )
+
+
+class TestSimulateSegmentsOnDevice:
+    """End-to-end through the real batched path. Requires the ``[jax]`` extra."""
+
+    @pytest.fixture(autouse=True)
+    def _require_device_stack(self):
+        pytest.importorskip("jax", reason="the [jax] extra is not installed")
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+
+    def test_returns_one_stack_per_segment(self):
+        """The span is tiled into fixed-duration segments, each a full detector stack."""
+        adapter = _adapter()
+        segments = adapter.simulate_segments(
+            SignalAdapter.events_to_struct_of_arrays(_events()),
+            sampling_frequency=_FS,
+            minimum_frequency=30.0,
+            segment_duration=_SEGMENT,
+            start_time=_START,
+            end_time=_START + _SPAN,
+        )
+        assert len(segments) == int(_SPAN // _SEGMENT)
+        assert segments[0].detector_names == ("ET1_SARD", "ET2_SARD", "ET3_SARD")
+        assert segments[0].data.shape == (3, round(_SEGMENT * _FS))
+
+    def test_the_segments_contain_signal(self):
+        """A catalogue that overlaps the span must leave non-zero strain in it.
+
+        Asserted on finite, non-zero content rather than on exact values: this test exists to show
+        the device path is reached and produces a waveform, not to re-verify gwmock-signal's physics,
+        which its own suite covers.
+        """
+        adapter = _adapter()
+        segments = adapter.simulate_segments(
+            SignalAdapter.events_to_struct_of_arrays(_events()),
+            sampling_frequency=_FS,
+            minimum_frequency=30.0,
+            segment_duration=_SEGMENT,
+            start_time=_START,
+            end_time=_START + _SPAN,
+        )
+        channel = segments[0].detector_names[0]
+        occupied = sum(int(np.count_nonzero(segment.to_dict()[channel].value)) for segment in segments)
+        peak = max(float(np.max(np.abs(segment.to_dict()[channel].value))) for segment in segments)
+        assert occupied > 0, "no segment contains signal, so the device path produced nothing"
+        assert np.isfinite(peak)
+        assert peak > 0.0
+
+    def test_every_detector_in_the_network_differs(self):
+        """Three ET channels must carry three different projections, not one repeated.
+
+        atol=0 because strain is ~1e-23: the default absolute tolerance would call any two strain
+        arrays equal and the assertion could not fail.
+        """
+        adapter = _adapter()
+        segments = adapter.simulate_segments(
+            SignalAdapter.events_to_struct_of_arrays(_events()),
+            sampling_frequency=_FS,
+            minimum_frequency=30.0,
+            segment_duration=_SEGMENT,
+            start_time=_START,
+            end_time=_START + _SPAN,
+        )
+        with_signal = max(segments, key=lambda segment: np.count_nonzero(segment.data))
+        first, second, third = with_signal.data
+        assert not np.allclose(first, second, rtol=1e-6, atol=0.0)
+        assert not np.allclose(second, third, rtol=1e-6, atol=0.0)

--- a/uv.lock
+++ b/uv.lock
@@ -664,6 +664,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+jax = [
+    { name = "gwmock-signal", extra = ["jax"] },
+]
 sgwb = [
     { name = "gwmock-signal", extra = ["sgwb"] },
 ]
@@ -693,8 +696,9 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.16.0" },
     { name = "gwmock-noise", specifier = ">=0.10.0" },
     { name = "gwmock-pop", specifier = ">=0.11.4" },
-    { name = "gwmock-signal", specifier = ">=0.11.2" },
-    { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", specifier = ">=0.11.2" },
+    { name = "gwmock-signal", specifier = ">=0.12.0" },
+    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'jax'", specifier = ">=0.12.0" },
+    { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", specifier = ">=0.12.0" },
     { name = "h5py", specifier = ">=3.12.1" },
     { name = "psutil", specifier = ">=6.1.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
@@ -703,7 +707,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67.0" },
     { name = "typer", specifier = ">=0.19.0" },
 ]
-provides-extras = ["sgwb"]
+provides-extras = ["jax", "sgwb"]
 
 [package.metadata.requires-dev]
 build = [{ name = "hatch", specifier = ">=1.17.1" }]
@@ -772,6 +776,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+jax = [
+    { name = "ripplegw" },
+]
 sgwb = [
     { name = "gwmock-noise" },
 ]
@@ -1119,6 +1126,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/09/18/04d82793d804a6766ca73e4ed30ef928aea252db7c86f73b2faf11fe9e90/jaxlib-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5c38a393d37b4a70569224dc8273d8ae6ccea837e45410ed53ca03e15d6fad58", size = 62642149, upload-time = "2026-07-16T19:00:02.597Z" },
     { url = "https://files.pythonhosted.org/packages/91/2e/418dae82175154f6b5f53aec8909bda800dcbc9c65d94373de146b06e3b1/jaxlib-0.11.0-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:5ed7c54a6ef02eea19c0a02e3f603e4f9ad77248098bb9fc3feffca7f4814b83", size = 82261560, upload-time = "2026-07-16T19:00:06.22Z" },
     { url = "https://files.pythonhosted.org/packages/ac/ff/2edc74b4de40ac4222ee48b3805a6ea5e40f34abe4cd10b65bc0fa0864db/jaxlib-0.11.0-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:005ae3a663193d3a89eafadc073880c67d6b829e0ad989690275d02b5adc810a", size = 87367515, upload-time = "2026-07-16T19:00:10.661Z" },
+]
+
+[[package]]
+name = "jaxtyping"
+version = "0.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wadler-lindig" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/c1/091b8852bd7cbf50bd655543c8506033cf4029300c67f8c176c1286879a9/jaxtyping-0.3.11.tar.gz", hash = "sha256:b09c14acf6686feb9e0df5b0d8c6e7c5b6f8d36bf059ee54cd522a186c2ef050", size = 46489, upload-time = "2026-06-13T18:35:23.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/38/c66bbdc5047f4776c2bd3e47e5295a350e3fa44d5b8942105e71c2a876a0/jaxtyping-0.3.11-py3-none-any.whl", hash = "sha256:8a4bedc4e3f963fa82df41bd13c7ebc2bad925601eb48614c65798f21329d4e3", size = 56593, upload-time = "2026-06-13T18:35:22.01Z" },
 ]
 
 [[package]]
@@ -2319,6 +2338,19 @@ wheels = [
 ]
 
 [[package]]
+name = "ripplegw"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax" },
+    { name = "jaxtyping" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/4b/0497feefa9e502e717be8ac797a401eac2c9eb916bc682d98aeef3a97d91/ripplegw-0.3.0.tar.gz", hash = "sha256:9e2a415a94bf4aaa3d90a2426298cda4c0c1feaaecd8468745dcabc54abfb3d2", size = 479776, upload-time = "2026-07-29T10:33:36.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/cb/b9573f0ceae67274946ab633060053d7509d0d2f833f5f306aa593c13d4b/ripplegw-0.3.0-py3-none-any.whl", hash = "sha256:2aa86258b3b1714a92602d02c5edb58e7305b73bcd4136f5121345414cb7e302", size = 224968, upload-time = "2026-07-29T10:33:34.881Z" },
+]
+
+[[package]]
 name = "ruyaml"
 version = "0.91.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2690,6 +2722,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fe/25/e367a7229b0914772ca8d81b41fde012d9feda68523b52644a571bb21ce8/virtualenv-21.7.0.tar.gz", hash = "sha256:7f9519b9432ff11b6e1a3e94061664efc2ff99ea21780e3cf4f6bd0a5da8b37c", size = 5527510, upload-time = "2026-07-21T13:12:14.109Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/7a/ae29312b1e88a22e81f5d21fc11526d2a114089776c2550d2b205b6c2a47/virtualenv-21.7.0-py3-none-any.whl", hash = "sha256:a8370c1c5530fbabf955e40b8fbbc68a431648b10f9433faa587db30a06e51dd", size = 5507078, upload-time = "2026-07-21T13:12:12.136Z" },
+]
+
+[[package]]
+name = "wadler-lindig"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/67/cbae4bf7683a64755c2c1778c418fea96d00e34395bb91743f08bd951571/wadler_lindig-0.1.7.tar.gz", hash = "sha256:81d14d3fe77d441acf3ebd7f4aefac20c74128bf460e84b512806dccf7b2cd55", size = 15842, upload-time = "2025-06-18T07:00:42.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/96/04e7b441807b26b794da5b11e59ed7f83b2cf8af202bd7eba8ad2fa6046e/wadler_lindig-0.1.7-py3-none-any.whl", hash = "sha256:e3ec83835570fd0a9509f969162aeb9c65618f998b1f42918cfc8d45122fe953", size = 20516, upload-time = "2025-06-18T07:00:41.684Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 📝 Summary

**gwmock could not run a GPU simulation at all.** Not slowly — at all. It had no call site for
gwmock-signal's batched path: `cli/adapter_orchestration.py` loops over population events calling
`simulate` one at a time, which is the only shape the LAL and PyCBC backends offer.

`SignalAdapter.simulate_segments` is the batched counterpart — catalogue in as a struct-of-arrays,
assembled segments out — with `events_to_struct_of_arrays` to transpose what the orchestration layer
holds.

It is deliberately a **second** entry point rather than a change to `simulate_stack`, because the
per-event path must keep working unchanged for backends with no batched form.

### The device path always generates with Ripple

Worth stating plainly, because it is the sharpest edge here. Ripple is the only JAX implementation
and therefore the only batchable one, so this path ignores the configured backend. An adapter built
for LAL that runs here gets Ripple's version of the approximant — close agreement, not bit-for-bit.

The adapter cannot detect which backend it holds: `CBCSimulator` keeps its `waveform_backend` inside
a `WaveformFactory` and exposes no attribute for it. What it *can* check is the approximant, so
`_device_approximant()` rejects any approximant Ripple does not implement and lists the alternatives.
A `SEOBNRv4` adapter errors instead of quietly becoming a Phenom waveform. The remaining
implementation difference is documented rather than left unsaid.

### Verified end to end

Against the released gwmock-signal 0.12.0: six BNS events through the bundled `ET-Triangle-Sardinia`
preset give **four assembled segments across three channels, 493,755 non-zero samples, peak strain
3.6e-23**.

### Two dependency changes

The floor moves to `gwmock-signal>=0.12.0`, the first release exporting the device entry points — a
resolver could otherwise legally pick an older 0.11.x, where the import fails.

A **`jax` extra** is added, mirroring `sgwb`. This is a real gap independent of everything else:
gwmock declared no such extra, so `ripplegw` was absent from a standard install and the device path
was unreachable **by installation**, not just by code. Note this installs generic JAX, not a
CUDA-enabled build — GPU deployment instructions are still owed, and are not in this PR.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue) — the missing `[jax]` extra
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

Additive. The per-event path is untouched; no existing behaviour changes.

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** `uv run pytest` — **750 passed, 23 skipped**. The skips are pre-existing
      legacy-config ones, verified identical on `main`. 15 new tests in
      `tests/signal/test_adapter_batch.py`.
- [x] **Manual Test:** verified against the **released** 0.12.0 from PyPI, not only a local build.
- [x] **Manual Test:** red check — with `adapter.py` reverted to the first commit, all 7 tests added
      in the second commit fail and only the 8 pre-existing ones pass.
- Input-handling tests run without the `[jax]` extra; only those reaching Ripple skip.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

## 📷 Screenshots (if applicable)

Not applicable.

## What the independent review changed

An independent review found two ways this could silently generate a different waveform than the one
configured, and both were real.

`_waveform_model_name` searched `waveform_model`, then `_waveform_model`, then `approximant` on the
backend. `_waveform_model` turned out to be the private backing field of the public `waveform_model`
property, so the chain read the same value twice and then tried a name nothing defines — three
candidates, one real source. Now it reads the public property only, since a backend that grew a
similarly-named attribute for another purpose would otherwise be picked up silently.

**Callable waveform models** are registered under a generated key by the per-event path. That key was
reaching Ripple as if it were an approximant name, so the failure talked about an unsupported
approximant called `__gwmock_custom__...` rather than about the callable. Rejected explicitly now.

**Ragged events now raise.** This reverses the original behaviour and the reasoning behind it. The
docstring said intersecting to the shared keys avoids fabricating physics; it does the opposite — if
one event omits `spin_1z`, the column disappears and the backend default is applied to *every* event,
with nothing said. That is worse than the malformed catalogue it was concealing.

Two more: length validation tested `isinstance(list, tuple)`, so an `ndarray` of the wrong length
bypassed it and failed inside batching where the message no longer names the parameter; and
`earth_rotation` was not forwarded, so it was honoured on the per-event path and ignored here.

The review also caught a test whose name overpromised — it asserted through a failure message, which
passes for either merge order and so could not detect the precedence being backwards, the one thing
it existed to check. It now captures what actually reaches `simulate_cbc_catalogue`.

## Not in this PR

The CLI still cannot reach this. `_simulate()` is not wired to it and no config key selects a compute
backend, so the path exists for API callers but not from a YAML run. That is the next slice — see
`gwmock/device-call-site` and `gwmock/config-compute-backend`.

Also outstanding: per-event provenance on segments, assembly ownership, and CUDA-specific install
documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added batched gravitational-wave signal simulation for generating detector segments from event catalogues.
  - Added support for device-accelerated simulation through the optional JAX extra.
  - Added configurable chunking, waveform arguments, Earth-rotation handling, and simulation time ranges.
  - Added validation for event parameters, input shapes, and supported waveform approximants.
- **Compatibility**
  - Updated the signal simulation backend requirement to version 0.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->