### PR TITLE
feat(signal): refuse settings the execution path would ignore

### DIFF
--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -99,6 +99,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         self._population_events = tuple(population_events)
         self._population_metadata = dict(population_metadata)
         self._source_type = source_type
+        self._configuration_checked = False
         self._source_detector_specs = tuple(source_detector_specs)
         self._signal_network = detector_network
         self._detector_resolution = detector_resolution
@@ -476,6 +477,8 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
 
     def _simulate(self) -> TimeSeriesList:
         """Generate signal chunks for the current segment from population events."""
+        self._require_configuration_supported()
+
         if not self._population_events and self._source_type == "sgwb":
             return self._simulate_stationary_signal_segment()
 
@@ -511,6 +514,24 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         """Return how this segment's events should be generated."""
         signal_config = self.orchestration_config.signal
         return "per-event" if signal_config is None else str(getattr(signal_config, "execution", "per-event"))
+
+    def _require_configuration_supported(self) -> None:
+        """Check the signal settings against what the chosen execution path actually reads.
+
+        Runs before any events are consumed: ``population_index`` is checkpointed state, so failing
+        after advancing it would make a resumed run skip the events this call rejected. Runs once
+        per orchestrator rather than once per segment, so a warning is not repeated for every
+        segment of a long run.
+        """
+        if self._configuration_checked or self.orchestration_config.signal is None:
+            return
+        self._configuration_checked = True
+
+        from gwmock.signal.execution_support import require_execution_supports_configuration  # noqa: PLC0415
+
+        require_execution_supports_configuration(
+            self.orchestration_config.signal, self._execution_mode(), self._source_type
+        )
 
     def _events_for_this_segment(self) -> tuple[list[int], list[dict[str, Any]]]:
         """Consume the population events belonging to the current segment.
@@ -629,14 +650,10 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             canonicalise_parameters,
             require_batched_parameters_supported,
         )
-        from gwmock.signal.execution_support import require_execution_supports_configuration  # noqa: PLC0415
 
-        # Validated before any events are consumed. `population_index` is checkpointed state, so
-        # failing after advancing it would make a resumed run skip the events this call rejected.
-        # One check covering every setting the path does not honour, rather than a growing list of
-        # individual rejections. The per-key waveform-arguments check stays: that field *is*
-        # honoured, but only for the canonical parameters the batched entry point reads.
-        require_execution_supports_configuration(self.orchestration_config.signal, "batched")
+        # The per-key waveform-arguments check is separate from the whole-config one run by
+        # `_require_configuration_supported`: that field *is* honoured, but only for the canonical
+        # parameters the batched entry point reads.
         waveform_backend = self._batched_waveform_backend()
         require_batched_parameters_supported(canonicalise_parameters(dict(self.waveform_arguments)))
 

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -525,20 +525,24 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         """
         if self._configuration_checked or self.orchestration_config.signal is None:
             return
-        self._configuration_checked = True
 
         from gwmock.signal.execution_support import require_execution_supports_configuration  # noqa: PLC0415
 
         require_execution_supports_configuration(
             self.orchestration_config.signal, self._execution_mode(), self._source_type
         )
+        # Only after it passes. `retry_with_backoff` re-runs a failed batch on this same instance
+        # and restores `state`, which this flag is not part of -- so setting it first would let the
+        # retry sail past a configuration the first attempt refused.
+        self._configuration_checked = True
 
     def _events_for_this_segment(self) -> tuple[list[int], list[dict[str, Any]]]:
-        """Consume the population events belonging to the current segment.
+        """Return the population events belonging to the current segment, without consuming them.
 
-        Advances ``population_index`` and stops on ``coa_time >= end_time``, which is the per-event
-        loop's boundary. That matters for resume: ``population_index`` is checkpointed state, so a
-        run switched between modes must not skip or repeat events.
+        Stops on ``coa_time >= end_time``, which is the per-event loop's boundary. That matters for
+        resume: ``population_index`` is checkpointed state, so a run switched between modes must not
+        skip or repeat events. The index advances only in :meth:`_commit_consumed_events`, once
+        generation has succeeded.
 
         One difference, stated rather than glossed: the per-event loop also breaks when a *generated*
         strain starts at or after ``end_time``, a condition that cannot be evaluated before

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -569,8 +569,9 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             A configured ``RippleBackend``, or ``None`` to let gwmock-signal build its default.
 
         Raises:
