### PR TITLE
fix(data): decide sample alignment with a spacing-derived absolute tolerance

### DIFF
--- a/src/gwmock/data/time_series/inject.py
+++ b/src/gwmock/data/time_series/inject.py
@@ -12,6 +12,36 @@ from scipy.interpolate import interp1d
 
 logger = logging.getLogger("gwmock")
 
+#: How close to a whole sample an offset must be to count as aligned, in samples.
+#:
+#: Absolute, not relative. ``np.isclose``'s default is relative, and since a fractional offset can
+#: never exceed 0.5 samples, a relative test passes unconditionally once ``rtol * offset >= 0.5`` --
+#: about 50,000 samples, or 12 s into a segment at 4096 Hz. Beyond that every chunk was snapped to
+#: the nearest sample and the interpolation branch was unreachable, silently displacing signals by
+#: up to half a sample.
+#:
+#: The value is measured rather than picked. ``offset`` comes from a GPS-scale subtraction, so an
+#: exactly-aligned chunk still carries cancellation error: zero for power-of-two sample rates, and
+#: up to 4.0e-4 samples at 4000 Hz across GPS epochs from 1e9 to 1.8e9. 1e-3 clears that worst case
+#: by 2.5x while still detecting a misalignment of a hundredth of a sample.
+#:
+#: Erring tight is the safer direction. Treating an aligned chunk as misaligned interpolates it onto
+#: essentially the same grid points, which is close to a no-op; treating a misaligned one as aligned
+#: is the displacement this constant exists to prevent.
+ALIGNMENT_TOLERANCE_SAMPLES = 1e-3
+
+
+def is_aligned(offset_samples: float) -> bool:
+    """Return whether *offset_samples* is a whole number of samples, to within tolerance.
+
+    Args:
+        offset_samples: Offset between two series' start times, in samples.
+
+    Returns:
+        Whether the offset counts as aligned. See :data:`ALIGNMENT_TOLERANCE_SAMPLES`.
+    """
+    return bool(abs(offset_samples - round(offset_samples)) <= ALIGNMENT_TOLERANCE_SAMPLES)
+
 
 def inject(timeseries: TimeSeries, other: TimeSeries, interpolate_if_offset: bool = True) -> TimeSeries:
     """Inject one TimeSeries into another, handling time offsets.
@@ -46,7 +76,7 @@ def inject(timeseries: TimeSeries, other: TimeSeries, interpolate_if_offset: boo
     offset = (other_times[0] - target_times[0]) / sample_spacing
 
     # Check if offset is aligned (integer number of samples)
-    if not np.isclose(offset, round(offset)):
+    if not is_aligned(offset):
         if not interpolate_if_offset:
             logger.debug("Non-integer offset of %s samples; not interpolating, returning original timeseries", offset)
             return timeseries

--- a/src/gwmock/data/time_series/inject.py
+++ b/src/gwmock/data/time_series/inject.py
@@ -12,12 +12,17 @@ from scipy.interpolate import interp1d
 
 logger = logging.getLogger("gwmock")
 
-#: Multiple of the float64 spacing at the epoch allowed as alignment error.
+#: Multiple of the float64 spacing allowed as alignment error, in ULPs.
 #:
-#: 4x leaves about an order of magnitude over the largest error measured for a genuinely aligned
-#: chunk (4.0e-4 samples at GPS 1.577e9, 4000 Hz) while keeping the tolerance as small as possible --
-#: too loose is the harmful direction, since that is what snaps a misaligned chunk to a whole sample.
-_ALIGNMENT_SPACING_MARGIN = 4.0
+#: 8, to match ``SamplingGrid.lattice_tolerance_samples`` in gwmock-signal, which reached the same
+#: ULP-scaling design independently and with the same floor and ceiling. This is one decision about
+#: numerical resolution encoded in two packages, and gwmock-signal's value is the older of the two,
+#: so this defers to it rather than leaving the pair to disagree by a factor of two.
+#:
+#: It is comfortably above the largest error measured for a genuinely aligned chunk here (4.0e-4
+#: samples at GPS 1.577e9, 4000 Hz) and, via the ceiling below, still far under the half sample that
+#: would make everything look aligned.
+_ALIGNMENT_SPACING_MARGIN = 8.0
 
 #: Smallest tolerance ever used, for epochs near zero where the spacing is meaningless.
 _MINIMUM_ALIGNMENT_TOLERANCE = 1e-9
@@ -32,7 +37,11 @@ _MINIMUM_ALIGNMENT_TOLERANCE = 1e-9
 _MAXIMUM_ALIGNMENT_TOLERANCE = 1e-2
 
 
-def alignment_tolerance(reference_time: float, sampling_frequency: float) -> float:
+def alignment_tolerance(
+    reference_time: float,
+    sampling_frequency: float,
+    gps_times: object = None,
+) -> float:
     """Return how far from a whole sample an offset may sit and still count as aligned.
 
     Derived from the floating-point spacing at *reference_time* rather than fixed. The offset is
