### PR TITLE
feat(cli): run a segment's events through the batched device path

### DIFF
--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -604,12 +604,14 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             canonicalise_parameters,
         )
 
+        # Validated before any events are consumed. `population_index` is checkpointed state, so
+        # failing after advancing it would make a resumed run skip the events this call rejected.
+        waveform_backend = self._batched_waveform_backend()
+
         event_ids, events = self._events_for_this_segment()
         self._batch_injections = []
         if not events:
             return TimeSeriesList()
-
-        waveform_backend = self._batched_waveform_backend()
         parameters = canonicalise_parameters(
             {**self.waveform_arguments, **SignalAdapter.events_to_struct_of_arrays(events)}
         )

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -532,16 +532,26 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         events: list[dict[str, Any]] = []
         end_time_value = float(getattr(self.end_time, "value", self.end_time))
 
-        while self.population_index < len(self._population_events):
-            event_id = int(self.population_index)
-            parameters = dict(self._population_events[event_id])
+        # Read without advancing. `population_index` is checkpointed, and everything after this --
+        # transposing to a struct-of-arrays, canonicalising, generating -- can still fail. Advancing
+        # here would let a caller observe a consumed index after an exception, so the commit happens
+        # in `_commit_consumed_events` once generation has succeeded. The CLI's retry wrapper
+        # restores pre-batch state, so this is about direct library callers rather than the runner.
+        position = int(self.population_index)
+        while position < len(self._population_events):
+            parameters = dict(self._population_events[position])
             coa_time = parameters.get("coa_time")
             if coa_time is not None and float(coa_time) >= end_time_value:
                 break
-            event_ids.append(event_id)
+            event_ids.append(position)
             events.append(parameters)
-            self.population_index = cast(int, self.population_index) + 1
+            position += 1
         return event_ids, events
+
+    def _commit_consumed_events(self, event_ids: list[int]) -> None:
+        """Advance the checkpointed index past events whose generation succeeded."""
+        if event_ids:
+            self.population_index = event_ids[-1] + 1
 
     def _batched_waveform_backend(self) -> Any:
         """Return the ripple backend the batched path should generate with.
@@ -602,11 +612,13 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         from gwmock.signal.device_chunks import (  # noqa: PLC0415
             batched_strain_to_chunks,
             canonicalise_parameters,
+            require_batched_parameters_supported,
         )
 
         # Validated before any events are consumed. `population_index` is checkpointed state, so
         # failing after advancing it would make a resumed run skip the events this call rejected.
         waveform_backend = self._batched_waveform_backend()
+        require_batched_parameters_supported(canonicalise_parameters(dict(self.waveform_arguments)))
 
         event_ids, events = self._events_for_this_segment()
         self._batch_injections = []
@@ -633,6 +645,9 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         )
 
         chunks = batched_strain_to_chunks(batch, expected_detector_names=tuple(self.detectors))
+
+        # Generation succeeded, so these events are now genuinely consumed.
+        self._commit_consumed_events(event_ids)
         # Provenance records what the *catalogue* said, not the canonicalised and merged mapping
         # handed to the device, so the two execution modes describe an injection the same way. The
         # per-event path records `dict(parameters)` straight from the population.

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -479,6 +479,9 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         if not self._population_events and self._source_type == "sgwb":
             return self._simulate_stationary_signal_segment()
 
+        if self._execution_mode() == "batched":
+            return self._simulate_batched_segment()
+
         chunks = TimeSeriesList()
         self._batch_injections = []
         while self.population_index < len(self._population_events):
@@ -502,6 +505,85 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             self.population_index = cast(int, self.population_index) + 1
             if strain.start_time >= self.end_time:
                 break
+        return chunks
+
+    def _execution_mode(self) -> str:
+        """Return how this segment's events should be generated."""
+        signal_config = self.orchestration_config.signal
+        return "per-event" if signal_config is None else str(getattr(signal_config, "execution", "per-event"))
+
+    def _events_for_this_segment(self) -> tuple[list[int], list[dict[str, Any]]]:
+        """Consume the population events belonging to the current segment.
+
+        Advances ``population_index`` exactly as the per-event loop does, and stops at the same
+        boundary, so the two paths consume the catalogue identically. That matters for resume: a run
+        switched between modes mid-way must not skip or repeat events.
+
+        Returns:
+            The population indices and their parameter mappings, in catalogue order.
+        """
+        event_ids: list[int] = []
+        events: list[dict[str, Any]] = []
+        end_time_value = float(getattr(self.end_time, "value", self.end_time))
+
+        while self.population_index < len(self._population_events):
+            event_id = int(self.population_index)
+            parameters = dict(self._population_events[event_id])
+            coa_time = parameters.get("coa_time")
+            if coa_time is not None and float(coa_time) >= end_time_value:
+                break
+            event_ids.append(event_id)
+            events.append(parameters)
+            self.population_index = cast(int, self.population_index) + 1
+        return event_ids, events
+
+    def _simulate_batched_segment(self) -> TimeSeriesList:
+        """Generate this segment's events together, through gwmock-signal's batched path.
+
+        The device produces one buffer per event, aligned to this segment's sample lattice, and
+        gwmock's own assembler places them. Chunks stay per-event so ``inject_from_list`` keeps
+        handling spill-over into later segments and provenance stays per-injection -- the batched
+        path is a different way to *generate*, not a different way to assemble.
+
+        Returns:
+            One chunk per event, ready for injection, or an empty list if the segment has no events.
+        """
+        from gwmock_signal import SamplingGrid, simulate_cbc_batch  # noqa: PLC0415
+
+        from gwmock.signal.device_chunks import (  # noqa: PLC0415
+            batched_strain_to_chunks,
+            canonicalise_parameters,
+            per_event_injections,
+        )
+
+        event_ids, events = self._events_for_this_segment()
+        self._batch_injections = []
+        if not events:
+            return TimeSeriesList()
+
+        parameters = canonicalise_parameters(
+            {**self.waveform_arguments, **SignalAdapter.events_to_struct_of_arrays(events)}
+        )
+        sampling_frequency = float(self.sampling_frequency.value)
+
+        # The grid is this segment's own lattice, so every buffer starts on a sample of it and
+        # injection is an integer-offset add rather than a resample.
+        grid = SamplingGrid(float(getattr(self.start_time, "value", self.start_time)), sampling_frequency)
+
+        batch = simulate_cbc_batch(
+            self.signal_adapter.device_approximant(),
+            list(self._signal_network.detector_names),
+            sampling_frequency=sampling_frequency,
+            minimum_frequency=self.minimum_frequency,
+            parameters=parameters,
+            earth_rotation=self.earth_rotation,
+            output_grid=grid,
+        )
+
+        chunks = batched_strain_to_chunks(batch, expected_detector_names=tuple(self.detectors))
+        self._batch_injections = per_event_injections(parameters, event_ids)
+        for chunk, record in zip(chunks, self._batch_injections, strict=True):
+            chunk.metadata.update({"injection_parameters": dict(record["parameters"])})
         return chunks
 
     def _simulate_stationary_signal_segment(self) -> TimeSeriesList:

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -515,9 +515,15 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
     def _events_for_this_segment(self) -> tuple[list[int], list[dict[str, Any]]]:
         """Consume the population events belonging to the current segment.
 
-        Advances ``population_index`` exactly as the per-event loop does, and stops at the same
-        boundary, so the two paths consume the catalogue identically. That matters for resume: a run
-        switched between modes mid-way must not skip or repeat events.
+        Advances ``population_index`` and stops on ``coa_time >= end_time``, which is the per-event
+        loop's boundary. That matters for resume: ``population_index`` is checkpointed state, so a
+        run switched between modes must not skip or repeat events.
+
+        One difference, stated rather than glossed: the per-event loop also breaks when a *generated*
+        strain starts at or after ``end_time``, a condition that cannot be evaluated before
+        generating. Reaching it requires a waveform whose buffer begins beyond the segment despite a
+        ``coa_time`` inside it, which the bundled waveforms do not produce. So the two agree on every
+        case exercised here, and this helper is the weaker of the two rules where they could differ.
 
         Returns:
             The population indices and their parameter mappings, in catalogue order.
@@ -537,6 +543,49 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             self.population_index = cast(int, self.population_index) + 1
         return event_ids, events
 
+    def _batched_waveform_backend(self) -> Any:
+        """Return the ripple backend the batched path should generate with.
+
+        The batched entry point is ripple-only, and it takes a backend *instance*. Without passing
+        one, ``waveform-backend-arguments`` -- ripple's ``taper_fraction``, ``f_ref``,
+        ``ringdown_fraction`` -- are silently discarded and the run uses ripple's defaults while the
+        configuration says otherwise. That is the same silent-drop this codebase already fixed once
+        for the per-event path.
+
+        A configuration asking for a library the batched path cannot provide is refused rather than
+        quietly served with ripple, because the output of the wrong library looks entirely normal.
+
+        Returns:
+            A configured ``RippleBackend``, or ``None`` to let gwmock-signal build its default.
+
+        Raises:
+            ValueError: If the configuration selects a non-ripple library, or sets
+                ``waveform-options``, which the batched entry point has no way to apply.
+        """
+        signal_config = self.orchestration_config.signal
+        if signal_config is None:
+            return None
+
+        requested = getattr(signal_config, "waveform_backend", None)
+        if requested is not None and resolve_backend_class("waveform", requested).__name__ != "RippleBackend":
+            raise ValueError(
+                f"execution: batched always generates with ripple, but waveform-backend is "
+                f"{requested!r}. Substituting ripple would produce a different waveform than the "
+                f"configuration asks for. Use execution: per-event, or waveform-backend: ripple."
+            )
+
+        if self.waveform_options:
+            raise ValueError(
+                f"execution: batched cannot apply waveform-options {sorted(self.waveform_options)}; "
+                f"the batched entry point has no equivalent parameter. Use execution: per-event, or "
+                f"remove them."
+            )
+
+        arguments = _normalize_keys(dict(getattr(signal_config, "waveform_backend_arguments", {}) or {}))
+        if not arguments:
+            return None
+        return instantiate_backend("waveform", "ripple", init_kwargs=arguments)
+
     def _simulate_batched_segment(self) -> TimeSeriesList:
         """Generate this segment's events together, through gwmock-signal's batched path.
 