-            ValueError: If the configuration selects a non-ripple library, or sets
-                ``waveform-options``, which the batched entry point has no way to apply.
+            ValueError: If the configuration selects a library other than ripple. Settings the path
+                cannot apply at all are refused earlier, by
+                :func:`~gwmock.signal.execution_support.require_execution_supports_configuration`.
         """
         signal_config = self.orchestration_config.signal
         if signal_config is None:
@@ -582,13 +583,6 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                 f"execution: batched always generates with ripple, but waveform-backend is "
                 f"{requested!r}. Substituting ripple would produce a different waveform than the "
                 f"configuration asks for. Use execution: per-event, or waveform-backend: ripple."
-            )
-
-        if self.waveform_options:
-            raise ValueError(
-                f"execution: batched cannot apply waveform-options {sorted(self.waveform_options)}; "
-                f"the batched entry point has no equivalent parameter. Use execution: per-event, or "
-                f"remove them."
             )
 
         from gwmock.signal.device_chunks import BATCHED_BACKEND_ARGUMENTS  # noqa: PLC0415
@@ -635,9 +629,14 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             canonicalise_parameters,
             require_batched_parameters_supported,
         )
+        from gwmock.signal.execution_support import require_execution_supports_configuration  # noqa: PLC0415
 
         # Validated before any events are consumed. `population_index` is checkpointed state, so
         # failing after advancing it would make a resumed run skip the events this call rejected.
+        # One check covering every setting the path does not honour, rather than a growing list of
+        # individual rejections. The per-key waveform-arguments check stays: that field *is*
+        # honoured, but only for the canonical parameters the batched entry point reads.
+        require_execution_supports_configuration(self.orchestration_config.signal, "batched")
         waveform_backend = self._batched_waveform_backend()
         require_batched_parameters_supported(canonicalise_parameters(dict(self.waveform_arguments)))
 

--- a/src/gwmock/signal/execution_support.py
+++ b/src/gwmock/signal/execution_support.py
@@ -1,0 +1,118 @@
+"""Which signal settings each execution path actually honours, and refusing the rest.
+
+Three bugs in the batched path shared one shape: a setting was read from the configuration, stored
+on the orchestrator, and then never forwarded to the generator. ``waveform-backend-arguments`` were
+discarded, ``waveform-options`` had nowhere to go, and ``waveform-arguments`` outside a fixed set
+were dropped. Each was found separately, by review, after the run had produced plausible output.
+
+They were all instances of the same default: **a setting nobody wired is ignored**. Fixing them one
+at a time leaves the next one waiting. This inverts the default for the batched path -- a setting the
+path does not declare is *refused* -- so a configuration key added later fails loudly there until
+someone wires it, rather than passing silently.
+
+The per-event path is treated differently on purpose. It is the default, it has users, and at least
+one of its settings (``parameters``, which only the stochastic path reads) has been quietly ignored
+for CBC runs since before this. Turning that into an error would break working configurations for a
+problem they did not introduce, so it warns instead and the batched path is where the strict rule
+applies.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger("gwmock")
+
+#: Signal-config fields the batched execution path reads.
+#:
+#: Anything the user sets that is not here is refused, because the batched path would ignore it.
+#: ``waveform_arguments`` is listed but only partially honoured -- the batched entry point reads a
+#: fixed set of canonical parameters -- so it carries its own per-key check in
+#: :func:`gwmock.signal.device_chunks.require_batched_parameters_supported`.
+_BATCHED_HONOURED_FIELDS: frozenset[str] = frozenset(
+    {
+        "backend",
+        "source_type",
+        "waveform_model",
+        "waveform_backend",
+        "waveform_backend_arguments",
+        "waveform_arguments",
+        "detectors",
+        "minimum_frequency",
+        "earth_rotation",
+        "execution",
+        "output",
+    }
+)
+
+#: Why each unhonoured field cannot be applied, so the error says what to do rather than only what
+#: went wrong.
+_BATCHED_REASONS: dict[str, str] = {
+    "arguments": (
+        "these configure the simulator's constructor, and the batched path calls gwmock-signal's "
+        "batched entry point directly rather than going through the simulator"
+    ),
+    "parameters": (
+        "these are fixed parameters for the simulator's simulate() call, which the batched path "
+        "does not use; note they are also ignored by the per-event path for CBC sources"
+    ),
+    "waveform_options": (
+        "the batched entry point has no equivalent parameter, so LAL dictionary options such as "
+        "ModeArray cannot be applied"
+    ),
+}
+
+
+def _alias_of(signal_config: Any, field: str) -> str:
+    """Return the name the user writes in YAML for *field*, falling back to the field name."""
+    info = type(signal_config).model_fields.get(field)
+    return getattr(info, "alias", None) or field
+
+
+def require_execution_supports_configuration(signal_config: Any, execution: str) -> None:
+    """Refuse a configuration whose settings the chosen execution path would ignore.
+
+    Args:
+        signal_config: The validated ``orchestration.signal`` block.
+        execution: The execution mode, ``"per-event"`` or ``"batched"``.
+
+    Raises:
+        ValueError: If *execution* is ``"batched"`` and the user set a field it does not honour, or
+            an unrecognised key.
+    """
+    # Only what the user actually wrote. Defaults are not "configured", and treating them as such
+    # would refuse every configuration.
+    configured = set(getattr(signal_config, "model_fields_set", set()))
+    extra = set(getattr(signal_config, "model_extra", None) or {})
+
+    if execution != "batched":
+        # Unknown keys are ignored whatever the path does with them, so they are worth saying out
+        # loud even here -- a misspelled setting is silently absent otherwise.
+        for name in sorted(extra):
+            logger.warning(
+                "orchestration.signal.%s is not a recognised setting and will be ignored. Check the "
+                "spelling against the configuration reference.",
+                name,
+            )
+        if "parameters" in configured:
+            logger.warning(
+                "orchestration.signal.parameters is only read by the stochastic-background path. "
+                "For CBC sources it is ignored, and has been since before the batched path existed."
+            )
+        return
+
+    ignored = sorted((configured - _BATCHED_HONOURED_FIELDS) | extra)
+    if not ignored:
+        return
+
+    lines = []
+    for field in ignored:
+        reason = _BATCHED_REASONS.get(field, "the batched path does not read it")
+        lines.append(f"  {_alias_of(signal_config, field)}: {reason}")
+    raise ValueError(
+        "execution: batched would ignore settings this configuration sets:\n"
+        + "\n".join(lines)
+        + "\n\nA setting that is read but never applied produces output that looks correct, so the "
+        "batched path refuses rather than continuing. Use execution: per-event, or remove them."
+    )