@@ -48,12 +57,21 @@ def alignment_tolerance(reference_time: float, sampling_frequency: float) -> flo
     Args:
         reference_time: Epoch the offset is measured from, in seconds.
         sampling_frequency: Sample rate in Hz.
+        gps_times: Optional timestamps taking part in the comparison. The spacing is taken at the
+            largest magnitude involved, not at the epoch alone, since a time later than the epoch
+            has coarser resolution and it is the coarsest that bounds the error. Mirrors
+            ``SamplingGrid.lattice_tolerance_samples`` in gwmock-signal.
 
     Returns:
         Tolerance in samples, clamped to :data:`_MINIMUM_ALIGNMENT_TOLERANCE` and
         :data:`_MAXIMUM_ALIGNMENT_TOLERANCE`.
     """
-    derived = _ALIGNMENT_SPACING_MARGIN * float(np.spacing(abs(float(reference_time)))) * float(sampling_frequency)
+    magnitude = abs(float(reference_time))
+    if gps_times is not None:
+        times = np.asarray(gps_times, dtype=float)
+        if times.size:
+            magnitude = max(magnitude, float(np.max(np.abs(times))))
+    derived = _ALIGNMENT_SPACING_MARGIN * float(np.spacing(magnitude)) * float(sampling_frequency)
     if derived > _MAXIMUM_ALIGNMENT_TOLERANCE:
         logger.warning(
             "Sample alignment cannot be resolved at epoch %s and %s Hz: the floating-point spacing "
@@ -119,7 +137,8 @@ def inject(timeseries: TimeSeries, other: TimeSeries, interpolate_if_offset: boo
     offset = (other_times[0] - target_times[0]) / sample_spacing
 
     # Check if offset is aligned (integer number of samples)
-    if not is_aligned(offset, alignment_tolerance(target_times[0], 1.0 / sample_spacing)):
+    tolerance = alignment_tolerance(target_times[0], 1.0 / sample_spacing, gps_times=other_times)
+    if not is_aligned(offset, tolerance):
         if not interpolate_if_offset:
             logger.debug("Non-integer offset of %s samples; not interpolating, returning original timeseries", offset)
             return timeseries

--- a/src/gwmock/data/time_series/inject.py
+++ b/src/gwmock/data/time_series/inject.py
@@ -12,35 +12,78 @@ from scipy.interpolate import interp1d
 
 logger = logging.getLogger("gwmock")
 
-#: How close to a whole sample an offset must be to count as aligned, in samples.
+#: Multiple of the float64 spacing at the epoch allowed as alignment error.
 #:
-#: Absolute, not relative. ``np.isclose``'s default is relative, and since a fractional offset can
-#: never exceed 0.5 samples, a relative test passes unconditionally once ``rtol * offset >= 0.5`` --
-#: about 50,000 samples, or 12 s into a segment at 4096 Hz. Beyond that every chunk was snapped to
-#: the nearest sample and the interpolation branch was unreachable, silently displacing signals by
-#: up to half a sample.
+#: 4x leaves about an order of magnitude over the largest error measured for a genuinely aligned
+#: chunk (4.0e-4 samples at GPS 1.577e9, 4000 Hz) while keeping the tolerance as small as possible --
+#: too loose is the harmful direction, since that is what snaps a misaligned chunk to a whole sample.
+_ALIGNMENT_SPACING_MARGIN = 4.0
+
+#: Smallest tolerance ever used, for epochs near zero where the spacing is meaningless.
+_MINIMUM_ALIGNMENT_TOLERANCE = 1e-9
+
+#: Largest tolerance ever used, in samples.
 #:
-#: The value is measured rather than picked. ``offset`` comes from a GPS-scale subtraction, so an
-#: exactly-aligned chunk still carries cancellation error: zero for power-of-two sample rates, and
-#: up to 4.0e-4 samples at 4000 Hz across GPS epochs from 1e9 to 1.8e9. 1e-3 clears that worst case
-#: by 2.5x while still detecting a misalignment of a hundredth of a sample.
-#:
-#: Erring tight is the safer direction. Treating an aligned chunk as misaligned interpolates it onto
-#: essentially the same grid points, which is close to a no-op; treating a misaligned one as aligned
-#: is the displacement this constant exists to prevent.
-ALIGNMENT_TOLERANCE_SAMPLES = 1e-3
+#: A fractional offset cannot exceed 0.5 samples, so a tolerance approaching that would classify
+#: everything as aligned -- reintroducing the bug this machinery exists to prevent. 0.01 keeps a
+#: hundredth of a sample detectable. Reaching this ceiling means float64 can no longer resolve
+#: sample alignment at the given epoch and rate, which is worth saying out loud rather than
+#: silently degrading.
+_MAXIMUM_ALIGNMENT_TOLERANCE = 1e-2
 
 
-def is_aligned(offset_samples: float) -> bool:
-    """Return whether *offset_samples* is a whole number of samples, to within tolerance.
+def alignment_tolerance(reference_time: float, sampling_frequency: float) -> float:
+    """Return how far from a whole sample an offset may sit and still count as aligned.
+
+    Derived from the floating-point spacing at *reference_time* rather than fixed. The offset is
+    computed as ``(other_start - self_start) * sampling_frequency`` from two GPS-scale times, so an
+    exactly-aligned chunk still carries error of order ``spacing(epoch) * sampling_frequency``: at
+    GPS 1.6e9 and 4096 Hz that is ~1e-3 samples, and it grows with both the epoch and the rate.
+
+    A fixed tolerance therefore cannot be right everywhere. 1e-3 covers GPS 1e9-1.8e9 at 512-16384
+    Hz, but at GPS 1e10 and 2000 Hz the real error reaches ~1.7e-3 -- and a tolerance below the
+    error means genuinely aligned chunks get interpolated, which is worse than the misclassification
+    this whole check exists to avoid. Scaling with the spacing removes the domain assumption.
+
+    Args:
+        reference_time: Epoch the offset is measured from, in seconds.
+        sampling_frequency: Sample rate in Hz.
+
+    Returns:
+        Tolerance in samples, clamped to :data:`_MINIMUM_ALIGNMENT_TOLERANCE` and
+        :data:`_MAXIMUM_ALIGNMENT_TOLERANCE`.
+    """
+    derived = _ALIGNMENT_SPACING_MARGIN * float(np.spacing(abs(float(reference_time)))) * float(sampling_frequency)
+    if derived > _MAXIMUM_ALIGNMENT_TOLERANCE:
+        logger.warning(
+            "Sample alignment cannot be resolved at epoch %s and %s Hz: the floating-point spacing "
+            "implies an uncertainty of %.3g samples, so alignment decisions there are unreliable. "
+            "Capping the tolerance at %s.",
+            reference_time,
+            sampling_frequency,
+            derived,
+            _MAXIMUM_ALIGNMENT_TOLERANCE,
+        )
+    return min(_MAXIMUM_ALIGNMENT_TOLERANCE, max(_MINIMUM_ALIGNMENT_TOLERANCE, derived))
+
+
+def is_aligned(offset_samples: float, tolerance: float) -> bool:
+    """Return whether *offset_samples* is a whole number of samples, within *tolerance*.
+
+    Absolute, not relative. ``np.isclose``'s default tolerance is relative, and since a fractional
+    offset can never exceed 0.5 samples, a relative test passes unconditionally once
+    ``rtol * offset >= 0.5`` -- about 50,000 samples, or 12 s into a segment at 4096 Hz. Beyond that
+    the interpolation branch was unreachable and every chunk was snapped to the nearest sample,
+    displacing signals by up to half a sample.
 
     Args:
         offset_samples: Offset between two series' start times, in samples.
+        tolerance: Permitted deviation in samples, from :func:`alignment_tolerance`.
 
     Returns:
-        Whether the offset counts as aligned. See :data:`ALIGNMENT_TOLERANCE_SAMPLES`.
+        Whether the offset counts as aligned.
     """
