### PR TITLE
docs(examples): index every example and fix the end-to-end test matrix

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -56,16 +56,18 @@ each is runnable without editing.
 The glitch examples are per-detector rather than per-network because each
 detector draws from its own glitch population file.
 
-## Which of these the test suite runs
+## The end-to-end test matrix
 
-A **subset** of these examples is the end-to-end test matrix: the configs the
-suite drives through the real CLI to check a run completes, writes the expected
-files, and reproduces stored reference values.
+A **subset** of these examples is declared as the end-to-end matrix: the configs
+intended to be driven through the real CLI, checking that a run completes,
+writes the expected files, and reproduces stored reference values.
 
-> **Status.** The matrix below is fixed and enforced — `tests/e2e/matrix.py`
-> holds it as data, and a test fails if this table and that file disagree. The
-> runner that executes the configs lands separately; until it does, these
-> entries are checked for existence, not yet run.
+> **Status — declared, not yet executed.** No runner drives these configs today.
+> What is enforced now is that the set is fixed and consistent:
+> `tests/e2e/matrix.py` holds it as data, a test fails if this table and that
+> file disagree, and every entry must name an example that exists. Nothing yet
+> checks that running one reaches the code path claimed for it. The runner lands
+> separately, and this note goes when it does.
 
 The subset is chosen to cover each distinct **code path** exactly once, not
 every configuration. Where two examples differ only in values that flow through
@@ -75,7 +77,7 @@ what guarantee the others follow. That assumption is the reason the subset is
 legitimate; if a change makes two examples take genuinely different paths, the
 matrix needs a new entry.
 
-| Label                                              | Code path it covers                                                            |
+| Label                                              | Code path it is intended to cover                                              |
 | -------------------------------------------------- | ------------------------------------------------------------------------------ |
 | `default_config`                                   | The blank template must run unedited; noise-only, single segment               |
 | `noise/uncorrelated_gaussian/quick_start`          | Signal **and** noise in one run; CBC; GWF output                               |
@@ -96,11 +98,11 @@ Deliberately excluded, with the reason:
 - **`e2`/`e3` glitch files**, which differ only in the population file they
   read.
 