--- a/src/gwmock/signal/execution_support.py
+++ b/src/gwmock/signal/execution_support.py
@@ -3,18 +3,17 @@
 Three bugs in the batched path shared one shape: a setting was read from the configuration, stored
 on the orchestrator, and then never forwarded to the generator. ``waveform-backend-arguments`` were
 discarded, ``waveform-options`` had nowhere to go, and ``waveform-arguments`` outside a fixed set
-were dropped. Each was found separately, by review, after the run had produced plausible output.
+were dropped. In each case the run completed and produced plausible output.
 
 They were all instances of the same default: **a setting nobody wired is ignored**. Fixing them one
 at a time leaves the next one waiting. This inverts the default for the batched path -- a setting the
 path does not declare is *refused* -- so a configuration key added later fails loudly there until
 someone wires it, rather than passing silently.
 
-The per-event path is treated differently on purpose. It is the default, it has users, and at least
-one of its settings (``parameters``, which only the stochastic path reads) has been quietly ignored
-for CBC runs since before this. Turning that into an error would break working configurations for a
-problem they did not introduce, so it warns instead and the batched path is where the strict rule
-applies.
+The per-event path is treated differently on purpose. It is the default, it has users, and one of
+its settings (``parameters``, which only the stochastic path reads) has been quietly ignored for CBC
+runs since before this. Turning that into an error would break working configurations for a problem
+they did not introduce, so it warns instead and the batched path is where the strict rule applies.
 """
 
 from __future__ import annotations
@@ -70,12 +69,31 @@ def _alias_of(signal_config: Any, field: str) -> str:
     return getattr(info, "alias", None) or field
 
 
-def require_execution_supports_configuration(signal_config: Any, execution: str) -> None:
+def _unknown_keys(signal_config: Any) -> set[str]:
+    """Return every unrecognised key under ``orchestration.signal``, nested ones included.
+
+    Checking only the top level would leave an escape hatch: nested blocks such as ``output`` are
+    themselves ``extra="allow"`` models, so ``output.typo`` validates, is never read, and would
+    otherwise pass the strict batched rule because ``output`` as a whole is honoured.
+    """
+    unknown = set(getattr(signal_config, "model_extra", None) or {})
+    for field in type(signal_config).model_fields:
+        nested = getattr(signal_config, field, None)
+        nested_extra = getattr(nested, "model_extra", None)
+        if not nested_extra:
+            continue
+        unknown |= {f"{_alias_of(signal_config, field)}.{name}" for name in nested_extra}
+    return unknown
+
+
+def require_execution_supports_configuration(signal_config: Any, execution: str, source_type: str = "") -> None:
     """Refuse a configuration whose settings the chosen execution path would ignore.
 
     Args:
         signal_config: The validated ``orchestration.signal`` block.
         execution: The execution mode, ``"per-event"`` or ``"batched"``.