-    return bool(abs(offset_samples - round(offset_samples)) <= ALIGNMENT_TOLERANCE_SAMPLES)
+    return bool(abs(offset_samples - round(offset_samples)) <= tolerance)
 
 
 def inject(timeseries: TimeSeries, other: TimeSeries, interpolate_if_offset: bool = True) -> TimeSeries:
@@ -76,7 +119,7 @@ def inject(timeseries: TimeSeries, other: TimeSeries, interpolate_if_offset: boo
     offset = (other_times[0] - target_times[0]) / sample_spacing
 
     # Check if offset is aligned (integer number of samples)
-    if not is_aligned(offset):
+    if not is_aligned(offset, alignment_tolerance(target_times[0], 1.0 / sample_spacing)):
         if not interpolate_if_offset:
             logger.debug("Non-integer offset of %s samples; not interpolating, returning original timeseries", offset)
             return timeseries

--- a/src/gwmock/data/time_series/time_series.py
+++ b/src/gwmock/data/time_series/time_series.py
@@ -14,7 +14,7 @@ from gwpy.types.index import Index
 from scipy.interpolate import interp1d
 
 from gwmock.data.serialize.serializable import JSONSerializable
-from gwmock.data.time_series.inject import inject
+from gwmock.data.time_series.inject import inject, is_aligned
 
 logger = logging.getLogger("gwmock")
 
@@ -281,7 +281,7 @@ class TimeSeries(JSONSerializable):
         # Check whether there is any offset in times
         other_start_time = other.start_time.to(self.start_time.unit)
         idx = ((other_start_time - self.start_time) * self.sampling_frequency).value
-        if not np.isclose(idx, np.round(idx)):
+        if not is_aligned(idx):
             logger.warning("Chunk time grid does not align with segment time grid.")
             logger.warning("Interpolation will be used to align the chunk to the segment grid.")
 

--- a/src/gwmock/data/time_series/time_series.py
+++ b/src/gwmock/data/time_series/time_series.py
@@ -278,6 +278,13 @@ class TimeSeries(JSONSerializable):
             )
             return other
 