@@ -553,7 +602,6 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         from gwmock.signal.device_chunks import (  # noqa: PLC0415
             batched_strain_to_chunks,
             canonicalise_parameters,
-            per_event_injections,
         )
 
         event_ids, events = self._events_for_this_segment()
@@ -561,6 +609,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         if not events:
             return TimeSeriesList()
 
+        waveform_backend = self._batched_waveform_backend()
         parameters = canonicalise_parameters(
             {**self.waveform_arguments, **SignalAdapter.events_to_struct_of_arrays(events)}
         )
@@ -576,12 +625,19 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             sampling_frequency=sampling_frequency,
             minimum_frequency=self.minimum_frequency,
             parameters=parameters,
+            backend=waveform_backend,
             earth_rotation=self.earth_rotation,
             output_grid=grid,
         )
 
         chunks = batched_strain_to_chunks(batch, expected_detector_names=tuple(self.detectors))
-        self._batch_injections = per_event_injections(parameters, event_ids)
+        # Provenance records what the *catalogue* said, not the canonicalised and merged mapping
+        # handed to the device, so the two execution modes describe an injection the same way. The
+        # per-event path records `dict(parameters)` straight from the population.
+        self._batch_injections = [
+            {"event_id": int(event_id), "parameters": dict(event)}
+            for event_id, event in zip(event_ids, events, strict=True)
+        ]
         for chunk, record in zip(chunks, self._batch_injections, strict=True):
             chunk.metadata.update({"injection_parameters": dict(record["parameters"])})
         return chunks

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -591,7 +591,27 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                 f"remove them."
             )
 
+        from gwmock.signal.device_chunks import BATCHED_BACKEND_ARGUMENTS  # noqa: PLC0415
+
         arguments = _normalize_keys(dict(getattr(signal_config, "waveform_backend_arguments", {}) or {}))
+
+        # `f_ref` is written under `waveform-arguments` because that is where the per-event path
+        # takes it, but gwmock-signal treats it as a backend option -- its own reserved-argument
+        # table says "f_ref is configured on the backend, not through waveform_arguments". Left in
+        # the parameter mapping it would reach `simulate_cbc_batch` and do nothing, so the same
+        # config key would set the reference frequency in one execution mode and be inert in the
+        # other. Routed here instead, so the two modes agree.
+        for name in sorted(BATCHED_BACKEND_ARGUMENTS & set(self.waveform_arguments)):
+            from_arguments = self.waveform_arguments[name]
+            if name in arguments and arguments[name] != from_arguments:
+                raise ValueError(
+                    f"{name} is set to {from_arguments!r} in waveform-arguments and "
+                    f"{arguments[name]!r} in waveform-backend-arguments. One value has to win and "
+                    f"picking silently would make the waveform depend on which of two keys a reader "
+                    f"happened to look at. Set it in one place."
+                )
+            arguments[name] = from_arguments
+
         if not arguments:
             return None
         return instantiate_backend("waveform", "ripple", init_kwargs=arguments)
@@ -610,6 +630,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         from gwmock_signal import SamplingGrid, simulate_cbc_batch  # noqa: PLC0415
 
         from gwmock.signal.device_chunks import (  # noqa: PLC0415
+            BATCHED_BACKEND_ARGUMENTS,
             batched_strain_to_chunks,
             canonicalise_parameters,
             require_batched_parameters_supported,
@@ -624,9 +645,12 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         self._batch_injections = []
         if not events:
             return TimeSeriesList()
-        parameters = canonicalise_parameters(
-            {**self.waveform_arguments, **SignalAdapter.events_to_struct_of_arrays(events)}
-        )
+        # Backend options are excluded: they went to the constructor in `_batched_waveform_backend`,
+        # and leaving them here too would hand `simulate_cbc_batch` a key it does not read.
+        fixed_arguments = {
+            key: value for key, value in self.waveform_arguments.items() if key not in BATCHED_BACKEND_ARGUMENTS
+        }
+        parameters = canonicalise_parameters({**fixed_arguments, **SignalAdapter.events_to_struct_of_arrays(events)})
         sampling_frequency = float(self.sampling_frequency.value)
 
         # The grid is this segment's own lattice, so every buffer starts on a sample of it and

--- a/src/gwmock/cli/utils/config.py
+++ b/src/gwmock/cli/utils/config.py
@@ -212,6 +212,17 @@ class SignalConfig(BaseModel):
         alias="earth-rotation",
         description="Whether to project using time-dependent detector response",
     )
+    execution: str = Field(
+        default="per-event",
+        alias="execution",
+        description=(
+            "How the segment's events are generated: 'per-event' (default) calls the backend once "
+            "per event, 'batched' generates them together through gwmock-signal's batched path, "
+            "which is what makes GPU execution possible. Distinct from 'waveform-backend', which "
+            "chooses the library: 'batched' always generates with ripple, and whether that runs on "
+            "a GPU depends on the JAX device available, not on this setting."
+        ),
+    )
     output: SimulatorOutputConfig = Field(
         default_factory=lambda: SimulatorOutputConfig(
             file_name="signal-{{ detectors }}-{{ start_time }}-{{ duration }}.gwf",
@@ -229,6 +240,19 @@ class SignalConfig(BaseModel):
         """Require at least one detector."""
         if not v:
             raise ValueError("'detectors' must contain at least one detector")
+        return v
+
+    @field_validator("execution")
+    @classmethod
+    def validate_execution(cls, v: str) -> str:
+        """Reject an unknown execution mode rather than silently falling back to per-event.
+
+        A typo here would otherwise leave the run on the default path while the author believed
+        they had switched it, and the output would look entirely normal.
+        """
+        allowed = {"per-event", "batched"}
+        if v not in allowed:
+            raise ValueError(f"'execution' must be one of {sorted(allowed)}, got {v!r}")
         return v
 
 

--- a/src/gwmock/data/time_series/time_series.py
+++ b/src/gwmock/data/time_series/time_series.py
@@ -330,6 +330,17 @@ class TimeSeries(JSONSerializable):
                 start_time=supplied.start_time,
                 sampling_frequency=supplied.sampling_frequency,
             )
+            # Carry the wrapper metadata and each channel's identity across. A tail is the same
+            # signal continuing into the next segment, so dropping these would strip
+            # `injection_parameters` -- and the channel name and unit -- from any injection long
+            # enough to cross a boundary, which is precisely the long-inspiral case.
+            tail.metadata.update(dict(supplied.metadata))
+            for index in range(min(tail.num_of_channels, supplied.num_of_channels)):
+                source, target = supplied[index], tail[index]
+                target.name = source.name
+                target.channel = source.channel
+                # `unit` is read-only on a gwpy array; override_unit is the supported way to set it.
+                target.override_unit(source.unit)
             return tail.crop(start_time=self.end_time)
         return None
 

--- a/src/gwmock/data/time_series/time_series.py
+++ b/src/gwmock/data/time_series/time_series.py
@@ -320,8 +320,17 @@ class TimeSeries(JSONSerializable):
 
         # The tail comes from the supplied chunk, unresampled, so the next segment interpolates it
         # against its own grid rather than inheriting this segment's resampling.
+        #
+        # Cropped from a copy: `crop` rewrites `_data` in place and returns `self`, so cropping the
+        # supplied chunk directly would truncate the caller's own object and hand it back as the
+        # remainder. `inject_from_list` walks a caller-provided list, so that mutates its elements.
         if supplied.end_time > self.end_time:
-            return supplied.crop(start_time=self.end_time)
+            tail = TimeSeries(
+                data=np.asarray(supplied).copy(),
+                start_time=supplied.start_time,
+                sampling_frequency=supplied.sampling_frequency,
+            )
+            return tail.crop(start_time=self.end_time)
         return None
 
     def inject_from_list(self, ts_iterable: Iterable[TimeSeries]) -> TimeSeriesList:

--- a/src/gwmock/signal/adapter.py
+++ b/src/gwmock/signal/adapter.py
@@ -511,6 +511,14 @@ class SignalAdapter:
             chunk_size=chunk_size,
         )
 