+        source_type: The resolved source type. Only used to decide whether ``parameters`` is read,
+            which it is for ``"sgwb"`` and is not for compact-binary sources.
 
     Raises:
         ValueError: If *execution* is ``"batched"`` and the user set a field it does not honour, or
@@ -84,25 +102,27 @@ def require_execution_supports_configuration(signal_config: Any, execution: str)
     # Only what the user actually wrote. Defaults are not "configured", and treating them as such
     # would refuse every configuration.
     configured = set(getattr(signal_config, "model_fields_set", set()))
-    extra = set(getattr(signal_config, "model_extra", None) or {})
+    unknown = _unknown_keys(signal_config)
 
     if execution != "batched":
         # Unknown keys are ignored whatever the path does with them, so they are worth saying out
         # loud even here -- a misspelled setting is silently absent otherwise.
-        for name in sorted(extra):
+        for name in sorted(unknown):
             logger.warning(
                 "orchestration.signal.%s is not a recognised setting and will be ignored. Check the "
                 "spelling against the configuration reference.",
                 name,
             )
-        if "parameters" in configured:
+        # The stochastic path does read `parameters`, so warning about it there would be wrong.
+        if "parameters" in configured and source_type != "sgwb":
             logger.warning(
                 "orchestration.signal.parameters is only read by the stochastic-background path. "
-                "For CBC sources it is ignored, and has been since before the batched path existed."
+                "For %s sources it is ignored, and has been since before the batched path existed.",
+                source_type or "compact-binary",
             )
         return
 
-    ignored = sorted((configured - _BATCHED_HONOURED_FIELDS) | extra)
+    ignored = sorted((configured - _BATCHED_HONOURED_FIELDS) | unknown)
     if not ignored:
         return
 

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -223,6 +223,25 @@ class TestTheCheckIsReachedOnThePerEventPath:
 
         assert caplog.text == ""
 
+    def test_a_refused_configuration_is_refused_again_on_retry(self, tmp_path):
+        """The once-per-orchestrator guard must not turn into a once-per-orchestrator bypass.
+
+        ``retry_with_backoff`` re-runs a failed batch on the same instance and restores
+        ``simulator.state``, which this flag is not part of. Marking the check done before it passes
+        would let the second attempt run the very configuration the first one rejected -- the silent
+        drop again, reached by a different route.
+        """
+        orchestrator = _orchestrator(
+            tmp_path, "batched", waveform_backend=None, **{"waveform-options": {"ModeArray": [[2, 2]]}}
+        )
+
+        with pytest.raises(ValueError, match="would ignore settings"):
+            orchestrator._simulate()
+
+        # The retry. Without the fix this returns normally, generating from a rejected config.
+        with pytest.raises(ValueError, match="would ignore settings"):
+            orchestrator._simulate()
+
     def test_the_check_runs_once_rather_than_once_per_segment(self, tmp_path, caplog):
         """A warning repeated for every segment of a long run is noise, not a warning."""
         orchestrator = _orchestrator(tmp_path, "per-event", waveform_backend=None, **{"not-a-real-setting": "x"})

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -182,8 +182,13 @@ class TestWaveformConfigurationIsHonoured:
             _orchestrator(tmp_path, "batched", waveform_backend="lal")._simulate()
 
     def test_waveform_options_are_refused(self, tmp_path):