+        # Kept because the interpolation below rebinds `other` to samples drawn from this segment's
+        # own time array, which by construction cannot extend past `self.end_time`. The overflow has
+        # to be measured against what the caller actually passed, or a chunk crossing the segment
+        # boundary loses its tail -- and `TimeSeriesMixin.simulate` relies on that tail being
+        # returned to carry the rest of the signal into the next segment.
+        supplied = other
+
         # Check whether there is any offset in times
         other_start_time = other.start_time.to(self.start_time.unit)
         idx = ((other_start_time - self.start_time) * self.sampling_frequency).value
@@ -306,8 +313,10 @@ class TimeSeries(JSONSerializable):
         for i in range(self.num_of_channels):
             self[i] = inject(self[i], other[i])
 
-        if other.end_time > self.end_time:
-            return other.crop(start_time=self.end_time)
+        # The tail comes from the supplied chunk, unresampled, so the next segment interpolates it
+        # against its own grid rather than inheriting this segment's resampling.
+        if supplied.end_time > self.end_time:
+            return supplied.crop(start_time=self.end_time)
         return None
 
     def inject_from_list(self, ts_iterable: Iterable[TimeSeries]) -> TimeSeriesList:

--- a/src/gwmock/data/time_series/time_series.py
+++ b/src/gwmock/data/time_series/time_series.py
@@ -14,7 +14,7 @@ from gwpy.types.index import Index
 from scipy.interpolate import interp1d
 
 from gwmock.data.serialize.serializable import JSONSerializable
-from gwmock.data.time_series.inject import inject, is_aligned
+from gwmock.data.time_series.inject import alignment_tolerance, inject, is_aligned
 
 logger = logging.getLogger("gwmock")
 
@@ -281,7 +281,7 @@ class TimeSeries(JSONSerializable):
         # Check whether there is any offset in times
         other_start_time = other.start_time.to(self.start_time.unit)
         idx = ((other_start_time - self.start_time) * self.sampling_frequency).value
-        if not is_aligned(idx):
+        if not is_aligned(idx, alignment_tolerance(self.start_time.value, self.sampling_frequency.value)):
             logger.warning("Chunk time grid does not align with segment time grid.")
             logger.warning("Interpolation will be used to align the chunk to the segment grid.")
 

--- a/src/gwmock/data/time_series/time_series.py
+++ b/src/gwmock/data/time_series/time_series.py
@@ -288,7 +288,12 @@ class TimeSeries(JSONSerializable):
         # Check whether there is any offset in times
         other_start_time = other.start_time.to(self.start_time.unit)
         idx = ((other_start_time - self.start_time) * self.sampling_frequency).value
-        if not is_aligned(idx, alignment_tolerance(self.start_time.value, self.sampling_frequency.value)):
+        tolerance = alignment_tolerance(
+            self.start_time.value,
+            self.sampling_frequency.value,
+            gps_times=(other_start_time.value, other.end_time.to(self.start_time.unit).value),
+        )
+        if not is_aligned(idx, tolerance):
             logger.warning("Chunk time grid does not align with segment time grid.")
             logger.warning("Interpolation will be used to align the chunk to the segment grid.")
 

--- a/tests/data/time_series/test_inject.py
+++ b/tests/data/time_series/test_inject.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from gwpy.timeseries import TimeSeries as GWpyTimeSeries
 
-from gwmock.data.time_series.inject import inject
+from gwmock.data.time_series.inject import inject, is_aligned
 
 
 class TestInjectBasic:
@@ -846,3 +846,122 @@ class TestInjectExactBoundaries:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestAlignmentTolerance:
+    """The offset-to-whole-sample test, whose tolerance has to be absolute.
+
+    ``np.isclose`` defaults to a *relative* tolerance. A fractional offset can never exceed half a
+    sample, so a relative test passes unconditionally once ``rtol * offset >= 0.5`` -- about 50,000
+    samples, or 12 s into a segment at 4096 Hz. Past that point the interpolation branch was
+    unreachable and every chunk was snapped to the nearest sample, displacing signals by up to half
+    a sample with only a debug log to show for it. The example configurations use 4096-second
+    segments, so almost every injection was in that regime.
+    """
+
+    @staticmethod
+    def _series(start_sample: float, sampling_frequency: float = 4096.0, n: int = 8, amplitude: float = 1.0):
+        """Return a flat series starting *start_sample* samples after GPS 1e9."""
+        return GWpyTimeSeries(
+            np.full(n, amplitude),
+            t0=1e9 + start_sample / sampling_frequency,
+            dt=1.0 / sampling_frequency,
+            unit="m",
+        )
+
+    @staticmethod
+    def _target(n: int, sampling_frequency: float = 4096.0):
+        return GWpyTimeSeries(np.zeros(n), t0=1e9, dt=1.0 / sampling_frequency, unit="m")
+
+    @pytest.mark.parametrize("offset_samples", [10, 1_000, 49_999, 50_001, 200_000])
+    def test_a_half_sample_offset_is_interpolated_at_every_scale(self, offset_samples: int):
+        """A half-sample offset must interpolate regardless of how far into the segment it is.
+
+        The two large values straddle the point where the old relative test stopped
+        discriminating, which is what makes this parametrisation worth having rather than one
+        convenient offset.
+
+        The injected chunk is a delta rather than a flat top-hat: interpolating a constant returns
+        the same constant in its interior, so a flat chunk cannot reveal whether it was resampled
+        or merely snapped. A delta's energy spreads across neighbouring samples, which it does not
+        if the chunk was snapped to a whole sample.
+        """
+        target = self._target(offset_samples + 4096)
+        other = GWpyTimeSeries(
+            np.array([0.0, 0.0, 1.0, 0.0, 0.0]),
+            t0=1e9 + (offset_samples + 0.5) / 4096.0,
+            dt=1.0 / 4096.0,
+            unit="m",
+        )
+
+        result = inject(target, other, interpolate_if_offset=True)
+
+        values = np.asarray(result.value)
+        occupied = np.flatnonzero(values)
+        assert occupied.size, "nothing was injected"
+        assert occupied.size > 1, (
+            f"the chunk at offset {offset_samples}+0.5 landed on a single sample, so it was snapped "
+            f"to a whole sample instead of interpolated -- displacing it by half a sample"
+        )
+
+    @pytest.mark.parametrize("offset_samples", [10, 1_000, 200_000])
+    def test_a_half_sample_offset_is_refused_when_not_interpolating(self, offset_samples: int):
+        """With interpolation disabled, a misaligned chunk must be declined, not snapped.
+
+        This is the assertion that shows the *classification* changed rather than the arithmetic:
+        the target must come back untouched.
+        """
+        target = self._target(offset_samples + 4096)
+        other = self._series(offset_samples + 0.5)
+
+        result = inject(target, other, interpolate_if_offset=False)
+
+        assert not np.any(np.asarray(result.value)), (
+            f"the chunk at offset {offset_samples}+0.5 was injected despite interpolation being "
+            f"disabled, so it was misclassified as aligned"
+        )
+
+    @pytest.mark.parametrize("sampling_frequency", [1000.0, 2000.0, 3000.0, 4000.0, 4096.0, 8192.0])
+    @pytest.mark.parametrize("offset_samples", [1_000, 1_000_000])
+    def test_a_genuinely_aligned_chunk_is_not_interpolated(self, sampling_frequency: float, offset_samples: int):
+        """Tightening the tolerance must not push real alignments onto the interpolation path.
+
+        ``offset`` comes from a GPS-scale subtraction, so an exactly-aligned chunk still carries
+        cancellation error -- zero at power-of-two rates, up to 4.0e-4 samples at 4000 Hz. The
+        non-power-of-two rates here are the cases that error appears in, and they are the reason
+        the tolerance is 1e-3 rather than something tighter.
+        """
+        target = self._target(offset_samples + 64, sampling_frequency=sampling_frequency)
+        other = self._series(offset_samples, sampling_frequency=sampling_frequency, amplitude=2.0)
+
+        result = inject(target, other, interpolate_if_offset=False)
+
+        occupied = np.flatnonzero(np.asarray(result.value))
+        assert occupied.size, (
+            f"an aligned chunk at {sampling_frequency} Hz, offset {offset_samples}, was refused -- "
+            f"the tolerance is too tight for the representation error at this rate"
+        )
+        assert np.all(np.asarray(result.value)[occupied] == 2.0), "an aligned injection must be a plain add"
+
+
+class TestIsAligned:
+    """The predicate itself, across the domain rather than at one point."""
+
+    def test_zero_and_whole_offsets_are_aligned(self):
+        assert is_aligned(0.0)
+        assert is_aligned(1.0)
+        assert is_aligned(16_777_216.0)
+
+    def test_representation_error_counts_as_aligned(self):
+        """4.0e-4 samples is the worst measured error for a truly aligned chunk, at 4000 Hz."""
+        assert is_aligned(4.0e-4)
+        assert is_aligned(1_000_000 + 4.0e-4)
+
+    def test_a_fraction_of_a_sample_counts_as_misaligned(self):
+        assert not is_aligned(0.01)
+        assert not is_aligned(0.5)
+
+    @pytest.mark.parametrize("offset", [0.5, 50_000.5, 1_000_000.5, 16_777_216.5])
+    def test_a_half_sample_is_misaligned_at_any_magnitude(self, offset: float):
+        """The property the relative tolerance failed to provide: scale independence."""
+        assert not is_aligned(offset)

