### PR TITLE
test(e2e): run the example matrix through the CLI in its own suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,13 @@ jobs:
     # them across seven interpreter/OS combinations would multiply that for no added signal,
     # since what they exercise is orchestration rather than anything interpreter-specific.
     #
-    # `--all-extras` is load-bearing. The matrix in tests/e2e/matrix.py has entries gated on
-    # ripplegw and gengli, and with a plain `uv sync` those would skip -- reporting green while
-    # testing nothing. One Python and one OS, but the whole optional stack.
+    # `--all-extras` is load-bearing for the ripplegw-gated entries: with a plain `uv sync` those
+    # would skip, and the job would report green while testing less than it claims. The guard step
+    # below turns that from a silent skip into a failure.
+    #
+    # It does *not* cover the gengli entry. gengli is not a declared extra of this project at all,
+    # so no sync flag can install it, and that entry is separately blocked on a local glitch
+    # fixture. It stays skipped here -- see NOT_HERMETIC in tests/e2e/overlay.py.
     e2e:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,38 @@ jobs:
               uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
               with:
                   token: ${{ secrets.CODECOV_TOKEN }}
+
+    # End-to-end runs, kept out of the `test` matrix on purpose. They drive example configs
+    # through the real CLI and generate data, so they are minutes rather than seconds -- running
+    # them across seven interpreter/OS combinations would multiply that for no added signal,
+    # since what they exercise is orchestration rather than anything interpreter-specific.
+    #
+    # `--all-extras` is load-bearing. The matrix in tests/e2e/matrix.py has entries gated on
+    # ripplegw and gengli, and with a plain `uv sync` those would skip -- reporting green while
+    # testing nothing. One Python and one OS, but the whole optional stack.
+    e2e:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+              with:
+                  python-version: '3.12'
+                  enable-cache: 'true'
+
+            - name: Install dependencies
+              run: uv sync --group dev --all-extras
+
+            - name: Confirm the optional stack is present
+              # Otherwise a missing extra turns the whole job into a silent no-op: every gated
+              # entry skips and the job still passes.
+              run: |
+                  uv run --no-sync python -c "
+                  import importlib.util as u, sys
+                  missing = [m for m in ('ripplegw', 'jax') if u.find_spec(m) is None]
+                  sys.exit('e2e job is missing: ' + ', '.join(missing) if missing else 0)
+                  "
+
+            - name: Run end-to-end tests
+              run: uv run --no-sync pytest -m e2e --no-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+              with:
+                  # This job runs example configurations, which fetch remote inputs. Nothing here
+                  # needs to push, so the checkout token is not left in .git/config where a
+                  # subsequent step could reach it.
+                  persist-credentials: false
 
             - name: Install uv
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7

--- a/examples/README.md
+++ b/examples/README.md
@@ -67,16 +67,35 @@ detector draws from its own glitch population file.
 
 ## The end-to-end test matrix
 
-A **subset** of these examples is declared as the end-to-end matrix: the configs
-intended to be driven through the real CLI, checking that a run completes,
-writes the expected files, and reproduces stored reference values.
+A **subset** of these examples is the end-to-end matrix: the configs driven
+through the real CLI by the `e2e` test suite.
 
-> **Status — declared, not yet executed.** No runner drives these configs today.
-> What is enforced now is that the set is fixed and consistent:
-> `tests/e2e/matrix.py` holds it as data, a test fails if this table and that
-> file disagree, and every entry must name an example that exists. Nothing yet
-> checks that running one reaches the code path claimed for it. The runner lands
-> separately, and this note goes when it does.
+Those tests are excluded from the default run — they generate data — and run in
+their own CI job with every extra installed. To run them yourself:
+
+```bash
+uv run pytest -m e2e --no-cov
+```
+
+The examples themselves are never edited. A test-time overlay
+(`tests/e2e/overlay.py`) shortens each run and repoints its inputs at in-repo
+files, so the examples stay realistic while the suite finishes in about two
+minutes.
+
+> **What is and is not checked.** Each entry is run and its output verified
+> against the manifest the run itself records: every declared file present,
+> every file decoding to finite samples, the right channels, and signal actually
+> present where the span covers a population. Each entry is also run twice in
+> separate processes and compared by content hash, so reproducibility is
+> established.
+>
+> Not yet checked: agreement with **stored reference values**. That is the next
+> step, and reproducibility was the prerequisite for it.
+>
+> The overlay shortens runs, which costs coverage worth naming: sampling
+> frequency drops from 4096 Hz to 1024 Hz, moving the Nyquist frequency, and
+> spans are cut, reducing segment counts. A defect appearing only at full rate
+> or across many segments is out of scope here.
 
 The subset is chosen to cover each distinct **code path** exactly once, not
 every configuration. Where two examples differ only in values that flow through
@@ -94,7 +113,7 @@ matrix needs a new entry.
 | `signal/bbh/et_triangle_sardinia`                  | Signal-only CBC; Earth rotation; population loaded from file                   |
 | `signal/sgwb/et_triangle_sardinia`                 | `StochasticBackgroundSimulator` — a different simulator class; **HDF5** output |
 | `signal/waveform_backend/ripple`                   | A non-default waveform library resolved from config. Needs `ripplegw`          |
-| `noise/glitches/gengli/et_triangle_sardinia/e1`    | Glitch injection. Skipped when `gengli` is absent                              |
+| `noise/glitches/gengli/et_triangle_sardinia/e1`    | **Not run** — glitch injection, blocked on `gengli` and a local glitch fixture |
 
 Deliberately excluded, with the reason:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ addopts = [
   "--junitxml=test-results.xml",
   "--cov-append",
   "-m",
-  "not integration",
+  "not integration and not e2e",
 ]
 pythonpath = ["src"]
 testpaths = "tests"
@@ -122,6 +122,11 @@ markers = [
   "spark: marks tests which need Spark",
   "slow: marks tests as slow",
   "unit: fast offline tests",
+  # Drives an example configuration through the real CLI. Excluded from the default run via
+  # `-m "not e2e"` below, because these generate data and are minutes rather than seconds; the
+  # `e2e` CI job runs them, and it installs every extra so the optional-stack entries in
+  # tests/e2e/matrix.py actually execute rather than silently skipping.
+  "e2e: end-to-end tests that run an example config through the CLI",
 ]
 
 [tool.ruff]

--- a/tests/e2e/matrix.py
+++ b/tests/e2e/matrix.py
@@ -1,9 +1,9 @@
-"""The subset of ``examples/`` *declared* as the end-to-end matrix, and why each one is in it.
+"""The subset of ``examples/`` that the end-to-end suite runs, and why each one is in it.
 
-Declared, not yet executed: no runner drives these configs. Today the entries are checked
-only for existence, and for agreement with the table in ``examples/README.md``. The wording
-matters because a list of examples reads as a claim about coverage, and overstating it is
-worse than having no list -- so the present tense is reserved for when a runner exists.
+``test_examples_end_to_end.py`` drives each entry through the CLI and
+``test_reproducibility.py`` runs each twice in separate processes. One entry is an exception and
+says so in its own description: it cannot be executed here, and a test enforces that it is
+labelled ``not run`` rather than being counted as coverage that happens.
 
 This module is the single source of truth for the set. ``examples/README.md`` documents the
 same set for users, and ``test_examples_index.py`` fails if the two disagree.
@@ -26,12 +26,12 @@ class MatrixEntry:
 
     Attributes:
         label: Path-derived example label, exactly as ``gwmock config --get`` takes it.
-        covers: The code path this entry is intended to exercise. Written as a claim that can
-            be checked against the code, not as a restatement of the label. Intent for now --
-            nothing verifies that running the config reaches that path, because nothing runs
-            it yet.
+        covers: The code path this entry exercises. Written as a claim that can be checked
+            against the code, not as a restatement of the label. The entry is run, but nothing
+            asserts that the run *reaches* the named path -- that much is still a human claim,
+            kept honest by review.
         requires: Import names that must be present for this entry to run, if any. An entry