-        """There is no equivalent parameter on the batched entry point, so silence would lose them."""
-        with pytest.raises(ValueError, match="cannot apply waveform-options"):
+        """There is no equivalent parameter on the batched entry point, so silence would lose them.
+
+        Refused by the general consumption check rather than a rule of its own -- see
+        ``tests/signal/test_execution_support.py``. Kept here because this exercises it through the
+        orchestrator, confirming the check is actually reached on the real path.
+        """
+        with pytest.raises(ValueError, match="would ignore settings"):
             _orchestrator(
                 tmp_path, "batched", waveform_backend=None, **{"waveform-options": {"ModeArray": [[2, 2]]}}
             )._simulate()

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -12,6 +12,7 @@ would make the choice of mode change the dataset rather than only how it was com
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -192,6 +193,45 @@ class TestWaveformConfigurationIsHonoured:
             _orchestrator(
                 tmp_path, "batched", waveform_backend=None, **{"waveform-options": {"ModeArray": [[2, 2]]}}
             )._simulate()
+
+
+class TestTheCheckIsReachedOnThePerEventPath:
+    """The per-event warnings are worth nothing if nothing calls them.
+
+    Every other test of this check calls the helper directly, which cannot tell a wired-up check
+    from a dead one. These go through ``_simulate`` on the default path instead. The population is
+    emptied first so the per-event loop returns without generating anything -- the check runs at the
+    top of ``_simulate``, before any of that.
+    """
+
+    @staticmethod
+    def _simulate_nothing(tmp_path: Path, **signal_overrides: Any) -> None:
+        orchestrator = _orchestrator(tmp_path, "per-event", waveform_backend=None, **signal_overrides)
+        orchestrator._population_events = []
+        orchestrator._simulate()
+
+    def test_an_unrecognised_key_warns_through_the_orchestrator(self, tmp_path, caplog):
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            self._simulate_nothing(tmp_path, **{"not-a-real-setting": "x"})
+
+        assert "not a recognised setting" in caplog.text
+
+    def test_an_ordinary_configuration_warns_about_nothing(self, tmp_path, caplog):
+        """Guards the opposite failure: a check that fires on every run stops being read."""
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            self._simulate_nothing(tmp_path)
+
+        assert caplog.text == ""
+
+    def test_the_check_runs_once_rather_than_once_per_segment(self, tmp_path, caplog):
+        """A warning repeated for every segment of a long run is noise, not a warning."""
+        orchestrator = _orchestrator(tmp_path, "per-event", waveform_backend=None, **{"not-a-real-setting": "x"})
+        orchestrator._population_events = []
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            orchestrator._simulate()
+            orchestrator._simulate()
+
+        assert caplog.text.count("not a recognised setting") == 1
 
 
 class TestSegmentEventSelection:

--- a/tests/signal/test_execution_support.py
+++ b/tests/signal/test_execution_support.py
@@ -1,0 +1,128 @@
+"""Refusing settings the chosen execution path would ignore.
+
+Three bugs in the batched path shared one shape: a setting was read from the configuration and never
+forwarded to the generator, so the run produced plausible output while quietly disregarding what it
+had been told. Each was found separately, by review.
+
+The fix is not a fourth special case but an inverted default: the batched path declares what it
+honours, and anything else the user set is refused. A configuration key added later therefore fails
+loudly there until someone wires it.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from gwmock.cli.utils.config import SignalConfig
+from gwmock.signal.execution_support import require_execution_supports_configuration
+
+_BASE = {"detectors": ["H1"], "source-type": "bbh", "waveform-model": "IMRPhenomD"}
+
+
+def _config(**extra) -> SignalConfig:
+    return SignalConfig.model_validate({**_BASE, **extra})
+
+
+class TestBatchedRefusesWhatItIgnores:
+    """The strict rule, applied where the path is new and has no users to break."""
+
+    def test_a_plain_configuration_is_accepted(self):
+        """The check must not refuse configurations the path can honour."""
+        require_execution_supports_configuration(_config(), "batched")
+
+    def test_every_honoured_setting_is_accepted_together(self):
+        """Guards the opposite failure: a rule so strict nothing passes."""
+        require_execution_supports_configuration(
+            _config(
+                **{
+                    "waveform-backend": "ripple",
+                    "waveform-backend-arguments": {"taper_fraction": 0.05},
+                    "waveform-arguments": {"f_ref": 20.0},
+                    "minimum-frequency": 30,
+                    "earth-rotation": False,
+                    "execution": "batched",
+                }
+            ),
+            "batched",
+        )
+
+    @pytest.mark.parametrize(
+        ("setting", "value"),
+        [
+            # The bug found by review: no equivalent parameter on the batched entry point.
+            ("waveform-options", {"ModeArray": [[2, 2]]}),
+            # Found by writing this check: these configure the simulator's constructor, and the
+            # batched path bypasses the simulator entirely.
+            ("arguments", {"segment_duration": 8}),
+            # Also found by writing this check: read only by the stochastic path.
+            ("parameters", {"omega_ref": 1e-9}),
+        ],
+    )
+    def test_a_setting_the_path_cannot_apply_is_refused(self, setting: str, value):
+        with pytest.raises(ValueError, match="would ignore settings") as raised:
+            require_execution_supports_configuration(_config(**{setting: value}), "batched")
+
+        assert setting in str(raised.value), "the message must name the setting at fault"
+
+    def test_the_message_says_why_each_setting_cannot_be_applied(self):
+        """A list of rejected names does not tell the reader what to do about them."""
+        with pytest.raises(ValueError, match="would ignore settings") as raised:
+            require_execution_supports_configuration(_config(**{"arguments": {"a": 1}}), "batched")
+
+        assert "bypasses" in str(raised.value) or "directly rather than" in str(raised.value)
+
+    def test_an_unrecognised_key_is_refused(self):
+        """An unknown setting -- a typo, or one from a newer version -- is absent rather than wrong.
+
+        The config model allows extra keys, so nothing else reports them: the run simply behaves as
+        though the line were not there. The key here is deliberately not a plausible misspelling,
+        because the repository's spell checker rejects those in source.
+        """
+        with pytest.raises(ValueError, match="not-a-real-setting"):
+            require_execution_supports_configuration(_config(**{"not-a-real-setting": "IMRPhenomD"}), "batched")
+
+    def test_defaults_are_not_treated_as_configured(self):
+        """Only what the user wrote counts; otherwise every configuration would be refused.
+
+        ``model_fields_set`` is what makes the inverted default workable -- without it the check
+        cannot distinguish a field left alone from one deliberately set.
+        """
+        configuration = _config()
+
+        assert "minimum_frequency" not in configuration.model_fields_set
+        require_execution_supports_configuration(configuration, "batched")
+
+
+class TestPerEventWarnsRatherThanRefuses:
+    """The default path has users, and one of its settings has been ignored since before this."""
+
+    def test_an_unrecognised_key_warns(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            require_execution_supports_configuration(_config(**{"not-a-real-setting": "x"}), "per-event")
+
+        assert "not a recognised setting" in caplog.text
+
+    def test_parameters_warns_for_cbc(self, caplog):
+        """Pre-existing: only the stochastic path reads it, so CBC runs discard it silently."""
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            require_execution_supports_configuration(_config(**{"parameters": {"a": 1}}), "per-event")
+
+        assert "stochastic-background path" in caplog.text
+
+    def test_a_plain_configuration_warns_about_nothing(self, caplog):
+        """Otherwise every ordinary run would emit noise, and the warnings would stop being read."""
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            require_execution_supports_configuration(_config(), "per-event")
+
+        assert caplog.text == ""
+
+    def test_settings_the_batched_path_refuses_are_still_allowed(self, caplog):
+        """Refusing these here would break working configurations for a problem they did not cause."""
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            require_execution_supports_configuration(
+                _config(**{"waveform-options": {"ModeArray": [[2, 2]]}}), "per-event"
+            )
+
+        assert "waveform-options" not in caplog.text

--- a/tests/signal/test_execution_support.py
+++ b/tests/signal/test_execution_support.py
@@ -2,7 +2,7 @@
 
 Three bugs in the batched path shared one shape: a setting was read from the configuration and never
 forwarded to the generator, so the run produced plausible output while quietly disregarding what it
-had been told. Each was found separately, by review.
+had been told.
 
 The fix is not a fourth special case but an inverted default: the batched path declares what it
 honours, and anything else the user set is refused. A configuration key added later therefore fails
@@ -51,12 +51,12 @@ class TestBatchedRefusesWhatItIgnores:
     @pytest.mark.parametrize(
         ("setting", "value"),
         [
-            # The bug found by review: no equivalent parameter on the batched entry point.
+            # No equivalent parameter on the batched entry point.
             ("waveform-options", {"ModeArray": [[2, 2]]}),
-            # Found by writing this check: these configure the simulator's constructor, and the
-            # batched path bypasses the simulator entirely.
+            # These configure the simulator's constructor, and the batched path bypasses the
+            # simulator entirely.
             ("arguments", {"segment_duration": 8}),
-            # Also found by writing this check: read only by the stochastic path.
+            # Read only by the stochastic path.
             ("parameters", {"omega_ref": 1e-9}),
         ],
     )
@@ -83,6 +83,25 @@ class TestBatchedRefusesWhatItIgnores:
         with pytest.raises(ValueError, match="not-a-real-setting"):
             require_execution_supports_configuration(_config(**{"not-a-real-setting": "IMRPhenomD"}), "batched")
 
+    def test_an_unrecognised_key_inside_a_nested_block_is_refused(self):
+        """Checking only the top level would leave the rule with an escape hatch.
+
+        ``output`` is a model that allows extras too, so ``output.<typo>`` validates and is never
+        read -- and because ``output`` as a whole is honoured, a top-level-only check would wave it
+        through. That is the same silent drop, one level down.
+        """
+        configuration = _config(**{"output": {"file_name": "x.gwf", "not-a-real-setting": 1}, "execution": "batched"})
+
+        with pytest.raises(ValueError, match=r"output\.not-a-real-setting"):
+            require_execution_supports_configuration(configuration, "batched")
+
+    def test_known_nested_settings_are_still_accepted(self):
+        """The nested check must reject unknown keys, not every nested block."""
+        require_execution_supports_configuration(
+            _config(**{"output": {"file_name": "x.gwf", "arguments": {"channel": "H1:STRAIN"}}}),
+            "batched",
+        )
+
     def test_defaults_are_not_treated_as_configured(self):
         """Only what the user wrote counts; otherwise every configuration would be refused.
 