--- a/tests/data/time_series/test_inject.py
+++ b/tests/data/time_series/test_inject.py
@@ -6,7 +6,12 @@ import numpy as np
 import pytest
 from gwpy.timeseries import TimeSeries as GWpyTimeSeries
 
-from gwmock.data.time_series.inject import inject, is_aligned
+from gwmock.data.time_series.inject import (
+    _MAXIMUM_ALIGNMENT_TOLERANCE,
+    alignment_tolerance,
+    inject,
+    is_aligned,
+)
 
 
 class TestInjectBasic:
@@ -947,21 +952,57 @@ class TestAlignmentTolerance:
 class TestIsAligned:
     """The predicate itself, across the domain rather than at one point."""
 
+    #: Tolerance at a realistic GPS epoch and rate, ~3.9e-3 samples.
+    TOLERANCE = alignment_tolerance(1.6e9, 4096.0)
+
     def test_zero_and_whole_offsets_are_aligned(self):
-        assert is_aligned(0.0)
-        assert is_aligned(1.0)
-        assert is_aligned(16_777_216.0)
+        assert is_aligned(0.0, self.TOLERANCE)
+        assert is_aligned(1.0, self.TOLERANCE)
+        assert is_aligned(16_777_216.0, self.TOLERANCE)
 
     def test_representation_error_counts_as_aligned(self):
         """4.0e-4 samples is the worst measured error for a truly aligned chunk, at 4000 Hz."""
-        assert is_aligned(4.0e-4)
-        assert is_aligned(1_000_000 + 4.0e-4)
+        assert is_aligned(4.0e-4, self.TOLERANCE)
+        assert is_aligned(1_000_000 + 4.0e-4, self.TOLERANCE)
 
     def test_a_fraction_of_a_sample_counts_as_misaligned(self):
-        assert not is_aligned(0.01)
-        assert not is_aligned(0.5)
+        assert not is_aligned(0.05, self.TOLERANCE)
+        assert not is_aligned(0.5, self.TOLERANCE)
 
     @pytest.mark.parametrize("offset", [0.5, 50_000.5, 1_000_000.5, 16_777_216.5])
     def test_a_half_sample_is_misaligned_at_any_magnitude(self, offset: float):
         """The property the relative tolerance failed to provide: scale independence."""
-        assert not is_aligned(offset)
+        assert not is_aligned(offset, self.TOLERANCE)
+
+
+class TestAlignmentToleranceDerivation:
+    """The tolerance has to track the epoch, not be a constant."""
+
+    @pytest.mark.parametrize(
+        ("epoch", "sampling_frequency", "observed_error"),
+        [
+            (1.577e9, 4000.0, 4.0e-4),  # worst error measured locally
+            (1e10, 2000.0, 1.68e-3),  # the case a fixed 1e-3 got wrong
+        ],
+    )
+    def test_the_tolerance_exceeds_the_error_a_real_alignment_carries(
+        self, epoch: float, sampling_frequency: float, observed_error: float
+    ):
+        """A tolerance below the representation error interpolates genuinely aligned chunks.
+
+        That is worse than the misclassification this check exists to prevent, and it is why the
+        tolerance is derived from the floating-point spacing rather than fixed. A hardcoded 1e-3
+        passed the first case and failed the second.
+        """
+        assert alignment_tolerance(epoch, sampling_frequency) > observed_error
+
+    def test_the_tolerance_never_reaches_half_a_sample(self):
+        """Above half a sample the check would call everything aligned -- the original bug."""
+        for epoch in (1e9, 1e10, 1e12, 1e15):
+            for sampling_frequency in (1024.0, 16384.0, 1e6):
+                assert alignment_tolerance(epoch, sampling_frequency) <= _MAXIMUM_ALIGNMENT_TOLERANCE < 0.5
+
+    def test_the_tolerance_grows_with_epoch_and_rate(self):
+        """The property that makes it correct where a constant is not."""
+        assert alignment_tolerance(1e10, 4096.0) > alignment_tolerance(1e9, 4096.0)
+        assert alignment_tolerance(1e9, 16384.0) > alignment_tolerance(1e9, 1024.0)

--- a/tests/data/time_series/test_inject.py
+++ b/tests/data/time_series/test_inject.py
@@ -1002,6 +1002,36 @@ class TestAlignmentToleranceDerivation:
             for sampling_frequency in (1024.0, 16384.0, 1e6):
                 assert alignment_tolerance(epoch, sampling_frequency) <= _MAXIMUM_ALIGNMENT_TOLERANCE < 0.5
 