+    def device_approximant(self) -> str:
+        """Return the approximant the batched path will generate, or explain why there is not one.
+
+        Public because the orchestrator needs it to drive the batched path from another module;
+        the logic lives in :meth:`_device_approximant`.
+        """
+        return self._device_approximant()
+
     def _device_approximant(self) -> str:
         """Return the approximant to generate on device, or explain why there is not one.
 

--- a/src/gwmock/signal/device_chunks.py
+++ b/src/gwmock/signal/device_chunks.py
@@ -39,6 +39,54 @@ from gwmock.data.time_series.time_series_list import TimeSeriesList
 #: Dimensions of a batched strain array: event, detector, sample.
 _BATCHED_STRAIN_DIMENSIONS = 3
 
+#: Alias to canonical parameter name, mirroring what the per-event backends accept.
+#:
+#: The per-event path resolves these inside gwmock-signal (``_pop_alias`` in each backend); the
+#: batched entry point reads canonical names straight from the struct-of-arrays and does not. So a
+#: population using ``distance`` -- as the bundled BBH catalogue does -- works per-event and fails
+#: batched, which would make switching execution mode change whether a config runs at all. Taken
+#: from gwmock-signal's LAL backend rather than invented, so the two agree on what an alias is.
+_PARAMETER_ALIASES: dict[str, str] = {
+    "mass1": "detector_frame_mass_1",
+    "mass2": "detector_frame_mass_2",
+    "distance": "luminosity_distance",
+    "tidal_1": "lambda_1",
+    "tidal_2": "lambda_2",
+    "spin1x": "spin_1x",
+    "spin1y": "spin_1y",
+    "spin1z": "spin_1z",
+    "spin2x": "spin_2x",
+    "spin2y": "spin_2y",
+    "spin2z": "spin_2z",
+}
+
+
+def canonicalise_parameters(parameters: dict[str, Any]) -> dict[str, Any]:
+    """Return *parameters* with known aliases renamed to their canonical names.
+
+    Args:
+        parameters: Struct-of-arrays as the population loader produced it.
+
+    Returns:
+        A new mapping; *parameters* is not modified.
+
+    Raises:
+        ValueError: If both an alias and its canonical name are present with different values.
+            Guessing which the caller meant would silently pick one physics over another.
+    """
+    renamed = dict(parameters)
+    for alias, canonical in _PARAMETER_ALIASES.items():
+        if alias not in renamed:
+            continue
+        if canonical in renamed and not np.array_equal(np.asarray(renamed[canonical]), np.asarray(renamed[alias])):
+            raise ValueError(
+                f"Parameters contain both '{canonical}' and its alias '{alias}' with different "
+                f"values. Remove one; picking either would silently choose which physics to use."
+            )
+        renamed[canonical] = renamed.pop(alias)
+    return renamed
+
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from gwmock_signal import BatchedDetectorStrain
 

--- a/src/gwmock/signal/device_chunks.py
+++ b/src/gwmock/signal/device_chunks.py
@@ -210,38 +210,3 @@ def batched_strain_to_chunks(
             for event in range(strain.shape[0])
         ]
     )
-
-
-def per_event_injections(parameters: dict[str, Any], event_ids: list[int]) -> list[dict[str, Any]]:
-    """Return provenance records for a batch, one per event.
-
-    The per-event path records ``{"event_id", "parameters"}`` for each injection, and the batched
-    path has to produce the same thing or provenance silently thins out as soon as the device path is
-    used. Chunks stay per-event precisely so this remains possible.
-
-    Args:
-        parameters: The struct-of-arrays handed to the device, one entry per parameter.
-        event_ids: Population indices of the events in the batch, in the same order.
-
-    Returns:
-        One record per event, with that event's scalar parameters.
-
-    Raises:
-        ValueError: If a parameter column is shorter than the number of events.
-    """
-    records: list[dict[str, Any]] = []
-    for position, event_id in enumerate(event_ids):
-        scalars: dict[str, Any] = {}
-        for name, column in parameters.items():
-            if np.ndim(column) == 0:
-                scalars[name] = column
-                continue
-            values = np.atleast_1d(np.asarray(column))
-            if position >= values.size:
-                raise ValueError(
-                    f"Parameter '{name}' has {values.size} values but the batch has "
-                    f"{len(event_ids)} events, so event {event_id} has no value for it."
-                )
-            scalars[name] = values[position].item() if hasattr(values[position], "item") else values[position]
-        records.append({"event_id": int(event_id), "parameters": scalars})
-    return records

--- a/src/gwmock/signal/device_chunks.py
+++ b/src/gwmock/signal/device_chunks.py
@@ -45,13 +45,21 @@ _BATCHED_STRAIN_DIMENSIONS = 3
 #: batched entry point reads canonical names straight from the struct-of-arrays and does not. So a
 #: population using ``distance`` -- as the bundled BBH catalogue does -- works per-event and fails
 #: batched, which would make switching execution mode change whether a config runs at all. Taken
-#: from gwmock-signal's LAL backend rather than invented, so the two agree on what an alias is.
+#: from gwmock-signal's backends rather than invented, so the two agree on what an alias is.
+#:
+#: Scope: this covers the aliases LAL and ripple share, plus PyCBC's ``lambda1``/``lambda2``. It is a
+#: fourth copy of a mapping gwmock-signal already holds three times, one per backend, and the right
+#: home for it is a canonicalisation helper there. Until that exists, a config using an alias no
+#: backend shares would still be refused by the batched path with a missing-parameter error naming
+#: the canonical name.
 _PARAMETER_ALIASES: dict[str, str] = {
     "mass1": "detector_frame_mass_1",
     "mass2": "detector_frame_mass_2",
     "distance": "luminosity_distance",
     "tidal_1": "lambda_1",
     "tidal_2": "lambda_2",
+    "lambda1": "lambda_1",
+    "lambda2": "lambda_2",
     "spin1x": "spin_1x",
     "spin1y": "spin_1y",
     "spin1z": "spin_1z",

--- a/src/gwmock/signal/device_chunks.py
+++ b/src/gwmock/signal/device_chunks.py
@@ -79,6 +79,16 @@ _PARAMETER_ALIASES: dict[str, str] = {
 #: Taken from ``gwmock_signal.jax_batch`` and ``waveform.backends.ripple``. It will drift if
 #: gwmock-signal grows a parameter; the cost of that is a spurious rejection, which is visible,
 #: rather than a silent omission, which is not.
+#:
+#: The in-plane spins are here because ripple's batch resolver reads all six components for the
+#: precessing approximants (``IMRPhenomPv2``, ``IMRPhenomXP``, ``IMRPhenomXPHM``). Omitting them
+#: rejected every precessing configuration -- the opposite failure to a silent drop, and the reason
+#: this list is checked against the library rather than written from memory.
+#:
+#: ``f_ref`` is deliberately *absent*. It is a backend option, not a per-event parameter:
+#: gwmock-signal's own ``_RESERVED_WAVEFORM_ARGUMENTS`` says "f_ref is configured on the backend,
+#: not through waveform_arguments". Passing it in this mapping does nothing at all. The
+#: orchestrator forwards it to the ripple backend instead, so the configuration key still works.
 BATCHED_PARAMETERS: frozenset[str] = frozenset(
     {
         "coa_time",
@@ -90,13 +100,23 @@ BATCHED_PARAMETERS: frozenset[str] = frozenset(
         "luminosity_distance",
         "coa_phase",
         "inclination",
+        "spin_1x",
+        "spin_1y",
         "spin_1z",
+        "spin_2x",
+        "spin_2y",
         "spin_2z",
         "lambda_1",
         "lambda_2",
-        "f_ref",
     }
 )
+
+#: Waveform arguments that configure the ripple *backend* rather than an individual event.
+#:
+#: They are accepted in ``waveform-arguments`` because that is where the per-event path takes them,
+#: and a key that changes the waveform in one execution mode must not be inert in the other. The
+#: orchestrator routes them to the backend constructor.
+BATCHED_BACKEND_ARGUMENTS: frozenset[str] = frozenset({"f_ref"})
 
 
 def require_batched_parameters_supported(waveform_arguments: dict[str, Any]) -> None:
@@ -109,12 +129,12 @@ def require_batched_parameters_supported(waveform_arguments: dict[str, Any]) -> 
     Raises:
         ValueError: If any key is not one the batched entry point reads.
     """