-            whose dependency is missing will be skipped rather than failed.
+            whose dependency is missing is skipped rather than failed.
     """
 
     label: str
@@ -69,7 +69,7 @@ E2E_MATRIX: tuple[MatrixEntry, ...] = (
     ),
     MatrixEntry(
         label="noise/glitches/gengli/et_triangle_sardinia/e1",
-        covers="Glitch injection. Skipped when `gengli` is absent",
+        covers="**Not run** -- glitch injection, blocked on `gengli` and a local glitch fixture",
         requires=("gengli",),
     ),
 )

--- a/tests/e2e/overlay.py
+++ b/tests/e2e/overlay.py
@@ -26,6 +26,14 @@ from typing import Any
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 EXAMPLES_DIR = _REPO_ROOT / "examples"
 
+#: Seed pinned for every run, so two runs of one entry are comparable.
+#:
+#: Written to ``noise.arguments.seed`` as well as the global, because the orchestrator copies the
+#: global seed with ``setdefault`` -- an example that pins its own (several do, at 42) keeps it
+#: and the global is ignored. Setting only the global looks like it controls the seed while the
+#: example silently does; verified by changing each and seeing which moved the output.
+_TEST_SEED = 20260731
+
 #: In-repo CBC population, used in place of every remote population file. Small and fixed, so a
 #: run is reproducible and needs no network.
 POPULATION_FIXTURE = EXAMPLES_DIR / "signal" / "bbh_population.csv"
@@ -59,7 +67,6 @@ _OVERLAYS: dict[str, dict[str, Any]] = {
                 "sampling-frequency": 1024,
                 "duration": 8,
                 "total-duration": 8,
-                "seed": 20260731,
             }
         }
     },
@@ -70,7 +77,6 @@ _OVERLAYS: dict[str, dict[str, Any]] = {
                 "duration": 16,
                 "total-duration": 16,
                 "start-time": _ALIGNED_START,
-                "seed": 20260731,
             }
         },
         "orchestration": {"population": {"arguments": {"path": str(POPULATION_FIXTURE)}}},
@@ -83,7 +89,6 @@ _OVERLAYS: dict[str, dict[str, Any]] = {
                 "sampling-frequency": 1024,
                 "duration": 4,
                 "total-duration": 12,
-                "seed": 20260731,
             }
         }
     },
@@ -94,13 +99,30 @@ _OVERLAYS: dict[str, dict[str, Any]] = {
                 "duration": 16,
                 "total-duration": 16,
                 "start-time": _ALIGNED_START,
-                "seed": 20260731,
             }
         },
         "orchestration": {"population": {"arguments": {"path": str(POPULATION_FIXTURE)}}},
     },
-    # Already 16 s at 512 Hz, so only the seed is pinned.
-    "signal/sgwb/et_triangle_sardinia": {"globals": {"simulator-arguments": {"seed": 20260731}}},
+    # Already 16 s at 512 Hz; the seed is pinned centrally, so there is nothing to override.
+    "signal/sgwb/et_triangle_sardinia": {},
+    # The example pins its population to a commit, so the URL is stable -- but it is still a
+    # network fetch, and the local fixture is the same data. `waveform-backend: ripple` is left
+    # alone: it is the entire point of this entry.
+    #
+    # ripple JIT-compiles on first use, so this entry costs seconds where the others cost
+    # fractions of one. IMRPhenomD is what the example already selects, and is the cheap case --
+    # the precessing models take roughly seven times longer to compile.
+    "signal/waveform_backend/ripple": {
+        "globals": {
+            "simulator-arguments": {
+                "sampling-frequency": 1024,
+                "duration": 16,
+                "total-duration": 16,
+                "start-time": _ALIGNED_START,
+            }
+        },
+        "orchestration": {"population": {"arguments": {"path": str(POPULATION_FIXTURE)}}},
+    },
 }
 
 #: Entries whose span is expected to contain a gravitational-wave signal, so an all-zero output
@@ -110,6 +132,7 @@ CONTAINS_SIGNAL: frozenset[str] = frozenset(
     {
         "noise/uncorrelated_gaussian/quick_start",
         "signal/bbh/et_triangle_sardinia",
+        "signal/waveform_backend/ripple",
     }
 )
 
@@ -147,4 +170,12 @@ def apply_overlay(config: dict[str, Any], label: str, working_directory: Path) -
         )
     merged = _deep_merge(config, _OVERLAYS[label])
     merged.setdefault("globals", {})["working-directory"] = str(working_directory)
+    merged["globals"].setdefault("simulator-arguments", {})["seed"] = _TEST_SEED
+
+    # Override the noise seed rather than defaulting it: the orchestrator's own copy of the
+    # global seed is a `setdefault`, so an example that pins its own would otherwise keep it and
+    # this would have no effect. See _TEST_SEED.
+    noise = merged.get("orchestration", {}).get("noise")
+    if isinstance(noise, dict):
+        noise.setdefault("arguments", {})["seed"] = _TEST_SEED
     return merged

--- a/tests/e2e/overlay.py
+++ b/tests/e2e/overlay.py
@@ -1,0 +1,150 @@
+"""Test-time overrides that make an example configuration cheap to run.
+
+The examples are sized to be realistic -- most generate a day of data in 4096-second segments.
+The suite needs seconds. Rather than shorten the examples themselves, which would make them
+worse at their actual job, each is loaded and a small declarative overlay is merged over it.
+
+Two consequences worth knowing:
+
+* Changing an example changes what the suite runs. That is deliberate -- it is how an example
+  that stops working becomes a test failure.
+* An overlay is *not* allowed to change which code path the config takes. Shortening a duration
+  or repointing an input is fine; switching the waveform model or the detector network would
+  make the test stop covering the thing its matrix entry claims.
+
+Inputs are repointed at in-repo files because most example configs fetch their population over
+the network -- two of them from ``sandbox.zenodo.org``, whose records are purged. A suite that
+depends on those is a suite that fails for reasons unrelated to the code.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLES_DIR = _REPO_ROOT / "examples"
+
+#: In-repo CBC population, used in place of every remote population file. Small and fixed, so a
+#: run is reproducible and needs no network.
+POPULATION_FIXTURE = EXAMPLES_DIR / "signal" / "bbh_population.csv"
+
+#: The single event in :data:`POPULATION_FIXTURE`.
+_FIXTURE_EVENT_GPS = 1577491300.0
+
+#: Start time placing that event inside a short segment. A run whose span misses the population
+#: still succeeds and writes only zeros, so this is not a cosmetic choice -- see the
+#: ``contains_signal`` assertions in the end-to-end tests.
+_ALIGNED_START = 1577491296.0
+
+#: Entries that cannot be run without fetching from the network, with the reason. These are
+#: skipped rather than run against a remote URL. Removing an entry from here requires adding a
+#: local fixture for whatever it downloads.
+NOT_HERMETIC: dict[str, str] = {
+    "noise/glitches/gengli/et_triangle_sardinia/e1": (
+        "needs a local blip-glitch population fixture; the example reads one from "
+        "sandbox.zenodo.org, whose records are purged"
+    ),
+}
+
+#: Per-example overrides, deep-merged over the example's own configuration.
+#:
+#: Only durations, rates, sample counts, seeds and input paths appear here. Anything that would
+#: change the code path under test does not belong in an overlay.
+_OVERLAYS: dict[str, dict[str, Any]] = {
+    "default_config": {
+        "globals": {
+            "simulator-arguments": {
+                "sampling-frequency": 1024,
+                "duration": 8,
+                "total-duration": 8,
+                "seed": 20260731,
+            }
+        }
+    },
+    "noise/uncorrelated_gaussian/quick_start": {
+        "globals": {
+            "simulator-arguments": {
+                "sampling-frequency": 1024,
+                "duration": 16,
+                "total-duration": 16,
+                "start-time": _ALIGNED_START,
+                "seed": 20260731,
+            }
+        },
+        "orchestration": {"population": {"arguments": {"path": str(POPULATION_FIXTURE)}}},
+    },
+    # Kept multi-segment on purpose: this entry exists to cover chunking and per-segment seeds,
+    # so collapsing it to one segment would silently retire what it tests.
+    "noise/uncorrelated_gaussian/et_triangle_sardinia": {
+        "globals": {
+            "simulator-arguments": {
+                "sampling-frequency": 1024,
+                "duration": 4,
+                "total-duration": 12,
+                "seed": 20260731,
+            }
+        }
+    },
+    "signal/bbh/et_triangle_sardinia": {
+        "globals": {
+            "simulator-arguments": {
+                "sampling-frequency": 1024,
+                "duration": 16,
+                "total-duration": 16,
+                "start-time": _ALIGNED_START,
+                "seed": 20260731,
+            }
+        },
+        "orchestration": {"population": {"arguments": {"path": str(POPULATION_FIXTURE)}}},
+    },
+    # Already 16 s at 512 Hz, so only the seed is pinned.
+    "signal/sgwb/et_triangle_sardinia": {"globals": {"simulator-arguments": {"seed": 20260731}}},
+}
+
+#: Entries whose span is expected to contain a gravitational-wave signal, so an all-zero output
+#: is a failure rather than a valid result. Noise-only runs are excluded because their content
+#: is noise, and the SGWB run produces a background rather than a located event.
+CONTAINS_SIGNAL: frozenset[str] = frozenset(
+    {
+        "noise/uncorrelated_gaussian/quick_start",
+        "signal/bbh/et_triangle_sardinia",
+    }
+)
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Return *base* with *override* merged into it, recursing into nested mappings."""
+    merged = copy.deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def apply_overlay(config: dict[str, Any], label: str, working_directory: Path) -> dict[str, Any]:
+    """Return *config* shortened for test use and rooted at *working_directory*.
+
+    Args:
+        config: The example configuration, as loaded from its ``config.yaml``.
+        label: The example label, used to select the overlay.
+        working_directory: Directory the run should write into.
+
+    Returns:
+        A new configuration; *config* is not modified.
+
+    Raises:
+        KeyError: If no overlay is defined for *label*. Deliberate -- a new matrix entry has to
+            state how it is shortened, rather than silently running at full example size.
+    """
+    if label not in _OVERLAYS:
+        raise KeyError(
+            f"no test overlay is defined for '{label}'. Add one to tests/e2e/overlay.py; running "
+            f"an example at its full size would take minutes to hours."
+        )
+    merged = _deep_merge(config, _OVERLAYS[label])
+    merged.setdefault("globals", {})["working-directory"] = str(working_directory)
+    return merged

--- a/tests/e2e/test_examples_end_to_end.py
+++ b/tests/e2e/test_examples_end_to_end.py
@@ -1,0 +1,149 @@
+"""Drive each matrix example through the real CLI and check what it produced.
+
+These are the tests the matrix in :mod:`tests.e2e.matrix` exists for. Each runs one example
+configuration -- shortened by :mod:`tests.e2e.overlay`, never edited in place -- and asserts the
+run completed and wrote data of the expected shape.
+
+Marked ``e2e`` and therefore excluded from the default run: they generate data and take seconds
+to minutes each. The ``e2e`` CI job runs them with every extra installed.
+
+Scope of what is checked here is deliberately structural. Whether the output *matches a stored
+reference* comes later, and depends on first establishing that each path is reproducible at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import yaml
+
+from .matrix import E2E_MATRIX, MatrixEntry
+from .overlay import CONTAINS_SIGNAL, EXAMPLES_DIR, NOT_HERMETIC, apply_overlay
+
+pytestmark = pytest.mark.e2e
+
+
+def _skip_if_unavailable(entry: MatrixEntry) -> None:
+    """Skip when the entry cannot run here, saying which reason applies."""
+    for module in entry.requires:
+        pytest.importorskip(module, reason=f"'{entry.label}' needs {module}")
+    if entry.label in NOT_HERMETIC:
+        pytest.skip(f"'{entry.label}' {NOT_HERMETIC[entry.label]}")
+
+
+def _run(entry: MatrixEntry, working_directory: Path) -> dict[str, Any]:
+    """Run one matrix entry through the CLI and return the configuration used."""
+    from gwmock.cli.simulate import _simulate_impl
+
+    source = EXAMPLES_DIR / entry.label / "config.yaml"
+    config = apply_overlay(yaml.safe_load(source.read_text(encoding="utf-8")), entry.label, working_directory)
+
+    working_directory.mkdir(parents=True, exist_ok=True)
+    config_path = working_directory / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    _simulate_impl(str(config_path))
+    return config
+
+
+def _written_files(working_directory: Path) -> list[Path]:
+    """Return every data file the run produced, in a stable order."""
+    output = working_directory / "output"
+    return sorted(path for path in output.rglob("*") if path.is_file())
+
+
+def _samples(path: Path) -> np.ndarray:
+    """Return the concatenated samples in *path*, whatever container it uses.
+
+    Channel and dataset names are discovered from the file rather than assumed, so these tests
+    do not restate the naming templates the configurations already define. Asserting on names
+    duplicated from the config would only check that the test and the config agree.
+    """
+    if path.suffix == ".gwf":
+        from gwpy.io.gwf import get_channel_names
+        from gwpy.timeseries import TimeSeriesDict
+
+        names = get_channel_names(str(path))
+        if not names:
+            return np.array([])
+        series = TimeSeriesDict.read(str(path), names)
+        return np.concatenate([np.asarray(item.value) for item in series.values()])
+    if path.suffix in {".hdf5", ".h5"}:
+        import h5py
+
+        collected: list[np.ndarray] = []
+        with h5py.File(path, "r") as handle:
+            handle.visititems(
+                lambda _name, item: collected.append(np.ravel(item[()])) if isinstance(item, h5py.Dataset) else None
+            )
+        return np.concatenate(collected) if collected else np.array([])
+    if path.suffix == ".npy":
+        return np.ravel(np.load(path))
+    return np.array([])
+
+
+@pytest.mark.parametrize("entry", E2E_MATRIX, ids=lambda entry: entry.label)
+class TestExampleRuns:
+    """One run per matrix entry, with the checks that do not need a stored reference."""
+
+    def test_the_run_completes_and_writes_data(self, entry: MatrixEntry, tmp_path: Path):
+        """The example must run to completion and leave non-empty output behind.
+
+        The weakest useful assertion, and the one that catches most breakage: an exception
+        anywhere in orchestration, or a run that silently writes nothing.
+        """
+        _skip_if_unavailable(entry)
+        _run(entry, tmp_path)
+
+        written = _written_files(tmp_path)
+        assert written, f"'{entry.label}' completed but wrote no output files"
+        empty = [path.name for path in written if path.stat().st_size == 0]
+        assert not empty, f"'{entry.label}' wrote empty files: {empty}"
+
+    def test_the_output_is_readable_and_finite(self, entry: MatrixEntry, tmp_path: Path):
+        """Every written file must decode, and contain no NaN or infinity.
+
+        A file that exists but cannot be read, or that decodes to NaN, passes a
+        does-it-exist check while being useless -- and NaN propagates silently into whatever
+        analysis consumes it.
+        """
+        _skip_if_unavailable(entry)
+        _run(entry, tmp_path)
+
+        checked = 0
+        for path in _written_files(tmp_path):
+            samples = _samples(path)
+            if not samples.size:
+                continue
+            checked += 1
+            assert np.all(np.isfinite(samples)), f"'{path.name}' contains non-finite samples"
+        assert checked, f"'{entry.label}' produced no file whose samples could be decoded"
+
+    def test_the_output_contains_signal_where_expected(self, entry: MatrixEntry, tmp_path: Path):
+        """A run whose span covers the population must not be all zeros.
+
+        This is the assertion that distinguishes "the pipeline ran" from "the pipeline produced
+        data". A configuration whose segment misses its events completes, writes
+        correctly-shaped files, and contains nothing at all -- a trap hit for real while
+        developing these tests, not a hypothetical one.
+        """
+        if entry.label not in CONTAINS_SIGNAL:
+            pytest.skip(f"'{entry.label}' is not expected to contain a located signal")
+        _skip_if_unavailable(entry)
+        config = _run(entry, tmp_path)
+
+        # Only the signal outputs. Counting every file instead lets a signal+noise
+        # configuration pass on its noise alone -- verified: with the start time deliberately
+        # misaligned, `signal/bbh` failed but `quick_start` still passed, because its noise is
+        # non-zero whatever the signal did.
+        signal_directory = tmp_path / "output" / config["orchestration"]["signal"]["output"]["output_directory"]
+        signal_files = [path for path in _written_files(tmp_path) if signal_directory in path.parents]
+        assert signal_files, f"'{entry.label}' wrote nothing under {signal_directory}"
+
+        occupied = sum(int(np.count_nonzero(_samples(path))) for path in signal_files)
+        assert occupied > 0, (
+            f"'{entry.label}' wrote only zeros to {signal_directory.name}/, so no signal reached the "
+            f"output -- most likely the segment does not cover the population's events."
+        )