+    @pytest.mark.parametrize(
+        ("epoch", "sampling_frequency"),
+        [(1e9, 4096.0), (1.577e9, 4096.0), (1.577e9, 4000.0), (1e10, 2000.0), (1.4e9, 2048.0)],
+    )
+    def test_it_agrees_with_gwmock_signals_lattice_tolerance(self, epoch: float, sampling_frequency: float):
+        """The same numerical-resolution decision exists in gwmock-signal; they must not diverge.
+
+        ``SamplingGrid.lattice_tolerance_samples`` reached the same ULP-scaling design
+        independently, with the same floor and ceiling. Two encodings of one decision drift apart
+        silently unless something compares them -- and the device path is about to place chunks
+        using gwmock-signal's lattice and inject them using this tolerance, so a disagreement there
+        would mean a buffer gwmock-signal calls on-lattice that gwmock calls misaligned.
+        """
+        from gwmock_signal import SamplingGrid
+
+        theirs = SamplingGrid(epoch, sampling_frequency).lattice_tolerance_samples(epoch)
+
+        assert alignment_tolerance(epoch, sampling_frequency) == pytest.approx(theirs, rel=1e-12)
+
+    def test_the_tolerance_uses_the_coarsest_magnitude_involved(self):
+        """A timestamp later than the epoch has coarser resolution, and that is what bounds error.
+
+        Taking the spacing at the epoch alone would understate the tolerance whenever the times
+        being compared sit at a larger magnitude.
+        """
+        at_epoch = alignment_tolerance(1.0, 4096.0)
+        with_later_times = alignment_tolerance(1.0, 4096.0, gps_times=[1e10])
+
+        assert with_later_times > at_epoch
+
     def test_the_tolerance_grows_with_epoch_and_rate(self):
         """The property that makes it correct where a constant is not."""
         assert alignment_tolerance(1e10, 4096.0) > alignment_tolerance(1e9, 4096.0)

--- a/tests/data/time_series/test_time_series.py
+++ b/tests/data/time_series/test_time_series.py
@@ -192,3 +192,77 @@ class TestTimeSeriesSerialization:
         assert reconstructed.start_time == sample_timeseries.start_time
         assert reconstructed.sampling_frequency == sample_timeseries.sampling_frequency
         np.testing.assert_array_equal(reconstructed[0].value, sample_timeseries[0].value)
+
+
+class TestInjectBoundaryOverflow:
+    """A chunk crossing the segment boundary must hand its tail back, aligned or not.
+
+    ``TimeSeriesMixin.simulate`` carries a signal across segments by caching whatever
+    ``inject``/``inject_from_list`` returns. The interpolation path rebinds ``other`` to samples
+    drawn from the segment's own time array, which cannot extend past the segment end, so the
+    overflow check compared against the wrong series and the tail was dropped -- silently
+    truncating any misaligned signal at a segment boundary.
+
+    This was latent while the alignment test used a relative tolerance, because long segments always
+    took the aligned branch. Fixing that tolerance made the interpolation branch reachable and the
+    bug live, which is why it belongs with that change.
+    """
+
+    SAMPLING_FREQUENCY = 4096.0
+    START = 1e9
+    SEGMENT_SAMPLES = 1000
+    CHUNK_SAMPLES = 400
+    CHUNK_START_SAMPLE = 900
+
+    def _segment(self):
+        return TimeSeries(
+            data=np.zeros((1, self.SEGMENT_SAMPLES)),
+            start_time=self.START,
+            sampling_frequency=self.SAMPLING_FREQUENCY,
+        )
+
+    def _chunk(self, offset_samples: float):
+        return TimeSeries(
+            data=np.ones((1, self.CHUNK_SAMPLES)),
+            start_time=self.START + offset_samples / self.SAMPLING_FREQUENCY,
+            sampling_frequency=self.SAMPLING_FREQUENCY,
+        )
+
+    @pytest.mark.parametrize(
+        ("offset_samples", "description"),
+        [(900.0, "aligned"), (900.5, "half a sample misaligned")],
+    )
+    def test_the_overflow_is_returned(self, offset_samples: float, description: str):
+        """Both branches must return the part of the chunk beyond the segment."""
+        segment = self._segment()
+
+        remaining = segment.inject(self._chunk(offset_samples))
+
+        assert remaining is not None, (
+            f"a {description} chunk crossing the segment boundary returned no remainder, so its "
+            f"tail was discarded instead of being carried into the next segment"
+        )
+        expected = self.CHUNK_SAMPLES - (self.SEGMENT_SAMPLES - int(self.CHUNK_START_SAMPLE))
+        assert len(np.asarray(remaining)[0]) == expected
+
+    def test_the_returned_tail_is_not_resampled(self):
+        """The tail must keep its own grid so the next segment can place it correctly.
+
+        Handing back an already-interpolated tail would resample the same data twice, and would
+        also lose the sub-sample offset the next segment needs in order to place it.
+        """
+        segment = self._segment()
+        chunk = self._chunk(900.5)
+
+        remaining = segment.inject(chunk)
+
+        assert remaining is not None
+        assert np.all(np.asarray(remaining)[0] == 1.0), (
+            "the returned tail has been interpolated; it should be the supplied samples unchanged"
+        )
+
+    def test_a_chunk_inside_the_segment_returns_nothing(self):
+        """The complement, so the test above cannot pass by always returning a remainder."""
+        segment = self._segment()
+
+        assert segment.inject(self._chunk(100.5)) is None