-    unsupported = sorted(set(waveform_arguments) - BATCHED_PARAMETERS)
+    unsupported = sorted(set(waveform_arguments) - BATCHED_PARAMETERS - BATCHED_BACKEND_ARGUMENTS)
     if unsupported:
         raise ValueError(
             f"execution: batched cannot apply these waveform-arguments: {unsupported}. The batched "
-            f"entry point reads only {sorted(BATCHED_PARAMETERS)}, and would ignore the rest "
-            f"without complaint. Use execution: per-event, or remove them."
+            f"entry point reads only {sorted(BATCHED_PARAMETERS | BATCHED_BACKEND_ARGUMENTS)}, and "
+            f"would ignore the rest without complaint. Use execution: per-event, or remove them."
         )
 
 

--- a/src/gwmock/signal/device_chunks.py
+++ b/src/gwmock/signal/device_chunks.py
@@ -69,6 +69,55 @@ _PARAMETER_ALIASES: dict[str, str] = {
 }
 
 
+#: Canonical parameters the batched path actually consumes.
+#:
+#: Projection reads the first four; ripple's waveform generation reads the rest. Anything else
+#: handed to ``simulate_cbc_batch`` is ignored without complaint, which for a *fixed* argument the
+#: user wrote in their config is a silent drop -- the third of that kind found in this work. Listed
+#: here so it can be rejected instead.
+#:
+#: Taken from ``gwmock_signal.jax_batch`` and ``waveform.backends.ripple``. It will drift if
+#: gwmock-signal grows a parameter; the cost of that is a spurious rejection, which is visible,
+#: rather than a silent omission, which is not.
+BATCHED_PARAMETERS: frozenset[str] = frozenset(
+    {
+        "coa_time",
+        "declination",
+        "polarization_angle",
+        "right_ascension",
+        "detector_frame_mass_1",
+        "detector_frame_mass_2",
+        "luminosity_distance",
+        "coa_phase",
+        "inclination",
+        "spin_1z",
+        "spin_2z",
+        "lambda_1",
+        "lambda_2",
+        "f_ref",
+    }
+)
+
+
+def require_batched_parameters_supported(waveform_arguments: dict[str, Any]) -> None:
+    """Raise if a fixed waveform argument would be ignored by the batched path.
+
+    Args:
+        waveform_arguments: The ``waveform-arguments`` mapping from the configuration, already
+            canonicalised.
+
+    Raises:
+        ValueError: If any key is not one the batched entry point reads.
+    """
+    unsupported = sorted(set(waveform_arguments) - BATCHED_PARAMETERS)
+    if unsupported:
+        raise ValueError(
+            f"execution: batched cannot apply these waveform-arguments: {unsupported}. The batched "
+            f"entry point reads only {sorted(BATCHED_PARAMETERS)}, and would ignore the rest "
+            f"without complaint. Use execution: per-event, or remove them."
+        )
+
+
 def canonicalise_parameters(parameters: dict[str, Any]) -> dict[str, Any]:
     """Return *parameters* with known aliases renamed to their canonical names.
 

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -211,9 +211,17 @@ class TestSegmentEventSelection:
 
         assert event_ids == [0], "only the event before the segment end belongs to this segment"
         assert len(events) == 1
+        assert int(orchestrator.population_index) == 0, (
+            "reading the segment's events must not advance the checkpointed index: generation can "
+            "still fail afterwards, and a caller would then see events consumed that were never "
+            "produced"
+        )
+
+        orchestrator._commit_consumed_events(event_ids)
+
         assert int(orchestrator.population_index) == 1, (
-            "population_index must stop at the boundary; it is checkpointed, so over-consuming here "
-            "loses events on resume"
+            "committing must advance past exactly the events generated, so the next segment resumes "
+            "at the boundary rather than skipping or repeating"
         )
 
     def test_an_empty_segment_consumes_nothing(self, tmp_path):

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -68,11 +68,13 @@ def _config(working_directory: Path, execution: str) -> dict[str, Any]:
     }
 
 
-def _orchestrator(working_directory: Path, execution: str):
+def _orchestrator(working_directory: Path, execution: str, **signal_overrides: Any):
     from gwmock.cli.adapter_orchestration import AdapterOrchestrator
 
     working_directory.mkdir(parents=True, exist_ok=True)
-    config = Config.model_validate(_config(working_directory, execution))
+    raw = _config(working_directory, execution)
+    raw["orchestration"]["signal"].update(signal_overrides)
+    config = Config.model_validate(raw)
     return AdapterOrchestrator.from_config(
         config.orchestration,
         global_simulator_arguments=dict(config.globals.simulator_arguments),
@@ -133,6 +135,45 @@ class TestCanonicalParameters:
         }
 
 
+class TestWaveformConfigurationIsHonoured:
+    """Batched mode must not quietly ignore the waveform settings the config asks for.
+
+    The batched entry point takes a backend *instance*, so omitting it discards
+    ``waveform-backend-arguments`` and silently uses ripple's defaults -- the same silent drop this
+    codebase already fixed once for the per-event path. Output from the wrong settings looks
+    entirely normal, which is what makes it worth testing rather than assuming.
+    """
+
+    def test_backend_arguments_reach_the_device(self, tmp_path):
+        """``taper_fraction`` must change the generated waveform.
+
+        It lowers the effective start frequency, which lengthens the inspiral, so the buffer's
+        length changes -- an unmistakable signal that the argument was applied rather than dropped.
+        """
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        default = _orchestrator(tmp_path / "default", "batched")._simulate()
+        tapered = _orchestrator(
+            tmp_path / "tapered", "batched", **{"waveform-backend-arguments": {"taper_fraction": 0.25}}
+        )._simulate()
+
+        assert np.asarray(default[0]).shape != np.asarray(tapered[0]).shape, (
+            "taper_fraction did not change the waveform, so waveform-backend-arguments are being "
+            "discarded and the run silently uses ripple's defaults"
+        )
+
+    def test_a_non_ripple_library_is_refused(self, tmp_path):
+        """The batched path is ripple-only; substituting it would ignore the configuration."""
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        with pytest.raises(ValueError, match="always generates with ripple"):
+            _orchestrator(tmp_path, "batched", **{"waveform-backend": "lal"})._simulate()
+
+    def test_waveform_options_are_refused(self, tmp_path):
+        """There is no equivalent parameter on the batched entry point, so silence would lose them."""
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        with pytest.raises(ValueError, match="cannot apply waveform-options"):
+            _orchestrator(tmp_path, "batched", **{"waveform-options": {"ModeArray": [[2, 2]]}})._simulate()
+
+
 class TestCatalogueConsumption:
     """Both modes must walk the catalogue the same way, or a resumed run skips or repeats events."""
 
@@ -161,6 +202,23 @@ class TestCatalogueConsumption:
         assert len(batched._batch_injections) == len(chunks)
         assert all("event_id" in record and "parameters" in record for record in batched._batch_injections)
         assert all("injection_parameters" in chunk.metadata for chunk in chunks)
+
+    def test_both_modes_record_the_same_provenance(self, tmp_path):
+        """An injection must be described identically whichever mode produced it.
+
+        The batched path canonicalises names and merges fixed waveform arguments before handing
+        parameters to the device. Recording *that* mapping would make the same event appear with
+        ``luminosity_distance`` in one mode and ``distance`` in the other, so provenance is taken
+        from the catalogue instead.
+        """
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        per_event = _orchestrator(tmp_path / "per", "per-event")
+        batched = _orchestrator(tmp_path / "bat", "batched")
+
+        per_event._simulate()
+        batched._simulate()
+
+        assert batched._batch_injections == per_event._batch_injections
 
 
 @pytest.mark.e2e

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -1,0 +1,223 @@
+"""Selecting batched execution from a configuration file.
+
+``execution: batched`` generates a segment's events together through gwmock-signal's batched entry
+point instead of looping over them. That is what makes GPU execution reachable from a config, though
+whether it *runs* on a GPU depends on the JAX device present, not on this key.
+
+The chunks the batched path produces stay per-event, so gwmock's own assembler still handles
+spill-over into later segments and provenance stays per-injection. The tests below check that the two
+modes consume the catalogue identically and produce the same physics, because a difference in either
+would make the choice of mode change the dataset rather than only how it was computed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import yaml
+
+from gwmock.cli.utils.config import Config, SignalConfig
+from gwmock.signal.device_chunks import canonicalise_parameters
+
+_POPULATION_CSV = Path(__file__).resolve().parents[2] / "examples" / "signal" / "bbh_population.csv"
+_START = 1577491296.0
+_SAMPLING_FREQUENCY = 1024.0
+
+
+def _config(working_directory: Path, execution: str) -> dict[str, Any]:
+    """Return a one-segment BBH config in the given execution mode."""
+    return {
+        "globals": {
+            "simulator-arguments": {
+                "sampling-frequency": _SAMPLING_FREQUENCY,
+                "duration": 16,
+                "total-duration": 16,
+                "start-time": _START,
+                "seed": 20260731,
+            },
+            "working-directory": str(working_directory),
+            "output-directory": "output",
+            "metadata-directory": "metadata",
+        },
+        "orchestration": {
+            "population": {
+                "backend": "FilePopulationLoader",
+                "source-type": "bbh",
+                "n-samples": 1,
+                "arguments": {"path": str(_POPULATION_CSV)},
+            },
+            "signal": {
+                "source-type": "bbh",
+                "waveform-model": "IMRPhenomD",
+                # Both modes use ripple, so the comparison isolates batching rather than also
+                # changing the waveform library.
+                "waveform-backend": "ripple",
+                "execution": execution,
+                "minimum-frequency": 30,
+                "detectors": ["ET-Triangle-Sardinia"],
+                "output": {
+                    "output_directory": "signal",
+                    "file_name": "sig-{{ detectors }}.gwf",
+                    "arguments": {"channel": "{{ detectors }}:STRAIN"},
+                },
+            },
+        },
+    }
+
+
+def _orchestrator(working_directory: Path, execution: str):
+    from gwmock.cli.adapter_orchestration import AdapterOrchestrator
+
+    working_directory.mkdir(parents=True, exist_ok=True)
+    config = Config.model_validate(_config(working_directory, execution))
+    return AdapterOrchestrator.from_config(
+        config.orchestration,
+        global_simulator_arguments=dict(config.globals.simulator_arguments),
+    )
+
+
+class TestConfigKey:
+    """The key itself, before anything runs."""
+
+    def test_the_default_is_per_event(self):
+        """Existing configs must be unaffected."""
+        assert SignalConfig(detectors=["H1"]).execution == "per-event"
+
+    def test_batched_is_accepted(self):
+        assert SignalConfig.model_validate({"detectors": ["H1"], "execution": "batched"}).execution == "batched"
+
+    def test_an_unknown_mode_is_rejected(self):
+        """A typo must not leave the run silently on the default path.
+
+        The output of a per-event run looks entirely normal, so an author who mistyped the mode
+        would have no way to notice they had not switched it.
+        """
+        with pytest.raises(ValueError, match="'execution' must be one of"):
+            SignalConfig.model_validate({"detectors": ["H1"], "execution": "batchd"})
+
+
+class TestCanonicalParameters:
+    """Aliases, so switching mode does not change whether a config runs at all."""
+
+    def test_a_known_alias_is_renamed(self):
+        """The bundled BBH catalogue uses ``distance``; the batched path needs the canonical name.
+
+        The per-event backends resolve this internally, so without the rename the same config runs
+        one way and fails the other -- which is how this was found.
+        """
+        assert canonicalise_parameters({"distance": [400.0]}) == {"luminosity_distance": [400.0]}
+
+    @pytest.mark.parametrize(
+        ("alias", "canonical"),
+        [("mass1", "detector_frame_mass_1"), ("spin1z", "spin_1z"), ("tidal_2", "lambda_2")],
+    )
+    def test_the_alias_table_matches_gwmock_signals(self, alias: str, canonical: str):
+        """Taken from gwmock-signal's LAL backend rather than invented."""
+        assert canonicalise_parameters({alias: [1.0]}) == {canonical: [1.0]}
+
+    def test_an_unknown_key_is_left_alone(self):
+        assert canonicalise_parameters({"coa_time": [1.0]}) == {"coa_time": [1.0]}
+
+    def test_a_conflicting_alias_and_canonical_pair_is_refused(self):
+        """Choosing one silently would pick which physics to simulate."""
+        with pytest.raises(ValueError, match="both 'luminosity_distance' and its alias"):
+            canonicalise_parameters({"distance": [400.0], "luminosity_distance": [500.0]})
+
+    def test_an_agreeing_pair_is_accepted(self):
+        """Redundant but consistent input is not an error."""
+        assert canonicalise_parameters({"distance": [400.0], "luminosity_distance": [400.0]}) == {
+            "luminosity_distance": [400.0]
+        }
+
+
+class TestCatalogueConsumption:
+    """Both modes must walk the catalogue the same way, or a resumed run skips or repeats events."""
+
+    def test_both_modes_consume_the_same_events(self, tmp_path):
+        """``population_index`` is checkpointed state, so the two paths must agree on it.
+
+        A run switched between modes partway through would otherwise lose or duplicate events at the
+        boundary, and nothing downstream would notice.
+        """
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        per_event = _orchestrator(tmp_path / "per", "per-event")
+        batched = _orchestrator(tmp_path / "bat", "batched")
+
+        per_event._simulate()
+        batched._simulate()
+
+        assert int(batched.population_index) == int(per_event.population_index)
+
+    def test_the_batched_path_records_provenance_per_event(self, tmp_path):
+        """Segment-shaped output must not thin provenance down to one record per segment."""
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        batched = _orchestrator(tmp_path, "batched")
+
+        chunks = batched._simulate()
+
+        assert len(batched._batch_injections) == len(chunks)
+        assert all("event_id" in record and "parameters" in record for record in batched._batch_injections)
+        assert all("injection_parameters" in chunk.metadata for chunk in chunks)
+
+
+@pytest.mark.e2e
+class TestBothModesAgree:
+    """The batched path must produce the same physics, not merely run.
+
+    Marked ``e2e`` because it drives the CLI twice and ripple compiles on first use. This is the
+    assertion the whole device path rests on: if batching changed the data, the mode would be a
+    choice about the dataset rather than about how it was computed.
+    """
+
+    @staticmethod
+    def _generate(working_directory: Path, execution: str) -> np.ndarray:
+        from gwmock.cli.simulate import _simulate_impl
+
+        working_directory.mkdir(parents=True, exist_ok=True)
+        config_path = working_directory / "config.yaml"
+        config_path.write_text(yaml.safe_dump(_config(working_directory, execution)), encoding="utf-8")
+        _simulate_impl(str(config_path))
+
+        from gwpy.timeseries import TimeSeries
+
+        written = working_directory / "output" / "signal" / "sig-ET1_SARD.gwf"
+        assert written.is_file(), f"no output from the {execution} run"
+        return np.asarray(TimeSeries.read(written, channel="ET1_SARD:STRAIN").value)
+
+    def test_the_two_modes_agree_to_floating_point(self, tmp_path):
+        """Same events, same library, different execution: the strain must match.
+
+        Not bit-identical, and it should not be expected to be -- a batched ``vmap`` accumulates in a
+        different order than a loop. Measured at 1.03e-12 of the peak on this configuration, which is
+        floating-point reassociation rather than a difference in physics.
+
+        Compared against the **peak**, not element-wise. ``np.allclose`` with ``atol=0`` applies a
+        relative tolerance per sample, which fails wherever the strain is near zero -- an absolute
+        difference of 1e-34 against a sample of 1e-30 is a relative difference of 1e-4, and most of a
+        segment is near-zero. Scaling to the peak asks the question that matters: is the waveform the
+        same, to a fraction of its own amplitude. The default ``atol`` is not usable either, since at
+        ~1e-22 it would call any two strain arrays equal.
+        """
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        per_event = self._generate(tmp_path / "per", "per-event")
+        batched = self._generate(tmp_path / "bat", "batched")
+
+        assert per_event.shape == batched.shape
+        assert np.count_nonzero(per_event) == np.count_nonzero(batched), (
+            "the two modes placed the signal over a different number of samples"
+        )
+        assert int(np.argmax(np.abs(per_event))) == int(np.argmax(np.abs(batched))), (
+            "the peak moved between modes, so the signal is at a different time"
+        )
+        peak = float(np.max(np.abs(per_event)))
+        assert peak > 0.0, "the per-event run produced no signal, so there is nothing to compare"
+        largest_difference = float(np.max(np.abs(per_event - batched)))
+
+        assert largest_difference <= 1e-9 * peak, (
+            f"the batched path produced materially different strain: largest difference "
+            f"{largest_difference:.3e} is {largest_difference / peak:.3e} of the peak. That makes "
+            f"the execution mode a choice about the dataset rather than about how it was computed."
+        )

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -346,3 +346,75 @@ class TestBothModesAgree:
             f"{largest_difference:.3e} is {largest_difference / peak:.3e} of the peak. That makes "
             f"the execution mode a choice about the dataset rather than about how it was computed."
         )