--- a/tests/e2e/test_examples_end_to_end.py
+++ b/tests/e2e/test_examples_end_to_end.py
@@ -14,12 +14,16 @@ reference* comes later, and depends on first establishing that each path is repr
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 import pytest
 import yaml
+
+from gwmock.cli.utils.hash import compute_content_hash
 
 from .matrix import E2E_MATRIX, MatrixEntry
 from .overlay import CONTAINS_SIGNAL, EXAMPLES_DIR, NOT_HERMETIC, apply_overlay
@@ -35,18 +39,80 @@ def _skip_if_unavailable(entry: MatrixEntry) -> None:
         pytest.skip(f"'{entry.label}' {NOT_HERMETIC[entry.label]}")
 
 
-def _run(entry: MatrixEntry, working_directory: Path) -> dict[str, Any]:
-    """Run one matrix entry through the CLI and return the configuration used."""
-    from gwmock.cli.simulate import _simulate_impl
+def _gwmock_executable() -> str:
+    """Return the installed ``gwmock`` console script.
 
+    These tests exercise what a user actually runs, so they go through the entry point declared
+    in ``[project.scripts]`` rather than calling an internal function. Reaching past the console
+    script would skip argument parsing and the CLI's own error handling -- the parts an
+    end-to-end test exists to cover.
+    """
+    executable = shutil.which("gwmock")
+    assert executable, (
+        "the 'gwmock' console script is not on PATH, so the end-to-end suite cannot invoke the "
+        "CLI the way a user would. Install the project (`uv sync`) before running these tests."
+    )
+    return executable
+
+
+def _write_config(entry: MatrixEntry, working_directory: Path) -> tuple[Path, dict[str, Any]]:
+    """Write the overlaid configuration for *entry* and return its path and contents."""
     source = EXAMPLES_DIR / entry.label / "config.yaml"
     config = apply_overlay(yaml.safe_load(source.read_text(encoding="utf-8")), entry.label, working_directory)
 
     working_directory.mkdir(parents=True, exist_ok=True)
     config_path = working_directory / "config.yaml"
     config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