### PR DESCRIPTION
## 📝 Summary

Injection decided whether a chunk was grid-aligned with `np.isclose(offset, round(offset))`. That
tolerance is **relative**. A fractional offset can never exceed half a sample, so the test passes
unconditionally once `rtol * offset >= 0.5` — from about **50,000 samples, or 12 s into a segment at
4096 Hz**.

Past that point the interpolation branch was unreachable. Every chunk was snapped to the nearest
sample, displacing signals by up to **half a sample (122 µs at 4096 Hz)** behind a `logger.debug`.
The bundled examples use **4096-second segments** (up to 1.7e7 samples), so nearly every injection in
a realistic run was in that regime.

Both call sites were affected, and each carried its own copy of the check — `TimeSeries.inject`,
which interpolates _linearly_, and the module-level `inject`, which interpolates _cubically_. Both
now call one `is_aligned()`, so the rule has a single definition.

### The tolerance is derived, not chosen

`offset` comes from a GPS-scale subtraction, so even an exactly-aligned chunk carries cancellation
error. I measured it: **zero at power-of-two sample rates**, up to **4.0e-4 samples at 4000 Hz**
across GPS epochs 1e9–1.8e9 and rates 512–16384 Hz.

My first version used a fixed `1e-3`. Review found the regime that breaks: at **GPS 1e10 and 2000 Hz
the error reaches ~1.68e-3**, so a genuinely aligned chunk was classified misaligned and
interpolated, altering a smooth waveform by ~1.9e-3. That is the same defect as the original bug,
pointing the other way.

The error scales as `spacing(epoch) * sampling_frequency`, so a constant cannot be right everywhere.
The tolerance is now derived from `np.spacing` at the epoch times 4 — about an order of magnitude
above the measured 4.0e-4, kept as small as possible because **too loose is the harmful direction**.
Clamped below at 1e-9 for epochs near zero, and above at **1e-2** so it can never approach the half
sample that would make everything look aligned. Hitting that ceiling logs a warning, since it means
float64 cannot resolve alignment at that epoch and rate at all.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

No API is removed, but **this changes generated data** for configurations with segments longer than
~12 s at 4096 Hz — which is all the bundled examples. Signals that were silently snapped are now
interpolated to their true sub-sample position. Existing datasets will not reproduce bit-for-bit.

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** 835 passed, 23 skipped (804 before, plus 31 here). e2e: 34 passed, 9 skipped.
- [x] **Manual Test:** red check with the old check restored — **49,999 / 50,001 / 200,000 fail; 10 /
      1,000 pass**. 49,999 fails because `round(49999.5) = 50000` and `rtol * 50000` is exactly 0.5,
      which is what makes the parametrisation straddle the real threshold rather than guess at it.
- [x] **Manual Test:** swept the cancellation error across epochs 1e9–1.8e9, rates 512–16384 Hz,
      offsets 0–1.7e7 to fix the floor at 4.0e-4.
- [x] **Manual Test:** confirmed the two-stage path does not interpolate twice — the linear pass
      leaves an integer offset, so the cubic branch is skipped. Now asserted.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

## 📷 Screenshots (if applicable)

Not applicable.

## Two mistakes of mine, since both are instructive

**The first test passed for the wrong reason.** It injected a flat top-hat and asserted the values
changed. Interpolating a constant returns the same constant in its interior, so a flat chunk cannot
reveal whether it was resampled or merely snapped. Replaced with a delta, whose energy visibly
spreads.

**A duplicate class name silently dropped 16 tests.** Adding
`TestAlignmentToleranceDerivation` I first named it `TestAlignmentTolerance`, shadowing the existing
class. 61 tests became 45 and everything stayed green. Caught from the count, not from a failure.

## What the end-to-end suite tells us, and what it cannot

The reference hashes are **unchanged**, and that is the expected result rather than a reassuring one:
the e2e overlay shortens segments to 4–16 s, keeping every offset below the threshold. So **the e2e
suite structurally could not have caught this bug** — exactly the limitation recorded in #289 as out
of scope, now demonstrated rather than hypothetical.

Worth considering separately: one matrix entry at full rate with a segment long enough to exceed 12 s
of offset would close that gap, at the cost of runtime.

## Not measured

I have **not** diffed a full 4096-second production segment before and after. The fix should change
such output, and that is the claim I have not verified directly — the independent review did not
verify it either. Everything above is either measured at test scale or reasoned from the arithmetic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time-series injection alignment checks for greater floating-point accuracy.
  * Correctly accepts genuinely sample-aligned injections while rejecting fractional-sample offsets.
  * Provides consistent alignment behavior across different reference times and sampling frequencies.
  * Warns when numerical precision is insufficient to reliably determine alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->