+
+
+class TestReferenceFrequencyReachesTheBackend:
+    """`f_ref` is written under waveform-arguments but is a backend option.
+
+    gwmock-signal's own reserved-argument table says so: "f_ref is configured on the backend, not
+    through waveform_arguments". Left in the parameter mapping it reaches `simulate_cbc_batch` and is
+    read by nobody, so the same config key would set the reference frequency on the per-event path
+    and do nothing on the batched one -- two execution modes silently disagreeing about the waveform.
+    """
+
+    def test_it_is_forwarded_to_the_ripple_backend(self, tmp_path):
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        orchestrator = _orchestrator(tmp_path, "batched", **{"waveform-arguments": {"f_ref": 25.0}})
+
+        backend = orchestrator._batched_waveform_backend()
+
+        assert backend is not None, "f_ref alone must still produce a configured backend"
+        # `_f_ref` because the backend keeps it private; there is no public reader, and the
+        # alternative -- trusting that construction succeeded -- would pass without forwarding.
+        assert backend._f_ref == 25.0
+
+    def test_it_does_not_also_go_into_the_parameter_mapping(self, tmp_path):
+        """Passing it both ways would hand the batch entry point a key it does not read."""
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        captured = {}
+        orchestrator = _orchestrator(tmp_path, "batched", **{"waveform-arguments": {"f_ref": 25.0}})
+
+        import gwmock_signal
+
+        real = gwmock_signal.simulate_cbc_batch
+
+        def spy(*args, **kwargs):
+            captured.update(kwargs.get("parameters", {}))
+            return real(*args, **kwargs)
+
+        gwmock_signal.simulate_cbc_batch = spy
+        try:
+            orchestrator._simulate()
+        finally:
+            gwmock_signal.simulate_cbc_batch = real
+
+        assert captured, "the spy never saw a call, so this test proves nothing"
+        assert "f_ref" not in captured
+
+    def test_disagreeing_with_waveform_backend_arguments_is_refused(self, tmp_path):
+        """Two keys setting one physical quantity: pick silently and the waveform depends on which
+        one a reader happened to look at.
+
+        Deliberately not gated on ripplegw -- the conflict is caught before the backend is built, so
+        gating it would hide the branch from the CI job that installs no extras.
+        """
+        orchestrator = _orchestrator(
+            tmp_path,
+            "batched",
+            waveform_backend=None,
+            **{"waveform-arguments": {"f_ref": 25.0}, "waveform-backend-arguments": {"f_ref": 30.0}},
+        )
+
+        with pytest.raises(ValueError, match="f_ref is set to"):
+            orchestrator._batched_waveform_backend()
+
+    def test_agreeing_with_waveform_backend_arguments_is_accepted(self, tmp_path):
+        """Refusing a redundant but consistent pair would be gratuitous."""
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        orchestrator = _orchestrator(
+            tmp_path,
+            "batched",
+            **{"waveform-arguments": {"f_ref": 25.0}, "waveform-backend-arguments": {"f_ref": 25.0}},
+        )
+
+        assert orchestrator._batched_waveform_backend()._f_ref == 25.0

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -27,8 +27,13 @@ _START = 1577491296.0
 _SAMPLING_FREQUENCY = 1024.0
 
 
