### PR TITLE
feat(config): select the waveform library from a configuration file

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -22,5 +22,8 @@ extend-ignore-re = [
 [default.extend-words]
 # numpy function name, not a misspelling of "arrange"
 arange = "arange"
+# a binary whose orbital plane precesses; read as "processing" otherwise
+precessing = "precessing"
+precession = "precession"
 aer = "aer"
 BA = "BA"

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -297,7 +297,9 @@ orchestration:
 `signal.waveform-backend` selects which library generates the polarizations —
 `lal` (the default), `pycbc`, `ripple`, or `gwsignal`. It also accepts an entry
 point in the `gwmock.waveform` group or a `module:Class` reference, so a
-third-party backend can be plugged in the same way.
+third-party backend can be plugged in the same way. Such a backend is matched by
+its public surface — `available_approximants` and `generate_td_waveform` — and
+does not have to subclass gwmock-signal's `WaveformBackend`.
 
 Constructor arguments for that backend go under
 `signal.waveform-backend-arguments`. These are distinct from `signal.arguments`,

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -292,6 +292,40 @@ orchestration:
                 channel: '{{ detectors }}:STRAIN'
 ```
 
+### Choosing the waveform library
+
+`signal.waveform-backend` selects which library generates the polarizations —
+`lal` (the default), `pycbc`, `ripple`, or `gwsignal`. It also accepts an entry
+point in the `gwmock.waveform` group or a `module:Class` reference, so a
+third-party backend can be plugged in the same way.
+
+Constructor arguments for that backend go under
+`signal.waveform-backend-arguments`. These are distinct from `signal.arguments`,
+which is passed to the _simulator_ rather than to the waveform backend:
+
+```yaml
+signal:
+    waveform-model: IMRPhenomD
+    waveform-backend: ripple
+    waveform-backend-arguments:
+        taper_fraction: 0.05 # ripple-specific
+```
+
+Two things to be aware of:
+
+- This selects a **library, not a compute device.** `ripple` is JAX-based, but
+  it runs through the same per-event path as LAL; gwmock does not yet drive
+  ripple's batched on-device entry point from a configuration file.
+- The same approximant from two libraries agrees closely but not exactly, so the
+  choice changes the data. It is recorded in the run metadata as
+  `orchestration.signal.waveform_backend` for that reason.
+
+`ripple` requires the extra: `pip install 'gwmock[jax]'`. It also JIT-compiles
+each waveform model on first use — measured on a single 8-second segment,
+`IMRPhenomD` took ~10 s end to end against ~0.7 s for LAL, and the precessing
+`IMRPhenomXPHM` ~72 s. The cost is paid once per process, so it amortises over a
+long run.
+
 For SGWB studies, use `signal.source-type: sgwb`. Constructor options for the
 SGWB backend belong under `signal.arguments`, while spectrum parameters passed
 to `simulate(...)` belong under `signal.parameters`:

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,14 +23,22 @@ end.
 
 **By what you want to generate**
 
-| Goal                           | Label                                          |
-| ------------------------------ | ---------------------------------------------- |
-| Detector noise only            | `noise/uncorrelated_gaussian/<network>`        |
-| Noise with transient glitches  | `noise/glitches/gengli/<network>/<detector>`   |
-| CBC signals only (no noise)    | `signal/bbh/<network>`, `signal/bns/<network>` |
-| Signals **and** noise together | `noise/uncorrelated_gaussian/quick_start`      |
-| Stochastic background          | `signal/sgwb/<network>`                        |
-| A blank starting point         | `default_config`                               |
+| Goal                                      | Label                                          |
+| ----------------------------------------- | ---------------------------------------------- |
+| Detector noise only                       | `noise/uncorrelated_gaussian/<network>`        |
+| Noise with transient glitches             | `noise/glitches/gengli/<network>/<detector>`   |
+| CBC signals only (no noise)               | `signal/bbh/<network>`, `signal/bns/<network>` |
+| Signals **and** noise together            | `noise/uncorrelated_gaussian/quick_start`      |
+| Stochastic background                     | `signal/sgwb/<network>`                        |
+| Signals from a different waveform library | `signal/waveform_backend/ripple`               |
+| A blank starting point                    | `default_config`                               |
+
+**By waveform library** — `signal.waveform-backend` chooses which library
+generates the polarizations: `lal` (the default), `pycbc`, `ripple`, or
+`gwsignal`. Any signal example accepts it. It names a **library, not a compute
+device** — `ripple` generates ripple waveforms through the same per-event path,
+since gwmock does not yet drive ripple's batched on-device path from a
+configuration file.
 
 **By detector network** — every `<network>` above is one of
 `et_triangle_sardinia`, `et_triangle_emr`, `et_2l_aligned`, `et_2l_misaligned`.
@@ -52,6 +60,7 @@ each is runnable without editing.
 | `signal/bbh/<network>`                             | signal             | all four                      | `IMRPhenomXPHM`, f<sub>min</sub> 10 Hz, Earth rotation on          |
 | `signal/bns/<network>`                             | signal             | all four                      | `IMRPhenomPv2_NRTidalv2`, f<sub>min</sub> 20 Hz, Earth rotation on |
 | `signal/sgwb/<network>`                            | background + noise | Triangle Sardinia, 2L aligned | 16 s; signal written as **HDF5**, noise as GWF                     |
+| `signal/waveform_backend/ripple`                   | signal             | Triangle Sardinia             | Waveforms from **ripple** rather than LAL. Needs `gwmock[jax]`     |
 
 The glitch examples are per-detector rather than per-network because each
 detector draws from its own glitch population file.
@@ -84,6 +93,7 @@ matrix needs a new entry.
 | `noise/uncorrelated_gaussian/et_triangle_sardinia` | Noise-only across **many** segments (chunking, per-segment seeds)              |
 | `signal/bbh/et_triangle_sardinia`                  | Signal-only CBC; Earth rotation; population loaded from file                   |
 | `signal/sgwb/et_triangle_sardinia`                 | `StochasticBackgroundSimulator` — a different simulator class; **HDF5** output |
+| `signal/waveform_backend/ripple`                   | A non-default waveform library resolved from config. Needs `ripplegw`          |
 | `noise/glitches/gengli/et_triangle_sardinia/e1`    | Glitch injection. Skipped when `gengli` is absent                              |
 
 Deliberately excluded, with the reason:

--- a/examples/signal/waveform_backend/ripple/config.yaml
+++ b/examples/signal/waveform_backend/ripple/config.yaml
@@ -1,0 +1,55 @@
+# Generate CBC signals with the ripple (JAX) waveform library instead of LAL.
+#
+# `waveform-backend` selects which library generates the polarizations. It is otherwise
+# identical to signal/bbh/et_triangle_sardinia -- diff the two to see only that key change.
+#
+# This selects a LIBRARY, not a compute device. ripple runs through the same per-event path
+# as LAL here; gwmock does not yet drive ripple's batched on-device entry point from a
+# configuration file.
+#
+# Requires the extra:  pip install 'gwmock[jax]'
+#
+# Note on cost: ripple JIT-compiles each waveform model on first use. Measured on one
+# 8-second segment, IMRPhenomD took ~10 s end to end against ~0.7 s for LAL, and the
+# precessing IMRPhenomXPHM took ~72 s. The compile is paid once per process, so it is
+# amortised over a long run -- but IMRPhenomD is the friendlier choice for a first run.
+globals:
+    simulator-arguments:
+        sampling-frequency: 4096
+        duration: 4096
+        total-duration: 4096
+        # 1 Jan 2030, as the noise examples use. Chosen to contain the population's event
+        # (GPS 1577491300): a segment placed elsewhere still runs, and writes only zeros.
+        start-time: 1577491218
+        seed: 42
+    working-directory: .
+    output-directory: output
+    metadata-directory: metadata
+
+orchestration:
+    population:
+        backend: FilePopulationLoader
+        source-type: bbh
+        n-samples: 1
+        arguments:
+            # The small in-repo population, not the sandbox Zenodo deposit the other signal
+            # examples use: sandbox records are purged, so that URL has a built-in expiry.
+            path: https://raw.githubusercontent.com/Leuven-Gravity-Institute/gwmock/main/examples/signal/bbh_population.csv
+    signal:
+        waveform-model: IMRPhenomD
+        waveform-backend: ripple
+        waveform-backend-arguments:
+            # Raised-cosine taper below minimum-frequency, suppressing the Gibbs ringing a
+            # hard spectral cutoff would leave. Set 0.0 for an untapered cutoff.
+            taper_fraction: 0.05
+        minimum-frequency: 20
+        earth-rotation: true
+        detectors:
+            - ET-Triangle-Sardinia
+        output:
+            output_directory: signal
+            file_name:
+                'E-{{ detectors }}_STRAIN_BBH-{{ start_time }}-{{ duration
+                }}.gwf'
+            arguments:
+                channel: '{{ detectors }}:STRAIN'

--- a/examples/signal/waveform_backend/ripple/config.yaml
+++ b/examples/signal/waveform_backend/ripple/config.yaml
@@ -34,7 +34,12 @@ orchestration:
         arguments:
             # The small in-repo population, not the sandbox Zenodo deposit the other signal
             # examples use: sandbox records are purged, so that URL has a built-in expiry.
-            path: https://raw.githubusercontent.com/Leuven-Gravity-Institute/gwmock/main/examples/signal/bbh_population.csv
+            #
+            # Pinned to a commit rather than `main`, so the input to this example cannot change
+            # under it. Fetching from a branch means two runs of "the same example" can differ,
+            # which matters more here than tracking edits to the file. Update the SHA
+            # deliberately if the population is ever meant to change.
+            path: https://raw.githubusercontent.com/Leuven-Gravity-Institute/gwmock/9fa389516dfd8b818670b0ae4359e9be04f30e5e/examples/signal/bbh_population.csv
     signal:
         waveform-model: IMRPhenomD
         waveform-backend: ripple

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -325,6 +325,17 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         backend_arguments = _normalize_keys(dict(signal_config.arguments))
         if source_type == "sgwb":
             backend_arguments.setdefault("duration", duration)
+
+        # `waveform-backend` names a library; the simulator wants an instance. Resolved here so an
+        # unknown name is reported against the setting, rather than reaching WaveformFactory as a
+        # string and failing as an AttributeError about `str`.
+        waveform_backend_name = getattr(signal_config, "waveform_backend", None)
+        if waveform_backend_name:
+            backend_arguments["waveform_backend"] = instantiate_backend(
+                "waveform",
+                waveform_backend_name,
+                init_kwargs=_normalize_keys(dict(signal_config.waveform_backend_arguments)),
+            )
         backend_instance = SignalAdapter.instantiate_backend(
             backend_class,
             waveform_model=signal_config.waveform_model,
@@ -364,6 +375,14 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                 },
                 "signal": {
                     "waveform_model": self.waveform_model,
+                    # Which library generated the polarizations. Recorded because it changes the
+                    # data: the same approximant from LAL and from ripple agree closely but not
+                    # exactly, so without this two runs with materially different strain would
+                    # carry identical provenance. Read from the config rather than stored
+                    # separately, to keep one source of truth. ``None`` means none was requested,
+                    # and gwmock-signal's own default (LAL) applied.
+                    "waveform_backend": self._configured_waveform_backend(),
+                    "waveform_backend_arguments": self._configured_waveform_backend_arguments(),
                     "waveform_arguments": self.waveform_arguments,
                     "waveform_options": self.waveform_options,
                     "parameters": self.signal_parameters,
@@ -383,6 +402,18 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                 "segment_seeds": self.segment_seeds(),
             },
         }
+
+    def _configured_waveform_backend(self) -> str | None:
+        """Return the requested waveform-backend name, or ``None`` if the default applied."""
+        signal_config = self.orchestration_config.signal
+        return None if signal_config is None else getattr(signal_config, "waveform_backend", None)
+
+    def _configured_waveform_backend_arguments(self) -> dict[str, Any]:
+        """Return the waveform-backend constructor arguments, empty when none were given."""
+        signal_config = self.orchestration_config.signal
+        if signal_config is None:
+            return {}
+        return dict(getattr(signal_config, "waveform_backend_arguments", {}) or {})
 
     def resolved_config(self) -> dict[str, Any]:
         """Return runtime-resolved config overrides, shaped like OrchestrationConfig.

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -27,6 +27,11 @@ from gwmock.simulator.base import Simulator
 from gwmock.simulator.seeds import derive_seed
 from gwmock.simulator.state import StateAttribute
 
+#: Waveform library used when a config gives ``waveform-backend-arguments`` but names no
+#: backend. It must stay the same library ``WaveformFactory`` defaults to internally, or
+#: supplying arguments would quietly change which library generates the waveforms.
+_DEFAULT_WAVEFORM_BACKEND = "lal"
+
 
 @dataclass(slots=True)
 class AdapterOrchestrationResult:
@@ -329,12 +334,22 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         # `waveform-backend` names a library; the simulator wants an instance. Resolved here so an
         # unknown name is reported against the setting, rather than reaching WaveformFactory as a
         # string and failing as an AttributeError about `str`.
+        #
+        # Arguments alone are enough to require this. Gating on the name would silently discard
+        # `waveform-backend-arguments` from a config that only tunes the default library --
+        # `f_ref` on LAL, say -- while the run metadata still recorded them as applied. So when
+        # arguments are given without a name, the default is constructed explicitly; that is the
+        # same class WaveformFactory would have built for itself, so nothing else changes.
+        #
+        # `is not None` rather than a truth test, so an empty configured name reaches the
+        # resolver and is rejected there instead of being treated as absent.
         waveform_backend_name = getattr(signal_config, "waveform_backend", None)
-        if waveform_backend_name:
+        waveform_backend_arguments = _normalize_keys(dict(signal_config.waveform_backend_arguments))
+        if waveform_backend_name is not None or waveform_backend_arguments:
             backend_arguments["waveform_backend"] = instantiate_backend(
                 "waveform",
-                waveform_backend_name,
-                init_kwargs=_normalize_keys(dict(signal_config.waveform_backend_arguments)),
+                waveform_backend_name if waveform_backend_name is not None else _DEFAULT_WAVEFORM_BACKEND,
+                init_kwargs=waveform_backend_arguments,
             )
         backend_instance = SignalAdapter.instantiate_backend(
             backend_class,

--- a/src/gwmock/cli/utils/backend_resolver.py
+++ b/src/gwmock/cli/utils/backend_resolver.py
@@ -272,14 +272,19 @@ def _validate_waveform_backend(backend_name: str, backend_instance: Any) -> None
     if isinstance(backend_instance, WaveformBackend):
         return
 
+    # Matching by public surface, as the population, signal and noise validators do. A
+    # third-party backend reached through an entry point should not be forced to subclass
+    # gwmock-signal's ABC in order to be usable, and ``WaveformFactory`` itself only ever calls
+    # these two methods.
     issues = _collect_protocol_issues(
         backend_instance,
         required_attributes={},
         required_callables=("available_approximants", "generate_td_waveform"),
     )
+    if not issues:
+        return
     raise TypeError(
-        f"Resolved waveform backend '{backend_name}' does not satisfy WaveformBackend"
-        f"{': ' + ', '.join(issues) if issues else ''}."
+        f"Resolved waveform backend '{backend_name}' does not satisfy WaveformBackend: {', '.join(issues)}."
     )
 
 

--- a/src/gwmock/cli/utils/backend_resolver.py
+++ b/src/gwmock/cli/utils/backend_resolver.py
@@ -20,12 +20,33 @@ from gwmock_pop import (
 )
 from gwmock_signal import GWSimulator, resolve_simulator_backend
 
-BackendKind = Literal["population", "signal", "noise"]
+BackendKind = Literal["population", "signal", "noise", "waveform"]
 
 _ENTRY_POINT_GROUPS: dict[BackendKind, str] = {
     "population": "gwmock.population",
     "signal": "gwmock.signal",
     "noise": "gwmock.noise",
+    "waveform": "gwmock.waveform",
+}
+
+#: Waveform backends, as ``module:Class`` paths rather than imported classes.
+#:
+#: Deliberately unimported here, so that resolving ``lal`` or ``pycbc`` does not require the
+#: optional stack. What the ``gwmock[jax]`` extra actually supplies is **ripplegw** -- JAX
+#: itself arrives unconditionally as a hard dependency of gwmock-pop -- and instantiating
+#: ``RippleBackend`` without ripplegw raises gwmock-signal's own ``ImportError``, which names
+#: what to install. Importing these at module scope would turn that into an import-time
+#: failure of the whole CLI for users who selected a backend they do have.
+_WAVEFORM_BACKEND_PATHS: dict[str, str] = {
+    "lal": "gwmock_signal.waveform.backends.lal:LALSimulationBackend",
+    "lalsimulation": "gwmock_signal.waveform.backends.lal:LALSimulationBackend",
+    "LALSimulationBackend": "gwmock_signal.waveform.backends.lal:LALSimulationBackend",
+    "pycbc": "gwmock_signal.waveform.backends.pycbc:PyCBCBackend",
+    "PyCBCBackend": "gwmock_signal.waveform.backends.pycbc:PyCBCBackend",
+    "ripple": "gwmock_signal.waveform.backends.ripple:RippleBackend",
+    "RippleBackend": "gwmock_signal.waveform.backends.ripple:RippleBackend",
+    "gwsignal": "gwmock_signal.waveform.backends.gwsignal:GWSignalBackend",
+    "GWSignalBackend": "gwmock_signal.waveform.backends.gwsignal:GWSignalBackend",
 }
 
 _POPULATION_BACKENDS: dict[str, type[Any]] = {
@@ -113,6 +134,9 @@ def validate_backend(
     if kind == "signal":
         _validate_signal_backend(backend_name, backend_class, backend_instance)
         return
+    if kind == "waveform":
+        _validate_waveform_backend(backend_name, backend_instance)
+        return
     _validate_noise_backend(backend_name, backend_instance)
 
 
@@ -130,6 +154,9 @@ def _resolve_builtin_backend(kind: BackendKind, backend_name: str) -> type[Any] 
             return resolve_simulator_backend(backend_name)
         except (KeyError, ValueError):
             return None
+    if kind == "waveform":
+        path = _WAVEFORM_BACKEND_PATHS.get(backend_name)
+        return None if path is None else _load_backend_class(path)
     return _NOISE_BACKENDS.get(backend_name)
 
 
@@ -206,6 +233,8 @@ def _builtin_aliases(kind: BackendKind) -> tuple[str, ...]:
         return tuple(_POPULATION_BACKENDS)
     if kind == "signal":
         return ("bbh", "bns", "nsbh", "sgwb")
+    if kind == "waveform":
+        return tuple(_WAVEFORM_BACKEND_PATHS)
     return tuple(_NOISE_BACKENDS)
 
 
@@ -228,6 +257,30 @@ def _validate_signal_backend(backend_name: str, backend_class: type[Any], backen
     if not issues:
         return
     raise TypeError(f"Resolved signal backend '{backend_name}' does not satisfy GWSimulator: {', '.join(issues)}.")
+
+
+def _validate_waveform_backend(backend_name: str, backend_instance: Any) -> None:
+    """Require a resolved waveform backend to satisfy gwmock-signal's ``WaveformBackend``.
+
+    ``WaveformFactory`` calls ``available_approximants`` on whatever it is handed, so a wrong
+    type surfaces as ``AttributeError: 'str' object has no attribute 'available_approximants'``
+    -- which names neither the setting at fault nor what it should have been. Checking here
+    turns that into a statement about the configuration.
+    """
+    from gwmock_signal.waveform.backends.base import WaveformBackend  # noqa: PLC0415
+
+    if isinstance(backend_instance, WaveformBackend):
+        return
+
+    issues = _collect_protocol_issues(
+        backend_instance,
+        required_attributes={},
+        required_callables=("available_approximants", "generate_td_waveform"),
+    )
+    raise TypeError(
+        f"Resolved waveform backend '{backend_name}' does not satisfy WaveformBackend"
+        f"{': ' + ', '.join(issues) if issues else ''}."
+    )
 
 
 def _validate_noise_backend(backend_name: str, backend_instance: Any) -> None:

--- a/src/gwmock/cli/utils/config.py
+++ b/src/gwmock/cli/utils/config.py
@@ -173,6 +173,25 @@ class SignalConfig(BaseModel):
         description="Fixed signal parameters passed to the backend simulate method.",
     )
     waveform_model: str | None = Field(default=None, alias="waveform-model", description="Waveform model name")
+    waveform_backend: str | None = Field(
+        default=None,
+        alias="waveform-backend",
+        description=(
+            "Which waveform library generates the polarizations: a built-in alias "
+            "('lal', 'pycbc', 'ripple', 'gwsignal'), an entry point in 'gwmock.waveform', or a "
+            "'module:Class' reference. Defaults to LAL. Note this selects a library, not a "
+            "compute device: 'ripple' generates with ripple through the same per-event path."
+        ),
+    )
+    waveform_backend_arguments: dict[str, Any] = Field(
+        default_factory=dict,
+        alias="waveform-backend-arguments",
+        description=(
+            "Constructor arguments for the waveform backend, e.g. 'f_ref', 'ringdown_fraction', "
+            "'segment_duration', or ripple's 'taper_fraction'. Distinct from 'arguments', which "
+            "goes to the simulator rather than to the waveform backend."
+        ),
+    )
     waveform_arguments: dict[str, Any] = Field(
         default_factory=dict,
         alias="waveform-arguments",

--- a/tests/cli/test_waveform_backend_selection.py
+++ b/tests/cli/test_waveform_backend_selection.py
@@ -1,0 +1,208 @@
+"""Selecting the waveform library from a configuration file.
+
+``signal.backend`` was already taken -- it names the *simulator* (``bbh``, ``bns``, ``sgwb``),
+resolved by ``resolve_simulator_backend``. So there was no way to ask for a different waveform
+library, and PyCBC and ripple were supported by gwmock-signal but unreachable from YAML.
+
+``signal.waveform-backend`` fills that gap. It selects a *library*, not a compute device:
+``ripple`` generates ripple waveforms through the same per-event path, because the batched
+device entry point still has no caller in the orchestration layer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from gwmock.cli.utils.config import Config
+
+_POPULATION_CSV = Path(__file__).resolve().parents[2] / "examples" / "signal" / "bbh_population.csv"
+
+
+def _config_dict(working_directory: Path, **signal_overrides: Any) -> dict[str, Any]:
+    """Return a minimal single-segment BBH config, with *signal_overrides* merged in.
+
+    The start time places the population's only event (GPS 1577491300) inside the segment;
+    without that the run completes and writes files full of zeros, which is a real trap --
+    see ``test_the_reference_run_actually_contains_signal``.
+    """
+    signal: dict[str, Any] = {
+        "source-type": "bbh",
+        "waveform-model": "IMRPhenomD",
+        "minimum-frequency": 25,
+        "detectors": ["ET-Triangle-Sardinia"],
+        "output": {
+            "output_directory": "signal",
+            "file_name": "sig-{{ detectors }}.gwf",
+            "arguments": {"channel": "{{ detectors }}:STRAIN"},
+        },
+    }
+    signal.update(signal_overrides)
+    return {
+        "globals": {
+            "simulator-arguments": {
+                "sampling-frequency": 2048,
+                "duration": 8,
+                "total-duration": 8,
+                "start-time": 1577491296,
+                "seed": 7,
+            },
+            "working-directory": str(working_directory),
+            "output-directory": "output",
+            "metadata-directory": "metadata",
+        },
+        "orchestration": {
+            "population": {
+                "backend": "FilePopulationLoader",
+                "source-type": "bbh",
+                "n-samples": 1,
+                "arguments": {"path": str(_POPULATION_CSV)},
+            },
+            "signal": signal,
+        },
+    }
+
+
+def _orchestrator(working_directory: Path, **signal_overrides: Any):
+    """Build an orchestrator from a config dict, as the CLI does."""
+    from gwmock.cli.adapter_orchestration import AdapterOrchestrator
+
+    config_path = working_directory / "config.yaml"
+    raw = yaml.safe_dump(_config_dict(working_directory, **signal_overrides))
+    config_path.write_text(raw, encoding="utf-8")
+    config = Config.model_validate(yaml.safe_load(config_path.read_text(encoding="utf-8")))
+    return AdapterOrchestrator.from_config(
+        config.orchestration,
+        global_simulator_arguments=dict(config.globals.simulator_arguments),
+    )
+
+
+def _active_waveform_backend(orchestrator) -> Any:
+    """Return the waveform backend instance the simulator will actually generate with.
+
+    Reaches through ``WaveformFactory``'s private attribute deliberately: the wiring from a
+    YAML string to the object that generates strain is exactly what these tests exist to
+    check, and no public accessor exposes it.
+    """
+    factory = orchestrator.signal_adapter._backend._waveform_factory
+    return factory._backend
+
+
+class TestSelection:
+    """Which library a config selects."""
+
+    def test_omitting_the_key_keeps_the_default(self, tmp_path):
+        """Existing configs must be unaffected; the default stays LAL."""
+        backend = _active_waveform_backend(_orchestrator(tmp_path))
+
+        assert type(backend).__name__ == "LALSimulationBackend"
+
+    def test_an_alias_selects_that_library(self, tmp_path):
+        """``ripple`` must reach the factory as a ``RippleBackend`` instance, not as a string."""
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        backend = _active_waveform_backend(_orchestrator(tmp_path, **{"waveform-backend": "ripple"}))
+
+        assert type(backend).__name__ == "RippleBackend"
+
+    def test_backend_arguments_are_applied(self, tmp_path):
+        """``taper_fraction`` is ripple-specific and had no route from config before this."""
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        orchestrator = _orchestrator(
+            tmp_path,
+            **{"waveform-backend": "ripple", "waveform-backend-arguments": {"taper_fraction": 0.02}},
+        )
+
+        assert _active_waveform_backend(orchestrator).taper_fraction == pytest.approx(0.02)
+
+    def test_an_unknown_name_is_reported_against_the_setting(self, tmp_path):
+        """Resolution happens up front, so the error names the library rather than a type.
+
+        Passed through to ``WaveformFactory`` instead, a string arrives as
+        ``AttributeError: 'str' object has no attribute 'available_approximants'``.
+        """
+        with pytest.raises(ValueError, match="Unknown waveform backend"):
+            _orchestrator(tmp_path, **{"waveform-backend": "nosuchlibrary"})
+
+
+class TestGeneratedData:
+    """That the selection reaches the strain, not just the object graph."""
+
+    @staticmethod
+    def _generate(working_directory: Path, **signal_overrides: Any):
+        """Run one segment through the real CLI and return the first channel's samples."""
+        import numpy as np
+        from gwpy.timeseries import TimeSeries
+
+        from gwmock.cli.simulate import _simulate_impl
+
+        working_directory.mkdir(parents=True, exist_ok=True)
+        config_path = working_directory / "config.yaml"
+        config_path.write_text(yaml.safe_dump(_config_dict(working_directory, **signal_overrides)), encoding="utf-8")
+        _simulate_impl(str(config_path))
+        written = working_directory / "output" / "signal" / "sig-ET1_SARD.gwf"
+        assert written.is_file(), f"no signal file was written to {written}"
+        return np.asarray(TimeSeries.read(written, channel="ET1_SARD:STRAIN").value)
+
+    def test_the_reference_run_actually_contains_signal(self, tmp_path):
+        """An all-zero output is the trap here: the run still reports success.
+
+        The population's only event sits at GPS 1577491300, so a segment placed anywhere else
+        completes, writes correctly-shaped files, and contains nothing. Asserting non-zero
+        content is what separates "the pipeline ran" from "the pipeline produced data".
+        """
+        import numpy as np
+
+        samples = self._generate(tmp_path)
+
+        assert np.count_nonzero(samples) > 0, "the run wrote a file containing no signal"
+        assert np.all(np.isfinite(samples))
+
+    def test_ripple_and_lal_produce_different_strain(self, tmp_path):
+        """The selection has to change the data, otherwise the key is decorative.
+
+        Both are asked for the same approximant, so they should agree closely and differ in
+        detail. The merger must land in the same sample -- that is what distinguishes "a
+        different implementation ran" from "one of them is wrong".
+
+        ``atol=0`` because strain is ~1e-22: the default absolute tolerance would call any two
+        strain arrays equal and this assertion could not fail.
+        """
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        import numpy as np
+
+        lal = self._generate(tmp_path / "lal", **{"waveform-backend": "lal"})
+        ripple = self._generate(tmp_path / "ripple", **{"waveform-backend": "ripple"})
+
+        assert not np.allclose(lal, ripple, rtol=1e-6, atol=0.0), "selecting ripple changed nothing"
+        assert int(np.argmax(np.abs(lal))) == int(np.argmax(np.abs(ripple))), (
+            "the two libraries put the merger in different samples, so one of them is wrong"
+        )
+        assert np.max(np.abs(ripple)) == pytest.approx(np.max(np.abs(lal)), rel=0.05), (
+            "the same approximant from two libraries should agree to a few percent"
+        )
+
+
+class TestProvenance:
+    """The selected library has to be recorded, because it changes the data."""
+
+    def test_the_selected_backend_is_recorded(self, tmp_path):
+        """Two runs whose strain differs must not carry identical provenance."""
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        orchestrator = _orchestrator(
+            tmp_path,
+            **{"waveform-backend": "ripple", "waveform-backend-arguments": {"taper_fraction": 0.02}},
+        )
+        signal_metadata = orchestrator.metadata["orchestration"]["signal"]
+
+        assert signal_metadata["waveform_backend"] == "ripple"
+        assert signal_metadata["waveform_backend_arguments"] == {"taper_fraction": 0.02}
+
+    def test_the_default_is_recorded_as_unset(self, tmp_path):
+        """``None`` distinguishes "not requested" from a library that was explicitly named."""
+        signal_metadata = _orchestrator(tmp_path).metadata["orchestration"]["signal"]
+
+        assert signal_metadata["waveform_backend"] is None
+        assert signal_metadata["waveform_backend_arguments"] == {}

--- a/tests/cli/test_waveform_backend_selection.py
+++ b/tests/cli/test_waveform_backend_selection.py
@@ -117,6 +117,46 @@ class TestSelection:
 
         assert _active_waveform_backend(orchestrator).taper_fraction == pytest.approx(0.02)
 
+    def test_arguments_without_a_backend_name_are_still_applied(self, tmp_path):
+        """Tuning the default library is legitimate, and must not be silently discarded.
+
+        Gating on the backend name dropped ``waveform-backend-arguments`` from any config that
+        named no library -- while the run metadata still recorded them, so provenance claimed
+        settings that never reached the waveform. ``f_ref`` on LAL is the ordinary case.
+        """
+        orchestrator = _orchestrator(tmp_path, **{"waveform-backend-arguments": {"f_ref": 30.0}})
+        backend = _active_waveform_backend(orchestrator)
+
+        assert type(backend).__name__ == "LALSimulationBackend", "the library must not change"
+        # `_f_ref`: LALSimulationBackend stores it privately and exposes no accessor, unlike
+        # ripple's public `taper_fraction`. The alternative is asserting nothing at all here.
+        assert backend._f_ref == pytest.approx(30.0), "the argument was dropped"
+
+    def test_the_default_backend_matches_what_the_factory_would_have_built(self, tmp_path):
+        """The fallback library is stated in gwmock and again inside ``WaveformFactory``.
+
+        Two copies of one decision, so they are checked against each other rather than trusted:
+        if gwmock-signal changed its internal default, supplying arguments alone would silently
+        switch which library generates the waveforms.
+        """
+        from gwmock_signal.waveform.factory import WaveformFactory
+
+        factory_default = type(WaveformFactory()._backend)
+        explicit = type(_active_waveform_backend(_orchestrator(tmp_path, **{"waveform-backend": "lal"})))
+
+        assert explicit is factory_default, (
+            f"gwmock falls back to 'lal' ({explicit.__name__}) but WaveformFactory defaults to "
+            f"{factory_default.__name__}; supplying arguments alone would change the library."
+        )
+
+    def test_an_empty_backend_name_is_rejected_rather_than_ignored(self, tmp_path):
+        """An empty string is a mistake, and must not read as "use the default".
+
+        This is why the check is ``is not None`` rather than a truth test.
+        """
+        with pytest.raises(ValueError, match="non-empty string"):
+            _orchestrator(tmp_path, **{"waveform-backend": ""})
+
     def test_an_unknown_name_is_reported_against_the_setting(self, tmp_path):
         """Resolution happens up front, so the error names the library rather than a type.
 

--- a/tests/cli/utils/test_backend_resolver.py
+++ b/tests/cli/utils/test_backend_resolver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import shutil
 import subprocess
 import sys
@@ -237,3 +238,72 @@ def test_validate_noise_backend_accepts_protocol_instance():
 def test_validate_noise_backend_accepts_run_boundary_class():
     """Run-boundary adapters remain compatible during the orchestration transition."""
     validate_backend("noise", "run-only", RunOnlyNoiseBackend, RunOnlyNoiseBackend())
+
+
+class NotAWaveformBackend:
+    """Resolvable class that does not implement the waveform contract."""
+
+
+@pytest.mark.parametrize(
+    ("alias", "expected"),
+    [
+        ("lal", "LALSimulationBackend"),
+        ("lalsimulation", "LALSimulationBackend"),
+        ("LALSimulationBackend", "LALSimulationBackend"),
+        ("pycbc", "PyCBCBackend"),
+        ("ripple", "RippleBackend"),
+        ("gwsignal", "GWSignalBackend"),
+    ],
+)
+def test_resolve_waveform_builtin_aliases(alias: str, expected: str):
+    """Each waveform library is selectable by a short alias and by its class name."""
+    assert resolve_backend_class("waveform", alias).__name__ == expected
+
+
+def test_resolving_a_waveform_backend_does_not_require_the_others():
+    """Aliases map to import paths, not imported classes, so one absent library is not fatal.
+
+    ``lal`` must resolve in an installation with no ripplegw. Asserted by blocking the
+    ripplegw import outright rather than by uninstalling it.
+    """
+    real_import = builtins.__import__
+
+    def blocked(name: str, *args, **kwargs):
+        if name.split(".", maxsplit=1)[0] == "ripplegw":
+            raise ImportError("simulated: ripplegw is not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr(builtins, "__import__", blocked)
+    try:
+        assert resolve_backend_class("waveform", "lal").__name__ == "LALSimulationBackend"
+    finally:
+        monkey.undo()
+
+
+def test_waveform_backend_arguments_reach_the_constructor():
+    """Constructor arguments are how ripple's taper fraction is set from a config file."""
+    backend = instantiate_backend("waveform", "ripple", init_kwargs={"taper_fraction": 0.02})
+
+    assert backend.taper_fraction == pytest.approx(0.02)
+
+
+def test_unknown_waveform_backend_lists_the_available_aliases():
+    """The error has to name the alternatives; the set is not guessable."""
+    with pytest.raises(ValueError, match="Unknown waveform backend") as raised:
+        resolve_backend_class("waveform", "nosuchlibrary")
+
+    message = str(raised.value)
+    assert "ripple" in message
+    assert "gwmock.waveform" in message, "the entry-point group is part of the contract"
+
+
+def test_validate_waveform_backend_rejects_a_non_backend():
+    """A resolvable-but-wrong class must fail here, not inside WaveformFactory.
+
+    Handed to ``WaveformFactory`` instead, it surfaces as ``AttributeError: 'str' object has
+    no attribute 'available_approximants'`` -- a message about a type, naming neither the
+    setting at fault nor what it should have been.
+    """
+    with pytest.raises(TypeError, match="does not satisfy WaveformBackend"):
+        instantiate_backend("waveform", "tests.cli.utils.test_backend_resolver:NotAWaveformBackend")

--- a/tests/cli/utils/test_backend_resolver.py
+++ b/tests/cli/utils/test_backend_resolver.py
@@ -244,6 +244,23 @@ class NotAWaveformBackend:
     """Resolvable class that does not implement the waveform contract."""
 
 
+class StubWaveformBackend:
+    """Minimal waveform backend, so argument forwarding is testable without the [jax] extra.
+
+    Duck-typed rather than a ``WaveformBackend`` subclass, which exercises the validator's
+    match-by-public-surface path -- the same one a third-party entry-point backend relies on.
+    """
+
+    def __init__(self, *, taper_fraction: float = 0.0) -> None:
+        self.taper_fraction = taper_fraction
+
+    def available_approximants(self) -> tuple[str, ...]:
+        return ("StubApproximant",)
+
+    def generate_td_waveform(self, *args, **kwargs):
+        raise NotImplementedError("the stub is never asked to generate")
+
+
 @pytest.mark.parametrize(
     ("alias", "expected"),
     [
@@ -282,7 +299,28 @@ def test_resolving_a_waveform_backend_does_not_require_the_others():
 
 
 def test_waveform_backend_arguments_reach_the_constructor():
-    """Constructor arguments are how ripple's taper fraction is set from a config file."""
+    """Constructor arguments must be forwarded to the backend being built.
+
+    Checked against a stub rather than ``RippleBackend``, so this runs in an installation
+    without the optional stack. What is under test is the forwarding, not any one library --
+    and instantiating ripple needs ripplegw even though *resolving* it does not.
+    """
+    backend = instantiate_backend(
+        "waveform",
+        "tests.cli.utils.test_backend_resolver:StubWaveformBackend",
+        init_kwargs={"taper_fraction": 0.02},
+    )
+
+    assert backend.taper_fraction == pytest.approx(0.02)
+
+
+def test_ripple_accepts_its_taper_fraction():
+    """The same forwarding against the real class, which is how it is set from a config file.
+
+    Separate from the stub test because this one needs ripplegw: ``taper_fraction`` is
+    ripple-specific, so a stub cannot show that ripple actually accepts it.
+    """
+    pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
     backend = instantiate_backend("waveform", "ripple", init_kwargs={"taper_fraction": 0.02})
 
     assert backend.taper_fraction == pytest.approx(0.02)
@@ -296,6 +334,17 @@ def test_unknown_waveform_backend_lists_the_available_aliases():
     message = str(raised.value)
     assert "ripple" in message
     assert "gwmock.waveform" in message, "the entry-point group is part of the contract"
+
+
+def test_validate_waveform_backend_accepts_a_duck_typed_backend():
+    """A third-party backend must not have to subclass gwmock-signal's ABC to be usable.
+
+    The plugin story is that a `gwmock.waveform` entry point works on the same terms as the
+    other backend kinds, whose validators also match by public surface. `WaveformFactory` only
+    calls these two methods, so requiring the base class would be a stricter contract than the
+    code actually needs.
+    """
+    validate_backend("waveform", "stub", StubWaveformBackend, StubWaveformBackend())
 
 
 def test_validate_waveform_backend_rejects_a_non_backend():

--- a/tests/e2e/matrix.py
+++ b/tests/e2e/matrix.py
@@ -63,6 +63,11 @@ E2E_MATRIX: tuple[MatrixEntry, ...] = (
         covers="`StochasticBackgroundSimulator` -- a different simulator class; **HDF5** output",
     ),
     MatrixEntry(
+        label="signal/waveform_backend/ripple",
+        covers="A non-default waveform library resolved from config. Needs `ripplegw`",
+        requires=("ripplegw",),
+    ),
+    MatrixEntry(
         label="noise/glitches/gengli/et_triangle_sardinia/e1",
         covers="Glitch injection. Skipped when `gengli` is absent",
         requires=("gengli",),


### PR DESCRIPTION
## 📝 Summary

PyCBC and ripple are supported by gwmock-signal and were **unreachable from YAML**.
`signal.backend` was already taken — it names the _simulator_ (`bbh`, `bns`, `sgwb`) via
`resolve_simulator_backend` — so there was no key for the waveform library, and LAL was the only
reachable choice.

`signal.waveform-backend` fills that gap: `lal` (default), `pycbc`, `ripple`, `gwsignal`, an entry
point in `gwmock.waveform`, or a `module:Class` reference. Constructor arguments go in
`signal.waveform-backend-arguments`, which is how ripple's `taper_fraction` becomes settable from a
config file for the first time.

### The gap was smaller than it looked

The plumbing already existed. `signal.arguments` is key-normalised and splatted into the simulator
constructor, so `signal.arguments.waveform-backend` _did_ arrive at `CBCSimulator`. It then failed,
because YAML can express a string and `WaveformFactory` wants an instance:

```
AttributeError: 'str' object has no attribute 'available_approximants'
```

So the missing piece was only a name→instance resolver. This adds a `"waveform"` kind to the
**existing** backend resolver rather than a parallel mechanism, which means aliases, entry points and
`module:Class` references all behave as they do for the other kinds — and third-party waveform
backends become pluggable on the same terms.

### Provenance, which this PR would otherwise have broken

Run metadata recorded `waveform_model` but not the library. Since this is the _first_ way to vary the
library, shipping it unrecorded would mean two runs with measurably different strain carrying
identical provenance — bad in a repo built around replay and content hashing. Now recorded as
`orchestration.signal.waveform_backend`, derived from the config so there is one source of truth.

## ✨ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [x] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

Additive. Omitting the key keeps LAL, and a test pins that.

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** `uv run pytest` — **781 passed, 23 skipped** (pre-existing legacy-config
      skips). 19 new tests.
- [x] **Manual Test:** red check — with the three source files reverted, 16 of the new tests fail.
      The two that pass either way assert _unchanged_ behaviour (default stays LAL; a run contains
      signal), so they are guards and correctly non-discriminating.
- [x] **Manual Test:** the shipped example runs end to end — 18,432 non-zero samples, peak
      8.694e-22.
- [x] **Manual Test:** `lal` still resolves with the `ripplegw` import blocked, so a base install is
      unaffected.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

## 📷 Screenshots (if applicable)

Not applicable.

## Measurements

**The key changes the data, not just the object graph.** Same config, `lal` vs `ripple`: peak
**8.385e-22** vs **8.434e-22**, with the merger in the **same sample**. A different implementation
ran, and neither is wrong. To be careful about what that is — agreement between two implementations
of one approximant, _not_ a bound on either one's accuracy.

**Example approximant choice.** One 8-second segment: `IMRPhenomD` **10.3 s** end to end vs
`IMRPhenomXPHM` **71.6 s** (LAL: ~0.7 s). That is JIT compilation, not generation, and it is the same
order as the 121 s/call recorded for precessing models before gwmock-signal #342 — so it corroborates
that earlier figure. The example ships `IMRPhenomD`; 72 s would be a poor first run. Caveat: these
are total CLI wall times, so they bundle JAX import with compilation.

## Two corrections to my own reasoning

I wrote a comment claiming the lazy alias mapping avoids importing JAX. **False** — JAX is a hard
dependency of `gwmock-pop` (`jax>=0.5.0`), so it is always imported. What `gwmock[jax]` actually
supplies is **ripplegw**. Comment corrected; the lazy mapping is still right, for the right reason.

I also first wrote the example with the `sandbox.zenodo.org` population URL copied from the sibling
examples — the ephemeral one. Sandbox records are purged, so a new example should not ship a
known-expiring input; it now reads the small in-repo population.

## Scope

**This selects a library, not a compute device.** `ripple` is JAX-based but runs through the same
per-event path as LAL. `simulate_segments` still has **zero callers in `src/`**, so nothing here
drives the batched on-device entry point — that needs the orchestration loop replaced
(`gwmock/device-call-site`), and is where GPU end-to-end actually becomes real.

A separate trap surfaced while testing and is worth flagging for the e2e work: a run whose segment
does not contain the population's events **reports success and writes pure zeros**. The shipped
example's `start-time` is aligned to its event with a comment saying why, and a test asserts non-zero
content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for selecting waveform backends, including LALSimulation, PyCBC, Ripple, GWSIGNAL, and custom backends.
  * Added backend-specific constructor arguments and metadata recording for reproducible runs.
  * Added a Ripple waveform example with documentation and optional dependency guidance.

* **Documentation**
  * Documented backend selection, installation requirements, limitations, and first-use compilation timings.

* **Bug Fixes**
  * Expanded the spelling allowlist for waveform-related terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->