-The tests do **not** edit these files. Durations, sample counts and input paths
-are reduced by a test-time overlay, so the examples stay realistic as examples
-while the suite stays fast. Changing an example still changes what the suite
-runs — that is the point — but shortening one for the tests' benefit is never
-necessary.
+The tests will **not** edit these files. Durations, sample counts and input
+paths are to be reduced by a test-time overlay, so the examples stay realistic
+as examples while the suite stays fast. Changing an example will still change
+what the suite runs — that is the point — but shortening one for the tests'
+benefit should never be necessary.
 
 Adding a new example is free: the label is derived from the directory path. Add
 it to the table above. Add it to the matrix only if it reaches code no listed

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,107 @@
+# Example configurations
+
+Ready-to-run configuration files for gwmock. Every directory here containing a
+`config.yaml` is a **label** you can fetch from the CLI — the label is just the
+path:
+
+```bash
+gwmock config --list                                    # show every label
+gwmock config --get signal/bbh/et_triangle_sardinia --output config.yaml
+gwmock simulate config.yaml
+```
+
+New to gwmock? Start with **`noise/uncorrelated_gaussian/quick_start`** — one
+segment, signal and noise together, a few minutes to run. To write a
+configuration from scratch instead, start from **`default_config`**, a commented
+noise-only template.
+
+These examples are sized to be _realistic_, not fast: most generate one day of
+data in 4096-second segments. Shorten `total-duration` before running one end to
+end.
+
+## Choosing an example
+
+**By what you want to generate**
+
+| Goal                           | Label                                          |
+| ------------------------------ | ---------------------------------------------- |
+| Detector noise only            | `noise/uncorrelated_gaussian/<network>`        |
+| Noise with transient glitches  | `noise/glitches/gengli/<network>/<detector>`   |
+| CBC signals only (no noise)    | `signal/bbh/<network>`, `signal/bns/<network>` |
+| Signals **and** noise together | `noise/uncorrelated_gaussian/quick_start`      |
+| Stochastic background          | `signal/sgwb/<network>`                        |
+| A blank starting point         | `default_config`                               |
+
+**By detector network** — every `<network>` above is one of
+`et_triangle_sardinia`, `et_triangle_emr`, `et_2l_aligned`, `et_2l_misaligned`.
+These differ **only** in the `detectors:` entry, so you can equally take any
+example and change that one field. The four are provided as separate files so
+each is runnable without editing.
+
+## Every example
+
+| Label                                              | Generates          | Network                       | Notes                                                              |
+| -------------------------------------------------- | ------------------ | ----------------------------- | ------------------------------------------------------------------ |
+| `default_config`                                   | noise              | Triangle Sardinia             | Commented template; single 4096 s segment                          |
+| `noise/uncorrelated_gaussian/quick_start`          | signal + noise     | Triangle Sardinia             | **Start here.** 1024 s, one BBH event                              |
+| `noise/uncorrelated_gaussian/et_triangle_sardinia` | noise              | Triangle Sardinia             | 1 day, `ET_10_full_cryo_psd`                                       |
+| `noise/uncorrelated_gaussian/et_triangle_emr`      | noise              | Triangle EMR                  | 1 day, `ET_10_full_cryo_psd`                                       |
+| `noise/uncorrelated_gaussian/et_2l_aligned`        | noise              | 2L aligned                    | 1 day, `ET_15_full_cryo_psd`                                       |
+| `noise/uncorrelated_gaussian/et_2l_misaligned`     | noise              | 2L misaligned                 | 1 day, `ET_15_full_cryo_psd`                                       |
+| `noise/glitches/gengli/<network>/<e1\|e2\|e3>`     | noise + glitches   | all four                      | One file **per detector**; blip glitches at 1/min. Needs `gengli`  |
+| `signal/bbh/<network>`                             | signal             | all four                      | `IMRPhenomXPHM`, f<sub>min</sub> 10 Hz, Earth rotation on          |
+| `signal/bns/<network>`                             | signal             | all four                      | `IMRPhenomPv2_NRTidalv2`, f<sub>min</sub> 20 Hz, Earth rotation on |
+| `signal/sgwb/<network>`                            | background + noise | Triangle Sardinia, 2L aligned | 16 s; signal written as **HDF5**, noise as GWF                     |
+
+The glitch examples are per-detector rather than per-network because each
+detector draws from its own glitch population file.
+
+## Which of these the test suite runs
+
+A **subset** of these examples is the end-to-end test matrix: the configs the
+suite drives through the real CLI to check a run completes, writes the expected
+files, and reproduces stored reference values.
+
+> **Status.** The matrix below is fixed and enforced — `tests/e2e/matrix.py`
+> holds it as data, and a test fails if this table and that file disagree. The
+> runner that executes the configs lands separately; until it does, these
+> entries are checked for existence, not yet run.
+
+The subset is chosen to cover each distinct **code path** exactly once, not
+every configuration. Where two examples differ only in values that flow through
+the same code — four detector networks resolved by the same `Network` class, BBH
+versus BNS both handled by `CBCSimulator` — one is enough, and unit tests are
+what guarantee the others follow. That assumption is the reason the subset is
+legitimate; if a change makes two examples take genuinely different paths, the
+matrix needs a new entry.
+
+| Label                                              | Code path it covers                                                            |
+| -------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `default_config`                                   | The blank template must run unedited; noise-only, single segment               |
+| `noise/uncorrelated_gaussian/quick_start`          | Signal **and** noise in one run; CBC; GWF output                               |
+| `noise/uncorrelated_gaussian/et_triangle_sardinia` | Noise-only across **many** segments (chunking, per-segment seeds)              |
+| `signal/bbh/et_triangle_sardinia`                  | Signal-only CBC; Earth rotation; population loaded from file                   |
+| `signal/sgwb/et_triangle_sardinia`                 | `StochasticBackgroundSimulator` — a different simulator class; **HDF5** output |
+| `noise/glitches/gengli/et_triangle_sardinia/e1`    | Glitch injection. Skipped when `gengli` is absent                              |
+
+Deliberately excluded, with the reason:
+
+- **The other three networks**, for every category — same `Network` code,
+  different numbers.
+- **BNS**, because `resolve_simulator_backend` returns the same `CBCSimulator`
+  for `bbh` and `bns`; they differ in waveform model and tidal parameters, which
+  unit tests own. BNS is also the expensive case: its inspiral is roughly 160 s
+  at 20 Hz, so it cannot be shortened to a test-sized segment without truncating
+  the chirp and simulating something physically wrong.
+- **`e2`/`e3` glitch files**, which differ only in the population file they
+  read.
+
+The tests do **not** edit these files. Durations, sample counts and input paths
+are reduced by a test-time overlay, so the examples stay realistic as examples
+while the suite stays fast. Changing an example still changes what the suite
+runs — that is the point — but shortening one for the tests' benefit is never
+necessary.
+
+Adding a new example is free: the label is derived from the directory path. Add
+it to the table above. Add it to the matrix only if it reaches code no listed
+entry does.

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end tests driving the real CLI over a subset of the example configurations."""

--- a/tests/e2e/matrix.py
+++ b/tests/e2e/matrix.py
@@ -1,0 +1,65 @@
+"""The subset of ``examples/`` that the end-to-end suite runs, and why each one is in it.
+
+This module is the single source of truth for the matrix. ``examples/README.md`` documents
+the same set for users, and ``test_examples_index.py`` fails if the two disagree -- a
+README that can drift from what the suite actually runs is worse than no README, because
+it is read as a statement of coverage.
+
+The selection principle is one entry per distinct **code path**, not per configuration.
+Examples that differ only in values flowing through the same code (four detector networks
+resolved by one ``Network`` class; ``bbh`` and ``bns`` both resolving to ``CBCSimulator``)
+are represented once. Unit tests are what guarantee the unrepresented ones follow, so an
+entry earns its place only by reaching code no other entry does.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MatrixEntry:
+    """One example configuration in the end-to-end matrix.
+
+    Attributes:
+        label: Path-derived example label, exactly as ``gwmock config --get`` takes it.
+        covers: The code path this entry exists to exercise. Written as a claim that can be
+            checked against the code, not as a restatement of the label.
+        requires: Import names that must be present for this entry to run, if any. An entry
+            whose dependency is missing is skipped rather than failed.
+    """
+
+    label: str
+    covers: str
+    requires: tuple[str, ...] = ()
+
+
+#: The matrix. Keep in step with the "Which of these the test suite runs" table in
+#: ``examples/README.md`` -- a test enforces it.
+E2E_MATRIX: tuple[MatrixEntry, ...] = (
+    MatrixEntry(
+        label="default_config",
+        covers="The blank template must run unedited; noise-only, single segment",
+    ),
+    MatrixEntry(
+        label="noise/uncorrelated_gaussian/quick_start",
+        covers="Signal **and** noise in one run; CBC; GWF output",
+    ),
+    MatrixEntry(
+        label="noise/uncorrelated_gaussian/et_triangle_sardinia",
+        covers="Noise-only across **many** segments (chunking, per-segment seeds)",
+    ),
+    MatrixEntry(
+        label="signal/bbh/et_triangle_sardinia",
+        covers="Signal-only CBC; Earth rotation; population loaded from file",
+    ),
+    MatrixEntry(
+        label="signal/sgwb/et_triangle_sardinia",
+        covers="`StochasticBackgroundSimulator` -- a different simulator class; **HDF5** output",
+    ),
+    MatrixEntry(
+        label="noise/glitches/gengli/et_triangle_sardinia/e1",
+        covers="Glitch injection. Skipped when `gengli` is absent",
+        requires=("gengli",),
+    ),
+)