-    _simulate_impl(str(config_path))
+    return config_path, config
+
+
+def _run(entry: MatrixEntry, working_directory: Path) -> dict[str, Any]:
+    """Run one matrix entry through the real CLI and return the configuration used."""
+    config_path, config = _write_config(entry, working_directory)
+
+    completed = subprocess.run(  # noqa: S603
+        [_gwmock_executable(), "simulate", str(config_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        f"'{entry.label}' failed via the CLI (exit {completed.returncode}):\n{completed.stderr[-2000:]}"
+    )
     return config
+
+
+@pytest.fixture(scope="session")
+def completed_run(tmp_path_factory: pytest.TempPathFactory):
+    """Return a callable giving the output directory for an entry, running it at most once.
+
+    Every assertion below inspects the same run, so re-running per test would multiply the cost
+    of the whole suite by the number of assertions -- and each run is now a real CLI subprocess.
+    Caching per label keeps adding assertions cheap, which matters because the reference-value
+    comparisons still to come will add several more.
+
+    Session-scoped and shared, so the assertions must only *read* the output. They do.
+    """
+    cache: dict[str, Path] = {}
+
+    def _get(entry: MatrixEntry) -> Path:
+        if entry.label not in cache:
+            directory = tmp_path_factory.mktemp(entry.label.replace("/", "_"))
+            _run(entry, directory)
+            cache[entry.label] = directory
+        return cache[entry.label]
+
+    return _get
+
+
+def _config_of(entry: MatrixEntry, working_directory: Path) -> dict[str, Any]:
+    """Return the configuration the run actually used, read back from its directory.
+
+    Read from disk rather than recomputed, so a test cannot end up asserting against a
+    configuration that differs from the one the run was given.
+    """
+    _ = entry
+    return yaml.safe_load((working_directory / "config.yaml").read_text(encoding="utf-8"))
 
 
 def _written_files(working_directory: Path) -> list[Path]:
@@ -109,21 +175,21 @@ def _manifest(working_directory: Path) -> list[dict[str, Any]]:
 class TestExampleRuns:
     """One run per matrix entry, with the checks that do not need a stored reference."""
 
-    def test_the_run_completes_and_writes_data(self, entry: MatrixEntry, tmp_path: Path):
+    def test_the_run_completes_and_writes_data(self, entry: MatrixEntry, completed_run):
         """The example must run to completion and leave non-empty output behind.
 
         The weakest useful assertion, and the one that catches most breakage: an exception
         anywhere in orchestration, or a run that silently writes nothing.
         """
         _skip_if_unavailable(entry)
-        _run(entry, tmp_path)
+        tmp_path = completed_run(entry)
 
         written = _written_files(tmp_path)
         assert written, f"'{entry.label}' completed but wrote no output files"
         empty = [path.name for path in written if path.stat().st_size == 0]
         assert not empty, f"'{entry.label}' wrote empty files: {empty}"
 
-    def test_every_declared_output_was_written(self, entry: MatrixEntry, tmp_path: Path):
+    def test_every_declared_output_was_written(self, entry: MatrixEntry, completed_run):
         """The files on disk must be exactly the ones the run says it wrote.
 
         Checked both ways on purpose. Requiring only that *some* output exists lets a run pass
@@ -131,7 +197,7 @@ class TestExampleRuns:
         its own metadata does not mention is equally wrong, in a way a file count would miss.
         """
         _skip_if_unavailable(entry)
-        _run(entry, tmp_path)
+        tmp_path = completed_run(entry)
 
         declared = {item["path"] for item in _manifest(tmp_path)}
         assert declared, f"'{entry.label}' recorded no outputs in its metadata"
@@ -143,7 +209,7 @@ class TestExampleRuns:
             f"present but undeclared {sorted(found - declared)}"
         )
 
-    def test_every_output_decodes_and_is_finite(self, entry: MatrixEntry, tmp_path: Path):
+    def test_every_output_decodes_and_is_finite(self, entry: MatrixEntry, completed_run):
         """*Every* written file must decode, carry samples, and contain no NaN or infinity.
 
         Previously this counted the files that decoded and required at least one, which let an
@@ -154,13 +220,24 @@ class TestExampleRuns:
         while holding fewer channels than the run claims to have put in it.
         """
         _skip_if_unavailable(entry)
-        _run(entry, tmp_path)
+        tmp_path = completed_run(entry)
 
         for item in _manifest(tmp_path):
             path = tmp_path / item["path"]
             samples = _samples(path)
             assert samples.size, f"'{item['path']}' decoded to no samples"
             assert np.all(np.isfinite(samples)), f"'{item['path']}' contains non-finite samples"
+
+            declared_hash = item.get("content_sha256")
+            if declared_hash:
+                # The run records a content hash of what it wrote. Recomputing it here checks the
+                # pipeline's own bookkeeping against an independent calculation -- a recorded hash
+                # that does not match the data would make every downstream provenance claim wrong,
+                # and nothing else would notice.
+                assert compute_content_hash(path) == declared_hash, (
+                    f"'{item['path']}' does not match the content hash recorded for it in the run "
+                    f"metadata, so the run's own provenance is wrong about its output"
+                )
 
             declared_channels = item.get("channels")
             if declared_channels and path.suffix == ".gwf":
@@ -170,7 +247,7 @@ class TestExampleRuns:
                     f"'{item['path']}' does not hold the channels its metadata declares"
                 )
 