@@ -107,9 +126,30 @@ class TestPerEventWarnsRatherThanRefuses:
     def test_parameters_warns_for_cbc(self, caplog):
         """Pre-existing: only the stochastic path reads it, so CBC runs discard it silently."""
         with caplog.at_level(logging.WARNING, logger="gwmock"):
-            require_execution_supports_configuration(_config(**{"parameters": {"a": 1}}), "per-event")
+            require_execution_supports_configuration(_config(**{"parameters": {"a": 1}}), "per-event", "bbh")
 
         assert "stochastic-background path" in caplog.text
+
+    def test_parameters_does_not_warn_for_sgwb(self, caplog):
+        """The stochastic path genuinely reads them, so warning there would be simply wrong.
+
+        ``_simulate_stationary_signal_segment`` merges ``signal_parameters`` into what it passes to
+        the simulator, which is the one case where this setting has an effect.
+        """
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            require_execution_supports_configuration(
+                _config(**{"source-type": "sgwb", "parameters": {"omega_ref": 1e-9}}), "per-event", "sgwb"
+            )
+
+        assert caplog.text == ""
+
+    def test_an_unrecognised_key_inside_a_nested_block_warns(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            require_execution_supports_configuration(
+                _config(**{"output": {"file_name": "x.gwf", "not-a-real-setting": 1}}), "per-event"
+            )
+
+        assert "output.not-a-real-setting" in caplog.text
 
     def test_a_plain_configuration_warns_about_nothing(self, caplog):
         """Otherwise every ordinary run would emit noise, and the warnings would stop being read."""


### PR DESCRIPTION
> **Stacked.** Targets `main`, so the diff includes #292 and #295, both open. **The new work is the last two commits only.** Merge #292 and #295 first.

## 📝 Summary

Three defects in the batched execution path shared one shape: a setting was read from the configuration, stored on the orchestrator, and **never forwarded to the generator**. `waveform-backend-arguments` were discarded, `waveform-options` had nowhere to go, and `waveform-arguments` outside a fixed set were dropped. In each case the run completed and produced plausible output while disregarding what it had been told.

All three were instances of one default: **a setting nobody wired is ignored.** Fixing them individually leaves the next one waiting.

This inverts the default for the batched path. It declares which signal-config fields it honours, and anything else the user set is refused — so a configuration key added later fails loudly there until someone wires it. Pydantic's `model_fields_set` is what makes that workable: it distinguishes a field the user *wrote* from one left at its default, so the rule can be strict without refusing every configuration.

### Two further cases this surfaced

- **`signal.arguments`** configures the simulator's constructor, and the batched path calls gwmock-signal's batched entry point directly rather than going through the simulator — so these never apply.
- **`signal.parameters`** is read only by the stochastic path. For CBC sources it is ignored, and that predates the batched path entirely — it has been silently discarded on the default path all along.

Unrecognised keys are caught too, including nested ones. The config models allow extras, so a typo is *absent* rather than wrong, and nothing else reports it. `signal.output` is itself an `extra="allow"` model, so `output.<typo>` needs the same treatment even though `output` as a whole is honoured — otherwise the strict rule has an escape hatch one level down.

### Why the per-event path only warns

It is the default path, it has users, and `signal.parameters` has been ignored there for longer than the batched path has existed. Turning that into an error would break working configurations for a problem they did not introduce. The strict rule applies where the path is new and opt-in.

The check runs at the top of `_simulate`, before any event is consumed — `population_index` is checkpointed state, so failing after advancing it would make a resumed run skip the rejected events. It runs once per orchestrator rather than once per segment, so a warning is not repeated for every segment of a long run.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🎨 Refactoring

The batched path is new and opt-in, so refusals there break nothing existing. Per-event behaviour is unchanged apart from two warnings.

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** 902 passed, 23 skipped; e2e 35 passed, 9 skipped. 17 new tests.
- [x] **Manual Test:** all refusal cases verified — `waveform-options`, `arguments`, `parameters`, an unknown top-level key, an unknown nested `output` key, and a plain configuration that must still be accepted.
- [x] **Manual Test:** defaults are not treated as configured, which is what stops the rule refusing everything.
- [x] **Manual Test:** the per-event warnings are exercised through `_simulate` on a real orchestrator, not only by calling the helper — a test that calls the helper directly cannot tell a wired-up check from a dead one.
- [x] **Manual Test:** every new test confirmed failing against the unfixed code before being committed.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

## The risk this carries

`_BATCHED_HONOURED_FIELDS` is derived by hand from what `_simulate_batched_segment` does. A field wrongly listed as honoured reproduces the original defect — a silently ignored setting — but now with a passing check beside it. That list is the part of this change most worth scrutinising.

## Not in this PR

`signal.parameters` being ignored for CBC on the **per-event** path is pre-existing and only warned about here. Fixing it properly means either wiring it through or removing it from the schema for non-stochastic sources, which is a behaviour change deserving its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable per-event and batched signal-generation modes.
  * Batched processing now preserves event chunks, provenance, and checkpoint safety.
  * Added validation with clear feedback for unsupported configuration options.
  * Added support for converting batched waveform output into individual event segments.

* **Bug Fixes**
  * Preserved metadata and channel identity when injected data extends beyond segment boundaries.
  * Prevented source data from being modified during boundary-overflow handling.

* **Documentation**
  * Improved reference-output comparisons and added signed peak diagnostics for portability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->