--- a/tests/e2e/matrix.py
+++ b/tests/e2e/matrix.py
@@ -1,9 +1,12 @@
-"""The subset of ``examples/`` that the end-to-end suite runs, and why each one is in it.
+"""The subset of ``examples/`` *declared* as the end-to-end matrix, and why each one is in it.
 
-This module is the single source of truth for the matrix. ``examples/README.md`` documents
-the same set for users, and ``test_examples_index.py`` fails if the two disagree -- a
-README that can drift from what the suite actually runs is worse than no README, because
-it is read as a statement of coverage.
+Declared, not yet executed: no runner drives these configs. Today the entries are checked
+only for existence, and for agreement with the table in ``examples/README.md``. The wording
+matters because a list of examples reads as a claim about coverage, and overstating it is
+worse than having no list -- so the present tense is reserved for when a runner exists.
+
+This module is the single source of truth for the set. ``examples/README.md`` documents the
+same set for users, and ``test_examples_index.py`` fails if the two disagree.
 
 The selection principle is one entry per distinct **code path**, not per configuration.
 Examples that differ only in values flowing through the same code (four detector networks
@@ -23,10 +26,12 @@ class MatrixEntry:
 
     Attributes:
         label: Path-derived example label, exactly as ``gwmock config --get`` takes it.
-        covers: The code path this entry exists to exercise. Written as a claim that can be
-            checked against the code, not as a restatement of the label.
+        covers: The code path this entry is intended to exercise. Written as a claim that can
+            be checked against the code, not as a restatement of the label. Intent for now --
+            nothing verifies that running the config reaches that path, because nothing runs
+            it yet.
         requires: Import names that must be present for this entry to run, if any. An entry
-            whose dependency is missing is skipped rather than failed.
+            whose dependency is missing will be skipped rather than failed.
     """
 
     label: str
@@ -34,8 +39,8 @@ class MatrixEntry:
     requires: tuple[str, ...] = ()
 
 
-#: The matrix. Keep in step with the "Which of these the test suite runs" table in
-#: ``examples/README.md`` -- a test enforces it.
+#: The declared matrix. Keep in step with the corresponding table in ``examples/README.md``
+#: -- a test enforces it.
 E2E_MATRIX: tuple[MatrixEntry, ...] = (
     MatrixEntry(
         label="default_config",

--- a/tests/e2e/test_examples_index.py
+++ b/tests/e2e/test_examples_index.py
@@ -2,8 +2,11 @@
 
 Documentation that lists coverage is read as a statement *about* coverage, so it is worth
 enforcing rather than trusting. Three ways it can lie, one test each: an example missing
-from the index, an index row naming an example that is gone, and the documented test
-matrix disagreeing with the matrix the suite runs.
+from the index, an index row naming an example that is gone, and the documented matrix
+disagreeing with the matrix declared in ``matrix.py``.
+
+Note what is *not* checked here: that running a matrix entry reaches the code path claimed
+for it. No runner exists yet, so every claim in ``covers`` is intent.
 """
 
 from __future__ import annotations
@@ -18,6 +21,10 @@ from .matrix import E2E_MATRIX
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _EXAMPLES = _REPO_ROOT / "examples"
 _README = _EXAMPLES / "README.md"
+
+#: Heading that introduces the matrix table. Named once because the parser splits on it, so a
+#: reworded heading silently empties the comparison rather than failing it.
+_MATRIX_HEADING = "## The end-to-end test matrix"
 
 #: Placeholders used in the index table so it stays browsable at ~26 examples. Expanding
 #: them here rather than writing every row out keeps the README readable *and* checkable.
@@ -81,13 +88,21 @@ def test_the_index_does_not_name_examples_that_are_gone():
     assert not stale, f"the README indexes examples that no longer exist: {sorted(stale)}"
 
 
-def test_the_documented_matrix_matches_the_matrix_the_suite_runs():
+def test_the_documented_matrix_matches_the_declared_matrix():
     """The README's matrix table and ``E2E_MATRIX`` must be the same set, in the same order.
+
+    The *declared* matrix -- no runner executes these configs yet, so this compares two
+    statements of intent and nothing here shows that running them reaches the claimed paths.
 
     Order too, not just membership: the table is read top to bottom as the coverage
     argument, and a silently reordered one invites the two to drift apart in content next.
     """
-    body = _README.read_text(encoding="utf-8").split("## Which of these the test suite runs")[-1]
+    text = _README.read_text(encoding="utf-8")
+    assert _MATRIX_HEADING in text, (
+        f"the README no longer has a '{_MATRIX_HEADING}' heading, so this test cannot locate "
+        f"the table it is meant to compare."
+    )
+    body = text.split(_MATRIX_HEADING)[-1]
     documented = [re.match(r"\| `([^`]+)`", line).group(1) for line in body.splitlines() if line.startswith("| `")]
     assert documented == [entry.label for entry in E2E_MATRIX], (
         "examples/README.md and tests/e2e/matrix.py disagree about the end-to-end matrix."

--- a/tests/e2e/test_examples_index.py
+++ b/tests/e2e/test_examples_index.py
@@ -1,0 +1,108 @@
+"""``examples/README.md`` must describe the examples that actually exist, and the matrix.
+
+Documentation that lists coverage is read as a statement *about* coverage, so it is worth
+enforcing rather than trusting. Three ways it can lie, one test each: an example missing
+from the index, an index row naming an example that is gone, and the documented test
+matrix disagreeing with the matrix the suite runs.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from .matrix import E2E_MATRIX
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLES = _REPO_ROOT / "examples"
+_README = _EXAMPLES / "README.md"
+
+#: Placeholders used in the index table so it stays browsable at ~26 examples. Expanding
+#: them here rather than writing every row out keeps the README readable *and* checkable.
+_PLACEHOLDERS = {
+    "<network>": ("et_triangle_sardinia", "et_triangle_emr", "et_2l_aligned", "et_2l_misaligned"),
+    "<e1|e2|e3>": ("e1", "e2", "e3"),
+}
+
+
+def _actual_labels() -> set[str]:
+    """Return every example label, derived exactly as ``gwmock config --list`` derives it."""
+    return {str(path.parent.relative_to(_EXAMPLES)) for path in _EXAMPLES.rglob("config.yaml")}
+
+
+def _documented_patterns() -> list[str]:
+    """Return the label patterns in the README, from the leading code span of each table row."""
+    patterns = []
+    for line in _README.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("| `"):
+            continue
+        match = re.match(r"\| `([^`]+)`", line)
+        if match:
+            # A literal '|' has to be escaped inside a markdown table, so the alternation
+            # placeholders read as '<e1\|e2\|e3>' in the source. Undo that before matching.
+            patterns.append(match.group(1).replace(r"\|", "|"))
+    return patterns
+
+
+def _expand(pattern: str) -> set[str]:
+    """Expand one README pattern into the concrete labels it stands for."""
+    expanded = {pattern}
+    for placeholder, options in _PLACEHOLDERS.items():
+        if not any(placeholder in candidate for candidate in expanded):
+            continue
+        expanded = {candidate.replace(placeholder, option) for candidate in expanded for option in options}
+    return expanded
+
+
+def _documented_labels() -> set[str]:
+    """Return every concrete label the README index accounts for."""
+    return {label for pattern in _documented_patterns() for label in _expand(pattern)}
+
+
+def test_every_example_appears_in_the_index():
+    """An example absent from the README is one users cannot discover by browsing."""
+    undocumented = _actual_labels() - _documented_labels()
+    assert not undocumented, (
+        f"these examples exist but no README row covers them: {sorted(undocumented)}. "
+        f"Add a row, or extend an existing pattern."
+    )
+
+
+def test_the_index_does_not_name_examples_that_are_gone():
+    """A row for a deleted example sends users to a label the CLI will reject.
+
+    Only concrete rows are checked. A pattern row expands to every combination, and a
+    partially-populated family is legitimate -- the 2L networks have no ``e3`` detector.
+    """
+    concrete = {pattern for pattern in _documented_patterns() if "<" not in pattern}
+    stale = concrete - _actual_labels()
+    assert not stale, f"the README indexes examples that no longer exist: {sorted(stale)}"
+
+
+def test_the_documented_matrix_matches_the_matrix_the_suite_runs():
+    """The README's matrix table and ``E2E_MATRIX`` must be the same set, in the same order.
+
+    Order too, not just membership: the table is read top to bottom as the coverage
+    argument, and a silently reordered one invites the two to drift apart in content next.
+    """
+    body = _README.read_text(encoding="utf-8").split("## Which of these the test suite runs")[-1]
+    documented = [re.match(r"\| `([^`]+)`", line).group(1) for line in body.splitlines() if line.startswith("| `")]
+    assert documented == [entry.label for entry in E2E_MATRIX], (
+        "examples/README.md and tests/e2e/matrix.py disagree about the end-to-end matrix."
+    )
+
+
+@pytest.mark.parametrize("entry", E2E_MATRIX, ids=lambda entry: entry.label)
+def test_every_matrix_entry_is_a_real_example(entry):
+    """The matrix must not reference a label that has been renamed or removed."""
+    assert (_EXAMPLES / entry.label / "config.yaml").is_file(), (
+        f"matrix entry '{entry.label}' has no config.yaml; the example was renamed or removed."
+    )
+
+
+def test_each_matrix_entry_states_a_distinct_code_path():
+    """Two entries claiming the same coverage means one of them is not earning its runtime."""
+    claims = [entry.covers for entry in E2E_MATRIX]
+    assert len(set(claims)) == len(claims), "two matrix entries claim to cover the same code path"


### PR DESCRIPTION
## 📝 Summary

`examples/` had **no index**, and the 26 configs in it are not the matrix of execution paths they
look like.

Ten differ only in which detector's glitch population they read. Twelve only in the detector
network. Around 22 collapse onto roughly five distinct code paths — while four of the six CLI
commands appear in no example at all, and the output-format branches (`npy`, `txt` for signal;
`npy` for noise) have zero coverage.

This adds two things and no behaviour change.

**`examples/README.md`** indexes all 26: a goal-oriented table for picking one, then a full listing
using `<network>` and `<e1|e2|e3>` placeholders so 26 rows stay browsable rather than becoming a
wall.

**`tests/e2e/matrix.py`** fixes the subset the end-to-end suite will drive — one entry per distinct
code path, not per configuration. Four networks resolve through one `Network` class and `bbh`/`bns`
both resolve to `CBCSimulator`, so those are represented once. Unit tests are what guarantee the
rest follow, and that assumption is recorded as the reason the subset is legitimate.

### Why the drift tests

An index that lists coverage gets _read_ as a statement about coverage, so it is worth enforcing
rather than trusting. Three ways it can lie, one test each: an example missing from the index, an
index row naming an example that is gone, and the documented matrix disagreeing with the matrix in
code.

The third earned its keep immediately — markdown escapes pipes inside tables, so the alternation
placeholder is really `<e1\|e2\|e3>`, and my pattern expansion silently failed to match **nine**
glitch examples. That would have shipped as a confidently-wrong index.

### On BNS being excluded

Two independent grounds. `resolve_simulator_backend` returns the same `CBCSimulator` for `bbh` and
`bns` — they differ in waveform model and tidal parameters, which unit tests own. Separately, BNS is
the expensive case: its inspiral is roughly **160 s at 20 Hz**, so it cannot be shortened to a
test-sized segment without truncating the chirp and simulating something physically wrong.

That 160 s is 0PN scaling from a measured 1033 s at 10 Hz, so treat it as ±20%, not exact. It is the
constraint that decides BNS cannot be in a fast matrix, so the direction matters more than the
digits.

## ✨ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [x] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

No source changes. Nothing under `src/` is touched.

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** `uv run pytest` — **762 passed, 23 skipped**. The skips are pre-existing
      legacy-config ones, verified identical on `main`. 10 new tests in
      `tests/e2e/test_examples_index.py`.
- [x] **Manual Test:** the drift tests were confirmed red before being made to pass — the
      escaped-pipe bug above was found that way, not by inspection.
- [x] **Manual Test:** verified the parser still passes after `prettier` reformatted the tables,
      since it depends on that formatting.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation — this PR _is_ the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

## 📷 Screenshots (if applicable)

Not applicable.

## What this deliberately does not do

**No runner.** Nothing executes the matrix yet; the entries are checked for existence only. The
README says so in a status note rather than claiming coverage that does not exist — writing "the
suite runs these configs" while no runner existed would be precisely the lie the drift tests are
here to prevent.

**No examples deleted.** An earlier plan was to collapse the geometry duplicates. Keeping all 26 and
testing a subset serves users and tests separately, which is better than making the examples worse
to make the tests cheaper.

Still to come, each separately: the `e2e` marker and its own CI job, absorbing
`tests/cli/test_sgwb_end_to_end.py`, the test-time overlay that shortens durations without editing
these files, a determinism probe, and then stored reference values.

## Sequencing

`feat/waveform-backend-selection` is stacked on this branch and adds a
`signal/waveform_backend/ripple` example with its README row and matrix entry. Merging this first
lets that one rebase onto `main` cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for example configurations, CLI usage, detector networks, testing, overlays, and contribution workflows.

* **Tests**
  * Added end-to-end coverage for selected example configurations and optional dependency scenarios.
  * Added validation ensuring the examples documentation stays complete, accurate, and synchronized with the test matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->