-    def test_the_output_contains_signal_where_expected(self, entry: MatrixEntry, tmp_path: Path):
+    def test_the_output_contains_signal_where_expected(self, entry: MatrixEntry, completed_run):
         """A run whose span covers the population must not be all zeros.
 
         This is the assertion that distinguishes "the pipeline ran" from "the pipeline produced
@@ -181,7 +258,8 @@ class TestExampleRuns:
         if entry.label not in CONTAINS_SIGNAL:
             pytest.skip(f"'{entry.label}' is not expected to contain a located signal")
         _skip_if_unavailable(entry)
-        config = _run(entry, tmp_path)
+        tmp_path = completed_run(entry)
+        config = _config_of(entry, tmp_path)
 
         # Only the signal outputs. Counting every file instead lets a signal+noise
         # configuration pass on its noise alone -- verified: with the start time deliberately

--- a/tests/e2e/test_examples_end_to_end.py
+++ b/tests/e2e/test_examples_end_to_end.py
@@ -13,6 +13,7 @@ reference* comes later, and depends on first establishing that each path is repr
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -81,7 +82,27 @@ def _samples(path: Path) -> np.ndarray:
         return np.concatenate(collected) if collected else np.array([])
     if path.suffix == ".npy":
         return np.ravel(np.load(path))
-    return np.array([])
+    raise AssertionError(
+        f"'{path.name}' has no reader here, so its contents would go unchecked. Add one rather "
+        f"than letting an unrecognised output format be skipped silently."
+    )
+
+
+def _manifest(working_directory: Path) -> list[dict[str, Any]]:
+    """Return the ``outputs`` entries the run recorded in its metadata.
+
+    The run declares every file it wrote, with the channels and content hash for each. Checking
+    the directory against that declaration is stronger than counting files against a number
+    restated in the test, and it catches the case a count would miss in the other direction --
+    a file written that the run does not know about.
+    """
+    metadata_files = sorted((working_directory / "metadata").glob("*.metadata.json"))
+    assert metadata_files, f"no run metadata was written to {working_directory / 'metadata'}"
+
+    outputs: list[dict[str, Any]] = []
+    for path in metadata_files:
+        outputs.extend(json.loads(path.read_text(encoding="utf-8")).get("outputs", []))
+    return outputs
 
 
 @pytest.mark.parametrize("entry", E2E_MATRIX, ids=lambda entry: entry.label)
@@ -102,24 +123,52 @@ class TestExampleRuns:
         empty = [path.name for path in written if path.stat().st_size == 0]
         assert not empty, f"'{entry.label}' wrote empty files: {empty}"
 
-    def test_the_output_is_readable_and_finite(self, entry: MatrixEntry, tmp_path: Path):
-        """Every written file must decode, and contain no NaN or infinity.
+    def test_every_declared_output_was_written(self, entry: MatrixEntry, tmp_path: Path):
+        """The files on disk must be exactly the ones the run says it wrote.
 
-        A file that exists but cannot be read, or that decodes to NaN, passes a
-        does-it-exist check while being useless -- and NaN propagates silently into whatever
-        analysis consumes it.
+        Checked both ways on purpose. Requiring only that *some* output exists lets a run pass
+        having written one detector's frame and dropped the rest -- and a run that writes a file
+        its own metadata does not mention is equally wrong, in a way a file count would miss.
         """
         _skip_if_unavailable(entry)
         _run(entry, tmp_path)
 
-        checked = 0
-        for path in _written_files(tmp_path):
+        declared = {item["path"] for item in _manifest(tmp_path)}
+        assert declared, f"'{entry.label}' recorded no outputs in its metadata"
+
+        found = {str(path.relative_to(tmp_path)) for path in _written_files(tmp_path)}
+        assert declared == found, (
+            f"'{entry.label}' output does not match its own manifest: "
+            f"declared but absent {sorted(declared - found)}, "
+            f"present but undeclared {sorted(found - declared)}"
+        )
+
+    def test_every_output_decodes_and_is_finite(self, entry: MatrixEntry, tmp_path: Path):
+        """*Every* written file must decode, carry samples, and contain no NaN or infinity.
+
+        Previously this counted the files that decoded and required at least one, which let an
+        unreadable or empty file pass as long as a sibling was fine. An unrecognised format now
+        fails in ``_samples`` rather than being skipped.
+
+        The channel list is cross-checked against the manifest as well, since a frame can decode
+        while holding fewer channels than the run claims to have put in it.
+        """
+        _skip_if_unavailable(entry)
+        _run(entry, tmp_path)
+
+        for item in _manifest(tmp_path):
+            path = tmp_path / item["path"]
             samples = _samples(path)