-def _config(working_directory: Path, execution: str) -> dict[str, Any]:
-    """Return a one-segment BBH config in the given execution mode."""
+def _config(working_directory: Path, execution: str, waveform_backend: str | None = "ripple") -> dict[str, Any]:
+    """Return a one-segment BBH config in the given execution mode.
+
+    ``waveform_backend`` is omitted entirely when ``None``. That matters for the tests that must run
+    without the ``[jax]`` extra: naming ripple makes *constructing* the orchestrator instantiate
+    ``RippleBackend``, which needs ripplegw long before any generation happens.
+    """
     return {
         "globals": {
             "simulator-arguments": {
@@ -52,9 +57,9 @@ def _config(working_directory: Path, execution: str) -> dict[str, Any]:
             "signal": {
                 "source-type": "bbh",
                 "waveform-model": "IMRPhenomD",
-                # Both modes use ripple, so the comparison isolates batching rather than also
-                # changing the waveform library.
-                "waveform-backend": "ripple",
+                # Naming ripple for both modes makes the comparison isolate batching rather than
+                # also changing the waveform library.
+                **({"waveform-backend": waveform_backend} if waveform_backend is not None else {}),
                 "execution": execution,
                 "minimum-frequency": 30,
                 "detectors": ["ET-Triangle-Sardinia"],
@@ -68,11 +73,16 @@ def _config(working_directory: Path, execution: str) -> dict[str, Any]:
     }
 
 
-def _orchestrator(working_directory: Path, execution: str, **signal_overrides: Any):
+def _orchestrator(
+    working_directory: Path,
+    execution: str,
+    waveform_backend: str | None = "ripple",
+    **signal_overrides: Any,
+):
     from gwmock.cli.adapter_orchestration import AdapterOrchestrator
 
     working_directory.mkdir(parents=True, exist_ok=True)
-    raw = _config(working_directory, execution)
+    raw = _config(working_directory, execution, waveform_backend=waveform_backend)
     raw["orchestration"]["signal"].update(signal_overrides)
     config = Config.model_validate(raw)
     return AdapterOrchestrator.from_config(
@@ -162,16 +172,65 @@ class TestWaveformConfigurationIsHonoured:
         )
 
     def test_a_non_ripple_library_is_refused(self, tmp_path):
-        """The batched path is ripple-only; substituting it would ignore the configuration."""
-        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        """The batched path is ripple-only; substituting it would ignore the configuration.
+
+        Deliberately not gated on ``ripplegw``: the guard runs before anything touches the device,
+        so gating it would hide this branch from the CI job that has no extras -- which is the job
+        measuring coverage.
+        """
         with pytest.raises(ValueError, match="always generates with ripple"):
-            _orchestrator(tmp_path, "batched", **{"waveform-backend": "lal"})._simulate()
+            _orchestrator(tmp_path, "batched", waveform_backend="lal")._simulate()
 
     def test_waveform_options_are_refused(self, tmp_path):
         """There is no equivalent parameter on the batched entry point, so silence would lose them."""
-        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
         with pytest.raises(ValueError, match="cannot apply waveform-options"):
-            _orchestrator(tmp_path, "batched", **{"waveform-options": {"ModeArray": [[2, 2]]}})._simulate()
+            _orchestrator(
+                tmp_path, "batched", waveform_backend=None, **{"waveform-options": {"ModeArray": [[2, 2]]}}
+            )._simulate()
+
+
+class TestSegmentEventSelection:
+    """Which events a segment claims, tested without generating anything.
+
+    ``_events_for_this_segment`` is pure catalogue walking, so it needs no device -- and testing it
+    here rather than behind an ``importorskip`` is what keeps it covered in the CI job that installs
+    no extras.
+    """
+
+    def test_events_beyond_the_segment_are_left_for_the_next_one(self, tmp_path):
+        """The boundary rule is ``coa_time >= end_time``, and it is checkpointed state."""
+        orchestrator = _orchestrator(tmp_path, "batched", waveform_backend=None)
+        end_time = float(getattr(orchestrator.end_time, "value", orchestrator.end_time))
+        orchestrator._population_events = (
+            {"coa_time": end_time - 1.0, "detector_frame_mass_1": 30.0},
+            {"coa_time": end_time, "detector_frame_mass_1": 30.0},
+            {"coa_time": end_time + 5.0, "detector_frame_mass_1": 30.0},
+        )
+
+        event_ids, events = orchestrator._events_for_this_segment()
+
+        assert event_ids == [0], "only the event before the segment end belongs to this segment"
+        assert len(events) == 1
+        assert int(orchestrator.population_index) == 1, (
+            "population_index must stop at the boundary; it is checkpointed, so over-consuming here "
+            "loses events on resume"
+        )
+
+    def test_an_empty_segment_consumes_nothing(self, tmp_path):
+        """A segment with no events must not advance the index or invent provenance."""
+        orchestrator = _orchestrator(tmp_path, "batched", waveform_backend=None)
+        end_time = float(getattr(orchestrator.end_time, "value", orchestrator.end_time))
+        orchestrator._population_events = ({"coa_time": end_time + 100.0},)
+
+        chunks = orchestrator._simulate()
+
+        assert len(chunks) == 0
+        assert int(orchestrator.population_index) == 0
+        assert orchestrator._batch_injections == []
+
+    def test_the_execution_mode_comes_from_the_config(self, tmp_path):
+        assert _orchestrator(tmp_path / "a", "batched", waveform_backend=None)._execution_mode() == "batched"
+        assert _orchestrator(tmp_path / "b", "per-event", waveform_backend=None)._execution_mode() == "per-event"
 
 
 class TestCatalogueConsumption:

--- a/tests/data/time_series/test_time_series.py
+++ b/tests/data/time_series/test_time_series.py
@@ -229,10 +229,18 @@ class TestInjectBoundaryOverflow:
         )
 
     @pytest.mark.parametrize(
-        ("offset_samples", "description"),
-        [(900.0, "aligned"), (900.5, "half a sample misaligned")],
+        ("offset_samples", "description", "expected_tail"),
+        [
+            (900.0, "aligned", 300),
+            # One sample longer than the 300 that lie at or after the boundary. The chunk's sample
+            # at 999.5 is the left neighbour the *next* segment needs in order to interpolate its
+            # own grid point at 1000; dropping it would lose accuracy at every segment boundary.
+            # Verified not to be double-counted: this segment writes grid index 999 from the
+            # interpolation, and the tail supplies grid 1000 onward.
+            (900.5, "half a sample misaligned", 301),
+        ],
     )
-    def test_the_overflow_is_returned(self, offset_samples: float, description: str):
+    def test_the_overflow_is_returned(self, offset_samples: float, description: str, expected_tail: int):
         """Both branches must return the part of the chunk beyond the segment."""
         segment = self._segment()
 
@@ -242,8 +250,7 @@ class TestInjectBoundaryOverflow:
             f"a {description} chunk crossing the segment boundary returned no remainder, so its "
             f"tail was discarded instead of being carried into the next segment"
         )
-        expected = self.CHUNK_SAMPLES - (self.SEGMENT_SAMPLES - int(self.CHUNK_START_SAMPLE))
-        assert len(np.asarray(remaining)[0]) == expected
+        assert len(np.asarray(remaining)[0]) == expected_tail
 
     def test_the_returned_tail_is_not_resampled(self):
         """The tail must keep its own grid so the next segment can place it correctly.
@@ -260,6 +267,26 @@ class TestInjectBoundaryOverflow:
         assert np.all(np.asarray(remaining)[0] == 1.0), (
             "the returned tail has been interpolated; it should be the supplied samples unchanged"
         )
+
+    @pytest.mark.parametrize("offset_samples", [900.0, 900.5])
+    def test_the_caller_s_chunk_is_not_modified(self, offset_samples: float):
+        """Injection must not truncate the chunk it was handed.
+
+        ``crop`` rewrites ``_data`` in place and returns ``self``, so cropping the supplied chunk to
+        produce the remainder would hand the caller its own object back, shortened.
+        ``inject_from_list`` walks a caller-provided list, so that would mutate every element that
+        overflows.
+        """
+        segment = self._segment()
+        chunk = self._chunk(offset_samples)
+        original_length = len(np.asarray(chunk)[0])
+        original_start = float(chunk.start_time.value)
+
+        remaining = segment.inject(chunk)
+
+        assert len(np.asarray(chunk)[0]) == original_length, "the caller's chunk was truncated"
+        assert float(chunk.start_time.value) == original_start, "the caller's chunk was moved"
+        assert remaining is not chunk, "the remainder must not be the caller's own object"
 
     def test_a_chunk_inside_the_segment_returns_nothing(self):
         """The complement, so the test above cannot pass by always returning a remainder."""

--- a/tests/data/time_series/test_time_series.py
+++ b/tests/data/time_series/test_time_series.py
@@ -288,6 +288,28 @@ class TestInjectBoundaryOverflow:
         assert float(chunk.start_time.value) == original_start, "the caller's chunk was moved"
         assert remaining is not chunk, "the remainder must not be the caller's own object"
 
+    def test_the_tail_keeps_the_chunk_s_metadata_and_channel_identity(self):
+        """A tail is the same signal continuing, so it must arrive described the same way.
+
+        The remainder is rebuilt as a new TimeSeries to avoid mutating the caller's chunk. Building
+        it from data, start time and rate alone silently drops ``metadata`` -- which carries
+        ``injection_parameters`` -- along with each channel's name and unit. Any injection long
+        enough to cross a segment boundary would then lose its provenance in the next segment, and a
+        long inspiral is exactly the case that crosses one.
+        """
+        segment = self._segment()
+        chunk = self._chunk(900.0)
+        chunk.metadata.update({"injection_parameters": {"coa_time": 1234.5}})
+        chunk[0].name = "H1:STRAIN"
+
+        remaining = segment.inject(chunk)
+
+        assert remaining is not None
+        assert remaining.metadata.get("injection_parameters") == {"coa_time": 1234.5}, (
+            "the tail lost the injection provenance it was carrying"
+        )
+        assert remaining[0].name == "H1:STRAIN", "the tail lost its channel identity"
+
     def test_a_chunk_inside_the_segment_returns_nothing(self):
         """The complement, so the test above cannot pass by always returning a remainder."""
         segment = self._segment()

--- a/tests/signal/test_device_chunks.py
+++ b/tests/signal/test_device_chunks.py
@@ -14,7 +14,7 @@ from typing import Any
 import numpy as np
 import pytest
 
-from gwmock.signal.device_chunks import batched_strain_to_chunks, per_event_injections
+from gwmock.signal.device_chunks import batched_strain_to_chunks
 
 _SAMPLING_FREQUENCY = 1024.0
 _EPOCH = 1577491296.0
@@ -250,31 +250,6 @@ class TestGuards:
 
         with pytest.raises(ValueError, match="Expected strain of shape"):
             batched_strain_to_chunks(batch)
-
-
-class TestProvenance:
-    """Per-event records, so the device path does not thin out provenance."""
-
-    def test_each_event_gets_its_own_parameters(self):
-        records = per_event_injections(
-            {"detector_frame_mass_1": [30.0, 25.0], "coa_time": [1.0, 2.0], "f_ref": 20.0},
-            [7, 8],
-        )
-
-        assert [record["event_id"] for record in records] == [7, 8]
-        assert records[0]["parameters"]["detector_frame_mass_1"] == pytest.approx(30.0)
-        assert records[1]["parameters"]["coa_time"] == pytest.approx(2.0)
-
-    def test_a_scalar_parameter_is_shared_by_every_event(self):
-        """A fixed value applies to all events rather than being indexed per event."""
-        records = per_event_injections({"f_ref": 20.0}, [0, 1])
-
-        assert all(record["parameters"]["f_ref"] == pytest.approx(20.0) for record in records)
-
-    def test_a_short_column_is_refused(self):
-        """Silently recording the wrong parameters would be worse than failing."""
-        with pytest.raises(ValueError, match="has 1 values but the batch has 2 events"):
-            per_event_injections({"coa_time": [1.0]}, [0, 1])
 
 
 class TestAgainstTheRealDeviceOutput:

--- a/tests/signal/test_device_chunks.py
+++ b/tests/signal/test_device_chunks.py
@@ -8,13 +8,19 @@ hoped for. One test at the end runs the real batched path to check the stub has 
 
 from __future__ import annotations
 
+import inspect
+import re
 from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
 import pytest
 
-from gwmock.signal.device_chunks import batched_strain_to_chunks
+from gwmock.signal.device_chunks import (
+    BATCHED_PARAMETERS,
+    batched_strain_to_chunks,
+    require_batched_parameters_supported,
+)
 
 _SAMPLING_FREQUENCY = 1024.0
 _EPOCH = 1577491296.0
@@ -388,3 +394,63 @@ class TestSpillOverAcrossSegments:
         assert values[20] == pytest.approx(1.0), "only the second chunk covers sample 20"
         assert values[23] == pytest.approx(1.0), "the second chunk ends at sample 23"
         assert values[24] == pytest.approx(0.0), "nothing reaches sample 24"
+
+
+class TestTheParameterAllowList:
+    """What the batched path claims to read, checked against what gwmock-signal actually reads.
+
+    The list is written by hand from the library's contract, so the failure mode is drift. Two
+    directions, and they fail differently: a parameter present but unread is a silent drop, and a
+    parameter read but absent is a rejected configuration that should have worked. Both happened --
+    ``f_ref`` was the first and the in-plane spins were the second -- because nothing checked.
+
+    These tests read the library rather than a second hand-written copy of the same list, so a
+    gwmock-signal bump that renames or adds a parameter fails here instead of in a user's run.
+    """
+
+    def test_the_precessing_spin_components_are_accepted(self):
+        """Ripple's batch resolver reads all six for IMRPhenomPv2, XP and XPHM.
+
+        Omitting the in-plane four rejected every precessing configuration, which is also what the
+        bundled ET presets use.
+        """
+        spins = {f"spin_{body}{axis}": 0.1 for body in (1, 2) for axis in ("x", "y", "z")}
+
+        require_batched_parameters_supported(spins)
+
+    def test_every_in_plane_spin_ripple_reads_is_in_the_list(self):
+        """Anchored on the library's own source rather than on this test's opinion."""
+        ripple = pytest.importorskip("gwmock_signal.waveform.backends.ripple")
+        source = inspect.getsource(ripple)
+
+        read_by_ripple = set(re.findall(r'"(spin_[12][xyz])"', source))
+
+        assert read_by_ripple, "the spin names could not be found; this test has stopped checking anything"
+        assert read_by_ripple <= BATCHED_PARAMETERS, (
+            f"ripple reads {sorted(read_by_ripple - BATCHED_PARAMETERS)} but the batched path "
+            f"rejects them, so precessing configurations fail"
+        )
+
+    def test_f_ref_is_not_a_per_event_parameter(self):
+        """It configures the backend. In the parameter mapping it would be read by nobody."""
+        assert "f_ref" not in BATCHED_PARAMETERS
+
+    def test_gwmock_signal_still_agrees_that_f_ref_belongs_to_the_backend(self):
+        """The anchor for routing it to the constructor. If this changes, the routing is wrong.
+
+        Asserted against gwmock-signal's own reserved-argument table rather than against a comment
+        here, so a library that starts accepting ``f_ref`` per event fails this instead of silently
+        making the forwarding redundant.
+        """
+        ripple = pytest.importorskip("gwmock_signal.waveform.backends.ripple")
+
+        assert "f_ref" in ripple._RESERVED_WAVEFORM_ARGUMENTS
+
+    def test_f_ref_is_still_accepted_from_the_configuration(self):
+        """Rejecting it would be the opposite error: the per-event path takes it in this key."""
+        require_batched_parameters_supported({"f_ref": 20.0})
+
+    def test_an_unreadable_argument_is_still_refused(self):
+        """Guards the widening: the list must not have become permissive."""
+        with pytest.raises(ValueError, match="cannot apply these waveform-arguments"):
+            require_batched_parameters_supported({"not_a_waveform_parameter": 1.0})


### PR DESCRIPTION
> **Stacked PR.** This targets `main`, so the diff includes the commits of #291 and #292, which are
> open and already reviewed. **The new work is the last two commits only** —
> `feat(cli): run a segment's events through the batched device path` and
> `fix(cli): honour waveform configuration in batched mode`. Merge #291 and #292 first.

## 📝 Summary

`simulate_segments` has existed since #286 with **zero callers**. This gives it one, and closes
`gwmock/device-call-site` — the blocker for GPU end-to-end since this work started.

A new signal key, `execution: per-event` (default) or `batched`, selects how a segment's events are
generated. `batched` calls `simulate_cbc_batch` once for the segment, converts the result to
per-event chunks (#292), and hands them to gwmock's existing assembler.

Default is unchanged, and an unknown value is **rejected** rather than falling back — a typo would
otherwise leave the run on the default path producing output that looks entirely normal.

### The batched path changes how events are _generated_, not how they are _assembled_

The branch sits inside `_simulate`, already called once per segment, and returns the same per-event
chunks the loop does. So spill-over into later segments and per-injection provenance keep working
unchanged. Buffers are generated against a `SamplingGrid` built from the segment's own start time, so
each begins on a sample of the segment lattice and injection is an integer-offset add.

### The two modes agree to 1.03e-12 of the peak

Same config, same library — so this isolates _batching_ rather than conflating a library change. Not
bit-identical, nor should it be: a batched `vmap` reassociates differently from a loop. A deliberate
1e-6 perturbation is caught, giving six orders of margin between real agreement and detectable
change.

## ✨ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

Default behaviour unchanged.

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** 880 passed, 23 skipped; e2e 35 passed, 9 skipped. 16 new tests.
- [x] **Manual Test:** both modes end at the same `population_index`, and record **identical**
      injection provenance.
- [x] **Manual Test:** the agreement test is discriminating — a 1e-6 perturbation fails it.
- [x] **Manual Test:** `taper_fraction: 0.25` changes the buffer 3200 → 3600 samples, proving backend
      arguments reach the device.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

## 📷 Screenshots (if applicable)

Not applicable.

## Three things found by doing it

**The bundled catalogue broke batched mode.** It uses `distance`; the batched entry point wants
`luminosity_distance`. The per-event backends resolve that internally, so `execution: batched`
**failed on a config that worked** — switching mode would have changed whether a run happens at all.
Aliases now come from gwmock-signal's own tables, and a conflicting alias/canonical pair is refused
rather than silently resolved.

**Batched mode ignored the waveform configuration** — found by review, and the same silent-drop defect
as #288. The batched entry point takes a backend _instance_, which I never passed, so
`waveform-backend-arguments` were discarded and the run used ripple's defaults. Now passed through; a
non-ripple `waveform-backend` and `waveform-options` are refused rather than quietly served with
ripple.

**My first agreement assertion was wrong.** `np.allclose(..., atol=0)` applies a _per-sample_ relative
tolerance and fails wherever strain is near zero — 1e-34 against 1e-30 is a 1e-4 relative difference,
and most of a segment is near-zero. Comparing against the peak asks the question that matters. My own
rule about `atol=0` is right for equality checks and wrong for agreement ones.

## Claims I withdrew rather than defended

`_events_for_this_segment` originally claimed the two paths consume the catalogue identically. They do
not quite — the per-event loop has a second stop on the _generated_ strain's start time, which cannot
be evaluated before generating. Neither I nor the reviewer could construct a case where they differ
with the bundled waveforms, so the docstring now states which rule is shared, which is not, and what
reaching the difference would require.

## Known limits

**This has never run on a GPU.** Everything here is CPU JAX. "The path is correct" and "the GPU path
is exercised" are different claims, and only the first is supported.

**The alias table is a fourth copy** of a mapping gwmock-signal holds three times, one per backend.
The right home is a canonicalisation helper there; worth raising upstream rather than accumulating
copies.

**Duplicated boundary rule.** The event-consumption condition now exists in two places. The reviewer
recommended centralising it, which I would do as a follow-up rather than widen this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable per-event and batched signal execution modes.
  * Added support for converting batched detector output into event-level strain chunks.
  * Added validation for execution settings, waveform backends, detector layouts, and output grids.
  * Preserved event provenance and checkpoint progress during batched processing.

* **Bug Fixes**
  * Prevented signal injection overflow handling from mutating or truncating caller-provided data.

* **Tests**
  * Added extensive coverage for both execution modes, validation, chunk conversion, provenance, and numerical equivalence.
  * Improved reference comparisons to tolerate expected floating-point differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->