-            if not samples.size:
-                continue
-            checked += 1
-            assert np.all(np.isfinite(samples)), f"'{path.name}' contains non-finite samples"
-        assert checked, f"'{entry.label}' produced no file whose samples could be decoded"
+            assert samples.size, f"'{item['path']}' decoded to no samples"
+            assert np.all(np.isfinite(samples)), f"'{item['path']}' contains non-finite samples"
+
+            declared_channels = item.get("channels")
+            if declared_channels and path.suffix == ".gwf":
+                from gwpy.io.gwf import get_channel_names
+
+                assert sorted(get_channel_names(str(path))) == sorted(declared_channels), (
+                    f"'{item['path']}' does not hold the channels its metadata declares"
+                )
 
     def test_the_output_contains_signal_where_expected(self, entry: MatrixEntry, tmp_path: Path):
         """A run whose span covers the population must not be all zeros.

--- a/tests/e2e/test_overlay.py
+++ b/tests/e2e/test_overlay.py
@@ -1,0 +1,123 @@
+"""Invariants the test-time overlay has to hold.
+
+Not marked ``e2e``: these run no simulation, so they belong in the default suite where they guard
+the overlay on every pull request. What they protect is subtle and was got wrong once already --
+an overlay that quietly fails to apply, or that changes the code path it was meant to leave
+alone, makes the end-to-end suite report on something other than what its matrix claims.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from .matrix import E2E_MATRIX
+from .overlay import (
+    _ALIGNED_START,
+    _FIXTURE_EVENT_GPS,
+    _OVERLAYS,
+    _TEST_SEED,
+    CONTAINS_SIGNAL,
+    EXAMPLES_DIR,
+    NOT_HERMETIC,
+    POPULATION_FIXTURE,
+    apply_overlay,
+)
+
+#: Settings that select a code path. An overlay may shorten a run or repoint an input; changing
+#: any of these would make the entry stop covering what it claims to.
+_PATH_DEFINING_KEYS = ("waveform-model", "waveform-backend", "detectors", "source-type", "backend")
+
+#: Matrix entries that can actually be run here. A non-hermetic entry has no overlay yet on
+#: purpose: it cannot be exercised, so an overlay for it would be untested guesswork. The
+#: KeyError in ``apply_overlay`` is what tells whoever adds its fixture to write one.
+_RUNNABLE = tuple(entry for entry in E2E_MATRIX if entry.label not in NOT_HERMETIC)
+
+
+def _example(label: str) -> dict[str, Any]:
+    """Load one example configuration."""
+    return yaml.safe_load((EXAMPLES_DIR / label / "config.yaml").read_text(encoding="utf-8"))
+
+
+def test_every_matrix_entry_has_an_overlay():
+    """An entry with no overlay would run at full example size -- a day of data for most."""
+    missing = [entry.label for entry in _RUNNABLE if entry.label not in _OVERLAYS]
+    assert not missing, f"these runnable matrix entries have no test overlay: {missing}"
+
+
+def test_the_population_fixture_exists():
+    """Every remote population is repointed here, so its absence breaks every signal entry."""
+    assert POPULATION_FIXTURE.is_file(), f"the population fixture is missing: {POPULATION_FIXTURE}"
+
+
+def test_the_aligned_start_brackets_the_fixture_event():
+    """The signal entries' segment must actually contain the population's only event.
+
+    A segment that misses it still runs and writes correctly-shaped files full of zeros, so this
+    arithmetic is the difference between testing the pipeline and testing nothing. Checked
+    against the shortest duration any entry uses, since that is the tightest case.
+    """
+    shortest = min(
+        overlay["globals"]["simulator-arguments"]["duration"]
+        for label, overlay in _OVERLAYS.items()
+        if label in CONTAINS_SIGNAL
+    )
+
+    assert _ALIGNED_START <= _FIXTURE_EVENT_GPS < _ALIGNED_START + shortest, (
+        f"the fixture event at GPS {_FIXTURE_EVENT_GPS} falls outside "
+        f"[{_ALIGNED_START}, {_ALIGNED_START + shortest}), so signal entries would write zeros"
+    )
+
+
+@pytest.mark.parametrize("entry", _RUNNABLE, ids=lambda entry: entry.label)
+def test_the_overlay_pins_the_seed_where_the_orchestrator_reads_it(entry, tmp_path: Path):
+    """The seed must land in the noise arguments, not only in the globals.
+
+    The orchestrator copies the global seed into the noise arguments with ``setdefault``, so an
+    example that pins its own -- several pin 42 -- keeps it and a global-only override does
+    nothing. That was measured, not guessed: changing the global left all nine output files
+    identical, while changing the noise seed changed all nine.
+    """
+    merged = apply_overlay(_example(entry.label), entry.label, tmp_path)
+
+    assert merged["globals"]["simulator-arguments"]["seed"] == _TEST_SEED
+    noise = merged.get("orchestration", {}).get("noise")
+    if isinstance(noise, dict):
+        assert noise["arguments"]["seed"] == _TEST_SEED, (
+            "the example's own noise seed survived the overlay, so runs are pinned by the example "
+            "rather than by the test"
+        )
+
+
+@pytest.mark.parametrize("entry", _RUNNABLE, ids=lambda entry: entry.label)
+def test_the_overlay_does_not_change_the_code_path(entry, tmp_path: Path):
+    """Shortening a run must not alter what it exercises.
+
+    Compares every path-defining setting before and after the overlay. Without this an overlay
+    could, say, swap a waveform model for a faster one and the entry would keep claiming
+    coverage it no longer has.
+    """
+    original = _example(entry.label)
+    merged = apply_overlay(original, entry.label, tmp_path)
+
+    for section in ("signal", "population", "noise"):
+        before = original.get("orchestration", {}).get(section)
+        after = merged.get("orchestration", {}).get(section)
+        if not isinstance(before, dict) or not isinstance(after, dict):
+            continue
+        for key in _PATH_DEFINING_KEYS:
+            if key in before:
+                assert after.get(key) == before[key], (
+                    f"the overlay changed orchestration.{section}.{key} for '{entry.label}', "
+                    f"which changes the code path the entry is meant to cover"
+                )
+
+
+def test_contains_signal_only_names_matrix_entries():
+    """A stale label here would silently stop asserting that a signal was produced."""
+    labels = {entry.label for entry in E2E_MATRIX}
+    unknown = sorted(CONTAINS_SIGNAL - labels)
+    assert not unknown, f"CONTAINS_SIGNAL names entries that are not in the matrix: {unknown}"

--- a/tests/e2e/test_overlay.py
+++ b/tests/e2e/test_overlay.py
@@ -27,9 +27,32 @@ from .overlay import (
     apply_overlay,
 )
 
-#: Settings that select a code path. An overlay may shorten a run or repoint an input; changing
-#: any of these would make the entry stop covering what it claims to.
-_PATH_DEFINING_KEYS = ("waveform-model", "waveform-backend", "detectors", "source-type", "backend")
+#: Settings that select a code path or the physics. An overlay may shorten a run or repoint an
+#: input; changing any of these would make the entry stop covering what it claims to.
+#:
+#: ``minimum-frequency``, ``earth-rotation`` and ``waveform-backend-arguments`` are here because
+#: each selects behaviour rather than scale: the cutoff taper, the rotating-versus-static
+#: projection, and the waveform backend's own configuration.
+_PATH_DEFINING_KEYS = (
+    "waveform-model",
+    "waveform-backend",
+    "waveform-backend-arguments",
+    "detectors",
+    "source-type",
+    "backend",
+    "minimum-frequency",
+    "earth-rotation",
+)
+
+#: What an overlay *is* allowed to change, and therefore what these tests do not preserve.
+#:
+#: Recorded because it is a real limitation rather than an oversight. ``sampling-frequency`` is
+#: reduced from 4096 Hz to 1024 Hz, which moves the Nyquist frequency and the discretisation;
+#: ``duration`` and ``total-duration`` are cut, which changes how many segments a run produces.
+#: So these entries verify that orchestration works and produces sane data at test scale -- they
+#: do not reproduce the example's numerical behaviour, and a defect that only appears above
+#: 512 Hz or across many segments would not be caught here.
+_SCALE_KEYS = ("sampling-frequency", "duration", "total-duration")
 
 #: Matrix entries that can actually be run here. A non-hermetic entry has no overlay yet on
 #: purpose: it cannot be exercised, so an overlay for it would be untested guesswork. The
@@ -114,6 +137,40 @@ def test_the_overlay_does_not_change_the_code_path(entry, tmp_path: Path):
                     f"the overlay changed orchestration.{section}.{key} for '{entry.label}', "
                     f"which changes the code path the entry is meant to cover"
                 )
+
+
+def test_only_scale_settings_are_overridden_in_the_globals():
+    """Every global an overlay touches must be a scale knob, not a behaviour switch.
+
+    The complement of ``test_the_overlay_does_not_change_the_code_path``: rather than listing
+    what must be preserved, this bounds what may be altered, so a new overlay cannot quietly
+    introduce an override of something behavioural. ``seed`` is permitted because pinning it is
+    the point.
+    """
+    permitted = set(_SCALE_KEYS) | {"start-time", "seed"}
+    for label, overlay in _OVERLAYS.items():
+        touched = set(overlay.get("globals", {}).get("simulator-arguments", {}))
+        assert touched <= permitted, (
+            f"the overlay for '{label}' overrides {sorted(touched - permitted)}, which is not a "
+            f"scale setting. If that is deliberate, it belongs in the matrix entry's description "
+            f"rather than hidden in an overlay."
+        )
+
+
+@pytest.mark.parametrize("label", sorted(NOT_HERMETIC), ids=lambda label: label)
+def test_a_blocked_entry_is_declared_as_not_run(label: str):
+    """An entry that never runs must say so where coverage is read, not only in a skip message.
+
+    A matrix entry reads as coverage. One that is permanently skipped is the most misleading
+    thing the matrix can contain -- a reader sees seven entries and assumes seven paths are
+    exercised. Enforcing the marker keeps the count honest as entries come and go.
+    """
+    entry = next((entry for entry in E2E_MATRIX if entry.label == label), None)
+    assert entry is not None, f"'{label}' is listed as blocked but is not in the matrix"
+    assert "not run" in entry.covers.lower(), (
+        f"'{label}' cannot be executed here, so its matrix description must say so; it currently "
+        f"reads: {entry.covers!r}"
+    )
 
 
 def test_contains_signal_only_names_matrix_entries():

--- a/tests/e2e/test_reproducibility.py
+++ b/tests/e2e/test_reproducibility.py
@@ -24,17 +24,15 @@ finding is that the seed has to be threaded, before any reference value is store
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
-import yaml
 
 from gwmock.cli.utils.hash import compute_content_hash
 
 from .matrix import E2E_MATRIX, MatrixEntry
-from .overlay import EXAMPLES_DIR, NOT_HERMETIC, apply_overlay
-from .test_examples_end_to_end import _written_files
+from .overlay import NOT_HERMETIC
+from .test_examples_end_to_end import _gwmock_executable, _write_config, _written_files
 
 pytestmark = pytest.mark.e2e
 
@@ -44,32 +42,23 @@ _NOT_DATA = ("resource_usage_summary.json", "config.yaml")
 
 
 def _run_in_subprocess(entry: MatrixEntry, working_directory: Path) -> None:
-    """Run one matrix entry in a fresh interpreter.
+    """Run one matrix entry in a fresh process, through the installed console script.
 
-    A subprocess rather than an in-process call, so no state is shared between the two runs being
-    compared. ``sys.executable`` rather than the ``gwmock`` console script, so this does not
-    depend on what is on PATH.
+    Two separate properties are wanted. A *subprocess* means no state is shared between the two
+    runs being compared. The *console script* means each run goes through the entry point a user
+    invokes rather than an internal function, so what is measured is the reproducibility of the
+    real command.
     """
-    source = EXAMPLES_DIR / entry.label / "config.yaml"
-    config = apply_overlay(yaml.safe_load(source.read_text(encoding="utf-8")), entry.label, working_directory)
-
-    working_directory.mkdir(parents=True, exist_ok=True)
-    config_path = working_directory / "config.yaml"
-    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    config_path, _ = _write_config(entry, working_directory)
 
     completed = subprocess.run(  # noqa: S603
-        [
-            sys.executable,
-            "-c",
-            "import sys; from gwmock.cli.simulate import _simulate_impl; _simulate_impl(sys.argv[1])",
-            str(config_path),
-        ],
+        [_gwmock_executable(), "simulate", str(config_path)],
         capture_output=True,
         text=True,
         check=False,
     )
     assert completed.returncode == 0, (
-        f"'{entry.label}' failed in a subprocess (exit {completed.returncode}):\n{completed.stderr[-2000:]}"
+        f"'{entry.label}' failed via the CLI (exit {completed.returncode}):\n{completed.stderr[-2000:]}"
     )
 
 

--- a/tests/e2e/test_reproducibility.py
+++ b/tests/e2e/test_reproducibility.py
@@ -10,6 +10,12 @@ two are compared by *content* hash -- decoded samples plus their timing metadata
 That distinction matters for GWF, whose container records a write-time stamp: hashing the bytes
 would report a difference on every rerun regardless of the data.
 
+Each run happens in a **separate subprocess**. Running both in one interpreter would let shared
+state -- a cached RNG, JAX's compilation cache, LAL's process-global detector registry -- make two
+runs agree for reasons that do not hold across processes. Since stored reference values will be
+compared between different CI runs on different machines, process-independent reproducibility is
+the property that actually matters, and same-process agreement would overstate it.
+
 A failure here is information about the pipeline, not necessarily a bug in it. Some paths may
 legitimately need a seed that the configuration does not currently supply, in which case the
 finding is that the seed has to be threaded, before any reference value is stored for it.
@@ -17,21 +23,54 @@ finding is that the seed has to be threaded, before any reference value is store
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 from gwmock.cli.utils.hash import compute_content_hash
 
 from .matrix import E2E_MATRIX, MatrixEntry
-from .overlay import NOT_HERMETIC
-from .test_examples_end_to_end import _run, _written_files
+from .overlay import EXAMPLES_DIR, NOT_HERMETIC, apply_overlay
+from .test_examples_end_to_end import _written_files
 
 pytestmark = pytest.mark.e2e
 
 #: Files that are expected to differ between two runs and are not part of the data. Provenance
 #: records timings and host details by design, so comparing them would be comparing clocks.
 _NOT_DATA = ("resource_usage_summary.json", "config.yaml")
+
+
+def _run_in_subprocess(entry: MatrixEntry, working_directory: Path) -> None:
+    """Run one matrix entry in a fresh interpreter.
+
+    A subprocess rather than an in-process call, so no state is shared between the two runs being
+    compared. ``sys.executable`` rather than the ``gwmock`` console script, so this does not
+    depend on what is on PATH.
+    """
+    source = EXAMPLES_DIR / entry.label / "config.yaml"
+    config = apply_overlay(yaml.safe_load(source.read_text(encoding="utf-8")), entry.label, working_directory)
+
+    working_directory.mkdir(parents=True, exist_ok=True)
+    config_path = working_directory / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    completed = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-c",
+            "import sys; from gwmock.cli.simulate import _simulate_impl; _simulate_impl(sys.argv[1])",
+            str(config_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        f"'{entry.label}' failed in a subprocess (exit {completed.returncode}):\n{completed.stderr[-2000:]}"
+    )
 
 
 def _content_hashes(working_directory: Path) -> dict[str, str | None]:
@@ -45,18 +84,21 @@ def _content_hashes(working_directory: Path) -> dict[str, str | None]:
 
 @pytest.mark.parametrize("entry", E2E_MATRIX, ids=lambda entry: entry.label)
 def test_running_an_example_twice_produces_identical_data(entry: MatrixEntry, tmp_path: Path):
-    """Two runs of one configuration must agree file for file.
+    """Two runs of one configuration, in two fresh interpreters, must agree file for file.
 
     Compared by content hash rather than by array equality so that a mismatch names the file it
     is in, and so that the GWF container's write-time stamp does not count as a difference.
+
+    Separate processes so that a cached RNG, JAX's compilation cache or LAL's process-global
+    registry cannot make the two agree for a reason that would not survive a fresh run.
     """
     for module in entry.requires:
         pytest.importorskip(module, reason=f"'{entry.label}' needs {module}")
     if entry.label in NOT_HERMETIC:
         pytest.skip(f"'{entry.label}' {NOT_HERMETIC[entry.label]}")
 
-    _run(entry, tmp_path / "first")
-    _run(entry, tmp_path / "second")
+    _run_in_subprocess(entry, tmp_path / "first")
+    _run_in_subprocess(entry, tmp_path / "second")
 
     first = _content_hashes(tmp_path / "first")
     second = _content_hashes(tmp_path / "second")

--- a/tests/e2e/test_reproducibility.py
+++ b/tests/e2e/test_reproducibility.py
@@ -1,0 +1,75 @@
+"""Does running the same configuration twice produce the same data?
+
+This is a prerequisite, not a nicety. Every plan for comparing output against stored reference
+values assumes a run is reproducible; if a path is not, a stored value for it would fail
+intermittently and teach people to regenerate references reflexively, at which point the
+references stop meaning anything.
+
+So each matrix entry is run twice in two directories with an identical configuration, and the
+two are compared by *content* hash -- decoded samples plus their timing metadata, not file bytes.
+That distinction matters for GWF, whose container records a write-time stamp: hashing the bytes
+would report a difference on every rerun regardless of the data.
+
+A failure here is information about the pipeline, not necessarily a bug in it. Some paths may
+legitimately need a seed that the configuration does not currently supply, in which case the
+finding is that the seed has to be threaded, before any reference value is stored for it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gwmock.cli.utils.hash import compute_content_hash
+
+from .matrix import E2E_MATRIX, MatrixEntry
+from .overlay import NOT_HERMETIC
+from .test_examples_end_to_end import _run, _written_files
+
+pytestmark = pytest.mark.e2e
+
+#: Files that are expected to differ between two runs and are not part of the data. Provenance
+#: records timings and host details by design, so comparing them would be comparing clocks.
+_NOT_DATA = ("resource_usage_summary.json", "config.yaml")
+
+
+def _content_hashes(working_directory: Path) -> dict[str, str | None]:
+    """Return ``{path relative to the run directory: content hash}`` for the data written."""
+    return {
+        str(path.relative_to(working_directory)): compute_content_hash(path)
+        for path in _written_files(working_directory)
+        if path.name not in _NOT_DATA
+    }
+
+
+@pytest.mark.parametrize("entry", E2E_MATRIX, ids=lambda entry: entry.label)
+def test_running_an_example_twice_produces_identical_data(entry: MatrixEntry, tmp_path: Path):
+    """Two runs of one configuration must agree file for file.
+
+    Compared by content hash rather than by array equality so that a mismatch names the file it
+    is in, and so that the GWF container's write-time stamp does not count as a difference.
+    """
+    for module in entry.requires:
+        pytest.importorskip(module, reason=f"'{entry.label}' needs {module}")
+    if entry.label in NOT_HERMETIC:
+        pytest.skip(f"'{entry.label}' {NOT_HERMETIC[entry.label]}")
+
+    _run(entry, tmp_path / "first")
+    _run(entry, tmp_path / "second")
+
+    first = _content_hashes(tmp_path / "first")
+    second = _content_hashes(tmp_path / "second")
+
+    assert first, f"'{entry.label}' wrote no data files to hash"
+    assert sorted(first) == sorted(second), (
+        f"'{entry.label}' wrote different file names on the second run: "
+        f"only in first {sorted(set(first) - set(second))}, only in second {sorted(set(second) - set(first))}"
+    )
+
+    differing = [name for name in first if first[name] != second[name]]
+    assert not differing, (
+        f"'{entry.label}' is not reproducible: {differing} differ between two runs of an identical "
+        f"configuration. Until this is resolved, no reference value can be stored for it -- a "
+        f"stored value would fail intermittently."
+    )


### PR DESCRIPTION
## 📝 Summary

#287 declared an end-to-end matrix with **no runner** — the entries were checked only for
existence. This adds the runner.

- **`e2e` marker**, excluded from the default run via `-m "not integration and not e2e"`, plus its
  own CI job
- **`tests/e2e/overlay.py`** — declarative per-example overrides that shorten a run and repoint its
  inputs. The examples themselves are never edited, so they stay realistic while the suite finishes
  in about two minutes
- **`tests/e2e/test_examples_end_to_end.py`** — runs each entry through the CLI and verifies its
  output
- **`tests/e2e/test_overlay.py`** — overlay invariants, deliberately _not_ marked `e2e` so they run
  on every PR
- **`tests/e2e/test_reproducibility.py`** — runs each entry twice in separate processes and compares
  content hashes

### Output is checked against the run's own manifest

Each run records every file it wrote, with channels and a content hash. The output directory is
compared against that declaration **in both directions**, so a run that wrote one detector's frame
and dropped the rest fails — and so does one that writes a file its metadata doesn't mention.

That replaced a weaker first version which required only _some_ output, _some_ decodable file,
_some_ non-zero sample. Verified by deleting a frame and by planting a stray file; each breaks it.

### Reproducibility, in separate processes

All six runnable entries are reproducible. Each repetition runs in a **subprocess**, because
same-process agreement could come from a cached RNG, JAX's compilation cache, or LAL's
process-global registry — none of which survive a fresh interpreter. Since stored reference values
will be compared across CI runs on different machines, process independence is the property that
matters.

This is the prerequisite for comparing against stored references, which is deliberately **not** in
this PR.

## ✨ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [x] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

No `src/` changes. Tests, CI config, and docs only.

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** e2e **27 passed, 8 skipped** (~108 s); default suite **804 passed, 23
      skipped**, unchanged except for the new deselections.
- [x] **Manual Test:** deliberately misaligned the start time — both signal entries fail, which is
      what makes the signal assertion meaningful.
- [x] **Manual Test:** changed the seed where it's actually read — all nine output files differ, so
      the reproducibility probe discriminates.
- [x] **Manual Test:** confirmed hashes are non-null; a probe comparing `None` to `None` would pass
      vacuously.
- [x] **Manual Test:** all 21 pre-commit hooks pass on the committed tree.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

## 📷 Screenshots (if applicable)

Not applicable.

## Two tests that couldn't fail, and how they were caught

Both found by deliberately breaking things rather than by reading the code.

**The signal assertion.** It counted non-zero samples across every output file. With the start time
misaligned, `signal/bbh` failed but `quick_start` **passed** — it writes noise too, and the noise
alone satisfied the assertion. Now restricted to the configured signal output directory.

**The seed.** My first discrimination check changed the _global_ seed and saw **0 of 9** files
differ. Cause: the orchestrator copies the global seed into the noise arguments with `setdefault`,
so an example pinning its own (several pin `42`) keeps it. The overlay's global seed was a **no-op**
for those configs — meaning the runs were reproducible because the _examples_ pin a seed, not
because the test did. The overlay now writes the seed where it's read, and a test pins that.

## Known limits, stated rather than implied

**The gengli entry never runs.** It needs `gengli` — which is **not a declared extra of this
project**, so no sync flag installs it — and a local blip-glitch fixture, since the example reads
one from `sandbox.zenodo.org`, whose records are purged. It's labelled `**Not run**` in both the
matrix and the README, enforced by a test, because seven entries reading as seven exercised paths is
the most misleading thing a matrix can do.

**The overlay costs coverage.** Sampling frequency drops 4096 → 1024 Hz, moving the Nyquist
frequency, and spans are shortened, reducing segment counts. A defect appearing only at full rate or
across many segments is out of scope here.

**CI runs e2e on one Python and one OS.** These exercise orchestration, not anything
interpreter-specific; the normal matrix still covers portability. The job installs `--all-extras`
_and asserts the optional stack is importable_, because otherwise a missing extra makes the gated
entries skip and the job reports green while testing less than it claims.

## Review

An independent review reproduced both test counts and produced the manifest check, the subprocess
reproducibility runs, the extended preserved-key list, and the `**Not run**` labelling. It also
caught a false comment claiming `--all-extras` covers gengli. It could not reproduce the
seed-perturbation or misaligned-start experiments; those remain my measurements.

## Not in this PR

Stored reference values (tier 3). Also still open: `quick_start` and the other signal examples fetch
inputs from mutable `main` and purge-prone `sandbox.zenodo.org`. The overlay repoints them so the
_suite_ is hermetic, but those examples stay fragile, and pinned inputs are a prerequisite for
stored references meaning anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end coverage for example configurations, output generation, data validity, and expected signals.
  * Added reproducibility checks to confirm identical results across repeated runs.
  * Added validation for deterministic, isolated test configurations and required fixtures.

* **Chores**
  * Added automated end-to-end testing to continuous integration.
  * Updated test markers and documentation, including known unavailable scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->