### PR TITLE
fix(data): report the signal content injection drops off the front of a segment

### DIFF
--- a/src/gwmock/data/time_series/inject.py
+++ b/src/gwmock/data/time_series/inject.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 from astropy.units import second  # pylint: disable=no-name-in-module
@@ -102,6 +102,47 @@ def is_aligned(offset_samples: float, tolerance: float) -> bool:
         Whether the offset counts as aligned.
     """
     return bool(abs(offset_samples - round(offset_samples)) <= tolerance)
+
+
+def measure_content_before(
+    segment_start_time: float, sampling_frequency: float, chunk: Any
+) -> tuple[int, float, float]:
+    """Measure the part of *chunk* lying before *segment_start_time*, which injection discards.
+
+    :func:`inject` crops a chunk to the target's span, so anything earlier is dropped. Forward
+    overflow is different: it is returned as a tail and carried into the next segment. Backward
+    overflow has nowhere to go, because the segments it belongs to have already been written.
+
+    That matters for compact-binary sources, whose inspiral *precedes* ``coa_time`` while the
+    segment claiming an event is the one ``coa_time`` falls in. A waveform buffer therefore starts
+    before its own segment whenever ``coa_time`` lands within one buffer length of the boundary.
+
+    Args:
+        segment_start_time: Start of the segment being injected into, in the chunk's time unit.
+        sampling_frequency: Sample rate of the segment, in Hz.
+        chunk: The time series about to be injected.
+
+    Returns:
+        A ``(samples, seconds, energy_fraction)`` triple describing what lies before the segment.
+        ``energy_fraction`` is the share of the chunk's summed squares that is dropped, which is
+        the quantity an SNR responds to; it is ``0.0`` for a silent chunk.
+    """
+    times = np.asarray(chunk.time_array.value, dtype=float)
+    if times.size == 0:
+        return 0, 0.0, 0.0
+
+    # Half a sample of slack. A tail carried from the previous segment starts exactly on this
+    # boundary, and at GPS epochs the float64 spacing (~2.4e-7 s at 1.6e9) can put it a hair below
+    # -- which would otherwise be reported as a whole dropped sample every single segment.
+    n_before = int(np.searchsorted(times, segment_start_time - 0.5 / sampling_frequency))
+    if n_before <= 0:
+        return 0, 0.0, 0.0
+
+    data = np.atleast_2d(np.asarray(chunk, dtype=float))
+    total = float(np.sum(np.square(data)))
+    dropped = float(np.sum(np.square(data[:, :n_before])))
+    fraction = dropped / total if total > 0.0 else 0.0
+    return n_before, float(segment_start_time - times[0]), fraction
 
 
 def inject(timeseries: TimeSeries, other: TimeSeries, interpolate_if_offset: bool = True) -> TimeSeries:

--- a/src/gwmock/data/time_series/inject.py
+++ b/src/gwmock/data/time_series/inject.py
@@ -150,7 +150,10 @@ def measure_content_before(
     # 16384 Hz -- 2048x and 128x under the threshold. It would take a sampling frequency of 2.1 MHz
     # for float64 spacing at a GPS epoch to reach half a sample, so the slack holds across every rate
     # this package supports.
-    n_before = int(np.searchsorted(times, segment_start_time - 0.5 / sampling_frequency))
+    # `side="left"`, so a sample sitting exactly on the threshold is *not* counted as dropped.
+    # That case is a rounding tie by construction -- exactly half a sample from the boundary --
+    # and resolving it towards the boundary matches what the slack is for.
+    n_before = int(np.searchsorted(times, segment_start_time - 0.5 / sampling_frequency, side="left"))
     if n_before <= 0:
         return 0, 0.0, 0.0
 

--- a/src/gwmock/data/time_series/inject.py
+++ b/src/gwmock/data/time_series/inject.py
@@ -124,8 +124,12 @@ def measure_content_before(
 
     Returns:
         A ``(samples, seconds, energy_fraction)`` triple describing what lies before the segment.
-        ``energy_fraction`` is the share of the chunk's summed squares that is dropped, which is
-        the quantity an SNR responds to; it is ``0.0`` for a silent chunk.
+        ``energy_fraction`` is the share of the chunk's summed squares that is dropped -- unweighted
+        strain-squared energy, ``0.0`` for a silent chunk. It is a **proxy, not an SNR loss**: a
+        matched-filter figure needs a detector PSD and frequency-domain weighting, neither of which
+        is available here. It is reported in preference to the sample fraction only because the two
+        differ by more than a factor of two in ordinary cases, and the sample fraction is the more
+        misleading of the pair.
     """
     times = np.asarray(chunk.time_array.value, dtype=float)
     if times.size == 0:
@@ -134,6 +138,17 @@ def measure_content_before(
     # Half a sample of slack. A tail carried from the previous segment starts exactly on this
     # boundary, and at GPS epochs the float64 spacing (~2.4e-7 s at 1.6e9) can put it a hair below
     # -- which would otherwise be reported as a whole dropped sample every single segment.
+    #
+    # Half a sample, rather than the ULP-scaled `alignment_tolerance` used for grid alignment,
+    # because the question here is different: a sample nearer the boundary than half a sample period
+    # rounds *to* the boundary, so counting it as dropped would be wrong however exact the arithmetic
+    # was. The cost is that up to one genuinely discarded sample can go unreported, which is bounded
+    # and negligible beside the multi-second losses this exists to surface.
+    #
+    # Measured margin: spacing(1.577e9) = 2.384e-07 s is 2.4e-4 samples at 1024 Hz and 3.9e-3 at
+    # 16384 Hz -- 2048x and 128x under the threshold. It would take a sampling frequency of 2.1 MHz
+    # for float64 spacing at a GPS epoch to reach half a sample, so the slack holds across every rate
+    # this package supports.
     n_before = int(np.searchsorted(times, segment_start_time - 0.5 / sampling_frequency))
     if n_before <= 0:
         return 0, 0.0, 0.0

--- a/src/gwmock/data/time_series/inject.py
+++ b/src/gwmock/data/time_series/inject.py
@@ -124,6 +124,7 @@ def measure_content_before(
 
     Returns:
         A ``(samples, seconds, energy_fraction)`` triple describing what lies before the segment.
+        ``seconds`` is the span of those samples, so it always agrees with ``samples``.
         ``energy_fraction`` is the share of the chunk's summed squares that is dropped -- unweighted
         strain-squared energy, ``0.0`` for a silent chunk. It is a **proxy, not an SNR loss**: a
         matched-filter figure needs a detector PSD and frequency-domain weighting, neither of which
@@ -157,7 +158,11 @@ def measure_content_before(
     total = float(np.sum(np.square(data)))
     dropped = float(np.sum(np.square(data[:, :n_before])))
     fraction = dropped / total if total > 0.0 else 0.0
-    return n_before, float(segment_start_time - times[0]), fraction
+    # The span of the dropped samples, not the gap from the chunk's start to the boundary. The
+    # two differ whenever the chunk ends before the boundary: 1024 samples sitting 10 s early
+    # span 1 s, and the warning pairs this figure with the sample count as though they agreed.
+    # Deriving it from the count also avoids subtracting two close GPS-scale times.
+    return n_before, n_before / sampling_frequency, fraction
 
 
 def inject(timeseries: TimeSeries, other: TimeSeries, interpolate_if_offset: bool = True) -> TimeSeries:

--- a/src/gwmock/data/time_series/time_series.py
+++ b/src/gwmock/data/time_series/time_series.py
@@ -260,6 +260,12 @@ class TimeSeries(JSONSerializable):
                 "This ensures time grid alignment and avoids rounding errors."
             )
 
+        # Before the early returns below, not after. A chunk lying entirely before this segment is
+        # handed back as a remainder and then dropped by `TimeSeriesMixin.simulate`, so it is
+        # discarded just as surely as a partially-early one -- and reporting only the overlapping
+        # case would leave the larger loss the quieter of the two.
+        self._report_content_before_segment(other)
+
         if other.end_time < self.start_time:
             logger.warning(
                 "The time series to inject ends before the current time series starts. No injection performed."
@@ -284,8 +290,6 @@ class TimeSeries(JSONSerializable):
         # boundary loses its tail -- and `TimeSeriesMixin.simulate` relies on that tail being
         # returned to carry the rest of the signal into the next segment.
         supplied = other
-
-        self._report_content_before_segment(supplied)
 
         # Check whether there is any offset in times
         other_start_time = other.start_time.to(self.start_time.unit)

--- a/src/gwmock/data/time_series/time_series.py
+++ b/src/gwmock/data/time_series/time_series.py
@@ -367,7 +367,8 @@ class TimeSeries(JSONSerializable):
 
         coa_time = (chunk.metadata.get("injection_parameters") or {}).get("coa_time")
         logger.warning(
-            "Discarding %.3f s (%d samples, %.2f%% of its energy) of the signal with coa_time %s: it "
+            "Discarding %.3f s (%d samples, %.2f%% of its unweighted strain-squared energy) of the "
+            "signal with coa_time %s: it "
             "starts at %s, before this segment begins at %s. The earlier segments it belongs to are "
             "already written, so this content cannot be placed. A compact-binary waveform starts "
             "before its coa_time, so this happens whenever coa_time falls within one waveform buffer "

--- a/src/gwmock/data/time_series/time_series.py
+++ b/src/gwmock/data/time_series/time_series.py
@@ -14,7 +14,7 @@ from gwpy.types.index import Index
 from scipy.interpolate import interp1d
 
 from gwmock.data.serialize.serializable import JSONSerializable
-from gwmock.data.time_series.inject import alignment_tolerance, inject, is_aligned
+from gwmock.data.time_series.inject import alignment_tolerance, inject, is_aligned, measure_content_before
 
 logger = logging.getLogger("gwmock")
 
@@ -285,6 +285,8 @@ class TimeSeries(JSONSerializable):
         # returned to carry the rest of the signal into the next segment.
         supplied = other
 
+        self._report_content_before_segment(supplied)
+
         # Check whether there is any offset in times
         other_start_time = other.start_time.to(self.start_time.unit)
         idx = ((other_start_time - self.start_time) * self.sampling_frequency).value
@@ -343,6 +345,36 @@ class TimeSeries(JSONSerializable):
                 target.override_unit(source.unit)
             return tail.crop(start_time=self.end_time)
         return None
+
+    def _report_content_before_segment(self, chunk: TimeSeries) -> None:
+        """Warn that content starting before this segment is about to be dropped.
+
+        Reported rather than fixed. Placing it would mean writing into segments already on disk, so
+        the loss is real either way -- but it was silent, and a truncated inspiral looks like a
+        perfectly ordinary signal. Saying how much went, per signal, is what lets a run be judged.
+        """
+        samples, seconds, energy_fraction = measure_content_before(
+            float(self.start_time.to(chunk.start_time.unit).value),
+            float(self.sampling_frequency.value),
+            chunk,
+        )
+        if samples <= 0:
+            return
+
+        coa_time = (chunk.metadata.get("injection_parameters") or {}).get("coa_time")
+        logger.warning(
+            "Discarding %.3f s (%d samples, %.2f%% of its energy) of the signal with coa_time %s: it "
+            "starts at %s, before this segment begins at %s. The earlier segments it belongs to are "
+            "already written, so this content cannot be placed. A compact-binary waveform starts "
+            "before its coa_time, so this happens whenever coa_time falls within one waveform buffer "
+            "of a segment boundary; a longer segment duration makes it rarer but not impossible.",
+            seconds,
+            samples,
+            100.0 * energy_fraction,
+            "unknown" if coa_time is None else coa_time,
+            chunk.start_time,
+            self.start_time,
+        )
 
     def inject_from_list(self, ts_iterable: Iterable[TimeSeries]) -> TimeSeriesList:
         """Inject multiple TimeSeries from an iterable into the current TimeSeries.

--- a/tests/data/time_series/test_content_before_segment.py
+++ b/tests/data/time_series/test_content_before_segment.py
@@ -1,0 +1,234 @@
+"""Reporting the signal content that injection drops off the front of a segment.
+
+``inject`` crops a chunk to the target's span. Forward overflow is returned as a tail and carried
+into the next segment; backward overflow is discarded, because the segments it belongs to have
+already been written. A compact-binary waveform starts before its ``coa_time`` while the segment
+claiming an event is the one ``coa_time`` falls in, so the discard is reached by ordinary
+configurations rather than by anything exotic.
+
+These tests pin the measurement and the warning. They do not assert that the content is kept --
+it is not, and keeping it is a change to how events are scheduled, not to how they are injected.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pytest
+from astropy.units import Quantity
+
+from gwmock.data.time_series.inject import measure_content_before
+from gwmock.data.time_series.time_series import TimeSeries
+
+_FS = 1024.0
+# A GPS-scale epoch on purpose: the float64 spacing here is ~2.4e-7 s, which is where a naive
+# boundary comparison starts reporting phantom dropped samples.
+_EPOCH = 1577491296.0
+
+
+def _series(start_time: float, n_samples: int, amplitude: float = 1.0, n_channels: int = 1) -> TimeSeries:
+    return TimeSeries(
+        data=np.full((n_channels, n_samples), amplitude, dtype=float),
+        start_time=Quantity(start_time, unit="s"),
+        sampling_frequency=Quantity(_FS, unit="Hz"),
+    )
+
+
+class TestMeasurement:
+    """The numbers themselves, without the logging."""
+
+    def test_a_chunk_starting_inside_the_segment_loses_nothing(self):
+        chunk = _series(_EPOCH + 1.0, 1024)
+
+        assert measure_content_before(_EPOCH, _FS, chunk) == (0, 0.0, 0.0)
+
+    def test_a_tail_landing_exactly_on_the_boundary_loses_nothing(self):
+        """The carry-forward case, which happens every segment and must stay silent."""
+        chunk = _series(_EPOCH, 1024)
+
+        assert measure_content_before(_EPOCH, _FS, chunk) == (0, 0.0, 0.0)
+
+    def test_a_boundary_off_by_a_float_ulp_still_loses_nothing(self):
+        """Without the half-sample slack this reports a dropped sample on every carried tail.
+
+        ``np.spacing`` at a GPS epoch is ~2.4e-7 s against a 9.8e-4 s sample period, so the error is
+        four thousand times smaller than a sample and must not round up to one.
+        """
+        chunk = _series(_EPOCH - np.spacing(_EPOCH), 1024)
+
+        samples, _, _ = measure_content_before(_EPOCH, _FS, chunk)
+
+        assert samples == 0
+
+    def test_the_dropped_sample_count_and_duration_are_exact(self):
+        chunk = _series(_EPOCH - 0.5, 2048)
+
+        samples, seconds, _ = measure_content_before(_EPOCH, _FS, chunk)
+
+        assert samples == 512
+        assert seconds == pytest.approx(0.5)
+
+    def test_the_energy_fraction_is_the_share_of_summed_squares(self):
+        """Not the share of samples -- an SNR responds to energy, and the two differ a lot.
+
+        Half the samples here carry a quarter of the amplitude, hence a sixteenth of the energy
+        each, so the dropped fraction is 1/17 rather than 1/2.
+        """
+        data = np.concatenate([np.full(512, 0.25), np.full(512, 1.0)])
+        chunk = TimeSeries(
+            data=data.reshape(1, -1),
+            start_time=Quantity(_EPOCH - 0.5, unit="s"),
+            sampling_frequency=Quantity(_FS, unit="Hz"),
+        )
+
+        _, _, fraction = measure_content_before(_EPOCH, _FS, chunk)
+
+        assert fraction == pytest.approx((512 * 0.0625) / (512 * 0.0625 + 512 * 1.0))
+
+    def test_a_silent_chunk_reports_no_energy_rather_than_dividing_by_zero(self):
+        chunk = _series(_EPOCH - 0.5, 2048, amplitude=0.0)
+
+        samples, _, fraction = measure_content_before(_EPOCH, _FS, chunk)
+
+        assert samples == 512
+        assert fraction == 0.0
+
+    def test_every_channel_counts_towards_the_energy(self):
+        """A per-detector chunk drops content in all of its channels at once."""
+        one = measure_content_before(_EPOCH, _FS, _series(_EPOCH - 0.5, 2048, n_channels=1))
+        three = measure_content_before(_EPOCH, _FS, _series(_EPOCH - 0.5, 2048, n_channels=3))
+
+        assert one[2] == pytest.approx(three[2]), "the fraction is per chunk, so channels cancel out"
+
+    def test_an_empty_chunk_is_handled(self):
+        assert measure_content_before(_EPOCH, _FS, _series(_EPOCH, 0)) == (0, 0.0, 0.0)
+
+
+class TestTheWarning:
+    """What a run actually sees. Silence here is the defect this exists to remove."""
+
+    @staticmethod
+    def _segment() -> TimeSeries:
+        return TimeSeries(
+            data=np.zeros((1, int(4 * _FS))),
+            start_time=Quantity(_EPOCH, unit="s"),
+            sampling_frequency=Quantity(_FS, unit="Hz"),
+        )
+
+    def test_injecting_a_chunk_that_starts_early_warns(self, caplog):
+        chunk = _series(_EPOCH - 0.5, 2048)
+        chunk.metadata["injection_parameters"] = {"coa_time": _EPOCH + 1.0}
+
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            self._segment().inject(chunk)
+
+        assert "Discarding" in caplog.text
+        assert "0.500 s" in caplog.text, "the message must say how much time went"
+        assert "512 samples" in caplog.text
+        assert str(_EPOCH + 1.0) in caplog.text, "the message must identify which signal"
+
+    def test_the_warning_reports_energy_not_sample_count(self, caplog):
+        """A message quoting 50% of samples for 6% of the energy would misdirect the reader."""
+        data = np.concatenate([np.full(512, 0.25), np.full(512, 1.0)])
+        chunk = TimeSeries(
+            data=data.reshape(1, -1),
+            start_time=Quantity(_EPOCH - 0.5, unit="s"),
+            sampling_frequency=Quantity(_FS, unit="Hz"),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            self._segment().inject(chunk)
+
+        assert "5.88% of its energy" in caplog.text
+
+    def test_an_ordinary_injection_is_silent(self, caplog):
+        """Most injections are fine, and a warning on every one would be ignored."""
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            self._segment().inject(_series(_EPOCH + 1.0, 1024))
+
+        assert caplog.text == ""
+
+    def test_a_chunk_without_injection_parameters_still_warns(self, caplog):
+        """The loss is worth reporting even when the chunk cannot say which signal it is."""
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            self._segment().inject(_series(_EPOCH - 0.5, 2048))
+
+        assert "Discarding" in caplog.text
+        assert "unknown" in caplog.text
+
+    def test_a_real_run_warns_when_coa_time_lands_near_a_boundary(self, tmp_path, caplog):
+        """Synthetic arrays cannot show that ordinary configurations reach this.
+
+        A 30+25 Msun binary at 20 Hz is conditioned into a 4 s buffer with the merger 0.4 s from its
+        end, so a ``coa_time`` 0.5 s past a segment boundary puts 3.1 s of inspiral in the previous
+        segment -- which is already written.
+        """
+        from gwmock.cli.adapter_orchestration import AdapterOrchestrator
+        from gwmock.cli.utils.config import Config
+
+        epoch, segment = 1577491296.0, 16.0
+        population = tmp_path / "population.csv"
+        population.write_text(
+            "detector_frame_mass_1,detector_frame_mass_2,coa_time,distance,declination,"
+            "right_ascension,polarization_angle,inclination\n"
+            f"30.0,25.0,{epoch + segment + 0.5},400.0,0.3,1.1,0.2,0.5\n"
+        )
+        config = Config.model_validate(
+            {
+                "globals": {
+                    "simulator-arguments": {
+                        "sampling-frequency": _FS,
+                        "duration": segment,
+                        "total-duration": segment * 2,
+                        "start-time": epoch,
+                        "seed": 1,
+                    },
+                    "working-directory": str(tmp_path),
+                    "output-directory": "output",
+                    "metadata-directory": "metadata",
+                },
+                "orchestration": {
+                    "population": {
+                        "backend": "FilePopulationLoader",
+                        "source-type": "bbh",
+                        "n-samples": 1,
+                        "arguments": {"path": str(population)},
+                    },
+                    "signal": {
+                        "source-type": "bbh",
+                        "waveform-model": "IMRPhenomD",
+                        "minimum-frequency": 20,
+                        "detectors": ["H1"],
+                        "output": {
+                            "output_directory": "signal",
+                            "file_name": "s.gwf",
+                            "arguments": {"channel": "H1:S"},
+                        },
+                    },
+                },
+            }
+        )
+        orchestrator = AdapterOrchestrator.from_config(
+            config.orchestration, global_simulator_arguments=dict(config.globals.simulator_arguments)
+        )
+
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            orchestrator.simulate()  # first segment: nothing to claim yet
+            orchestrator.update_state()
+            orchestrator.simulate()  # the segment holding coa_time
+
+        assert "Discarding" in caplog.text, "an ordinary BBH config lost part of its inspiral without saying so"
+        assert "3.100 s" in caplog.text
+
+    def test_the_content_is_still_dropped(self, caplog):
+        """Pins the behaviour this PR does *not* change, so a later fix has to update it knowingly."""
+        segment = self._segment()
+        chunk = _series(_EPOCH - 0.5, 2048)
+
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            segment.inject(chunk)
+
+        written = np.asarray(segment[0]).astype(float)
+        assert np.count_nonzero(written) == 1536, "only the part inside the segment is placed"
+        assert "Discarding" in caplog.text

--- a/tests/data/time_series/test_content_before_segment.py
+++ b/tests/data/time_series/test_content_before_segment.py
@@ -13,6 +13,7 @@ it is not, and keeping it is a change to how events are scheduled, not to how th
 from __future__ import annotations
 
 import logging
+import re
 
 import numpy as np
 import pytest
@@ -219,7 +220,40 @@ class TestTheWarning:
             orchestrator.simulate()  # the segment holding coa_time
 
         assert "Discarding" in caplog.text, "an ordinary BBH config lost part of its inspiral without saying so"
-        assert "3.100 s" in caplog.text
+        # A bounded range, not the exact 3.100 s this currently prints. The value comes from LAL's
+        # conditioning, so pinning it would turn a waveform-library bump into a failure here while
+        # saying nothing about whether the reporting works. Still tight enough to fail if the
+        # measurement were the whole buffer, a single sample, or zero.
+        dropped = float(re.search(r"Discarding ([\d.]+) s", caplog.text).group(1))
+        assert 1.0 < dropped < 4.0, f"expected a few seconds of inspiral before the boundary, got {dropped}"
+
+    def test_a_chunk_lying_entirely_before_the_segment_is_reported(self, caplog):
+        """The larger loss must not be the quieter one.
+
+        ``inject`` returns early for a chunk with no overlap, and ``TimeSeriesMixin.simulate`` then
+        drops it from the cache. Reporting only the partially-early case would mean 100% of a
+        waveform vanishing with less said about it than 30% of one.
+        """
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            self._segment().inject(_series(_EPOCH - 10.0, 1024))
+
+        assert "Discarding" in caplog.text
+        assert "100.00% of its energy" in caplog.text
+
+    def test_an_off_grid_chunk_is_measured_before_it_is_resampled(self, caplog):
+        """The interpolation branch rebinds the chunk onto the segment's own grid.
+
+        Measuring after that would report what survived resampling rather than what was supplied,
+        so the loss has to be taken from the chunk as handed in.
+        """
+        off_grid = _series(_EPOCH - 0.5 + 0.5 / _FS, 2048)
+
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            self._segment().inject(off_grid)
+
+        assert "Discarding" in caplog.text
+        dropped = float(re.search(r"Discarding ([\d.]+) s", caplog.text).group(1))
+        assert dropped == pytest.approx(0.5 - 0.5 / _FS, abs=1.0 / _FS)
 
     def test_the_content_is_still_dropped(self, caplog):
         """Pins the behaviour this PR does *not* change, so a later fix has to update it knowingly."""

--- a/tests/data/time_series/test_content_before_segment.py
+++ b/tests/data/time_series/test_content_before_segment.py
@@ -109,6 +109,25 @@ class TestMeasurement:
 
         assert one[2] == pytest.approx(three[2]), "the fraction is per chunk, so channels cancel out"
 
+    def test_a_sample_exactly_on_the_threshold_is_not_dropped(self):
+        """The rounding tie, pinned rather than left to `searchsorted`'s default.
+
+        A sample exactly half a sample before the boundary is ambiguous by construction. It resolves
+        towards the boundary -- not counted -- which is what the slack exists to do. Untested, a
+        change of `side` would flip it silently.
+        """
+        chunk = _series(_EPOCH - 0.5 / _FS, 1024)
+
+        assert measure_content_before(_EPOCH, _FS, chunk) == (0, 0.0, 0.0)
+
+    def test_a_sample_just_past_the_threshold_is_dropped(self):
+        """The other side of the tie, so the test above pins a boundary rather than a blanket."""
+        chunk = _series(_EPOCH - 0.5 / _FS - 1.0 / _FS, 1024)
+
+        samples, _, _ = measure_content_before(_EPOCH, _FS, chunk)
+
+        assert samples == 1
+
     def test_an_empty_chunk_is_handled(self):
         assert measure_content_before(_EPOCH, _FS, _series(_EPOCH, 0)) == (0, 0.0, 0.0)
 
@@ -148,7 +167,7 @@ class TestTheWarning:
         with caplog.at_level(logging.WARNING, logger="gwmock"):
             self._segment().inject(chunk)
 
-        assert "5.88% of its energy" in caplog.text
+        assert "5.88% of its unweighted strain-squared energy" in caplog.text
 
     def test_an_ordinary_injection_is_silent(self, caplog):
         """Most injections are fine, and a warning on every one would be ignored."""
@@ -245,7 +264,7 @@ class TestTheWarning:
             self._segment().inject(_series(_EPOCH - 10.0, 1024))
 
         assert "Discarding" in caplog.text
-        assert "100.00% of its energy" in caplog.text
+        assert "100.00% of its unweighted strain-squared energy" in caplog.text
         # 1024 samples at 1024 Hz span 1 s, however far before the segment they sit. Reporting the
         # gap to the boundary instead would say 10 s here, while the message pairs the figure with a
         # sample count as though the two described the same span.

--- a/tests/data/time_series/test_content_before_segment.py
+++ b/tests/data/time_series/test_content_before_segment.py
@@ -70,6 +70,13 @@ class TestMeasurement:
         assert samples == 512
         assert seconds == pytest.approx(0.5)
 
+    @pytest.mark.parametrize("gap", [0.5, 2.0, 10.0])
+    def test_the_duration_always_matches_the_sample_count(self, gap: float):
+        """The warning prints the two side by side, so they have to describe the same span."""
+        samples, seconds, _ = measure_content_before(_EPOCH, _FS, _series(_EPOCH - gap, 512))
+
+        assert seconds == pytest.approx(samples / _FS)
+
     def test_the_energy_fraction_is_the_share_of_summed_squares(self):
         """Not the share of samples -- an SNR responds to energy, and the two differ a lot.
 
@@ -239,6 +246,10 @@ class TestTheWarning:
 
         assert "Discarding" in caplog.text
         assert "100.00% of its energy" in caplog.text
+        # 1024 samples at 1024 Hz span 1 s, however far before the segment they sit. Reporting the
+        # gap to the boundary instead would say 10 s here, while the message pairs the figure with a
+        # sample count as though the two described the same span.
+        assert "1.000 s" in caplog.text
 
     def test_an_off_grid_chunk_is_measured_before_it_is_resampled(self, caplog):
         """The interpolation branch rebinds the chunk onto the segment's own grid.


### PR DESCRIPTION
## 📝 Summary

`TimeSeries.inject` crops a chunk to the target segment's span. Forward overflow is returned as a tail and carried into the next segment; **backward overflow is discarded**, because the segments it belongs to have already been written.

A compact-binary waveform starts before its `coa_time`, while the segment claiming an event is the one `coa_time` falls in. So a buffer reaches back past its own segment whenever `coa_time` lands within one buffer length of a boundary — an ordinary configuration, not an exotic one. The run completed, the frames looked normal, and a truncated inspiral is indistinguishable from a short one.

Measured at 1024 Hz with 16 s segments, IMRPhenomD:

| Case | Buffer | Dropped | Samples | Strain² energy |
|---|---|---|---|---|
| BBH 30+25 M☉ @20 Hz, `coa_time` 0.5 s past a boundary | 4.0 s | 3.1 s | 77.5% | **32.4%** |
| BNS 1.4+1.35 M☉ @20 Hz | 256 s | 230.4 s | 90.0% | **99.998%** |

Exposure scales as pre-`coa` buffer over segment length, so the shipped `duration: 4096` examples affect roughly 5.6% of BNS events rather than all of them. The 16 s test configs affect most.

**Nothing about the placement changes here.** The content is still dropped. A run now says which signal lost what — in seconds, samples, and the share of summed squares.

### Why energy rather than sample count

They differ by more than 2× in the BBH case (77.5% vs 32.4%), because the merger sits inside the retained window and the inspiral does not. Quoting the sample fraction would be the more misleading of the two.

It is **unweighted strain-squared energy, and explicitly not an SNR loss** — a matched-filter figure needs a detector PSD and frequency-domain weighting, neither of which `inject` has access to. The docstring says so.

### Why warn rather than refuse

The loss predates this change and refusing would break working configurations for a problem they did not introduce. The actual fix — claiming an event in the segment where its *waveform* starts — changes generated data and invalidates the e2e reference values, so it is tracked separately.

## ✨ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🎨 Refactoring

Diagnostic only — no output changes, so the e2e reference values are untouched.

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** 932 passed, 23 skipped; e2e 35 passed, 9 skipped. 16 new tests.
- [x] **Manual Test:** mutation-tested rather than merely run — removing the half-sample slack fails exactly the ULP test; reporting the sample fraction instead of energy fails exactly the three energy tests; moving the measurement back after the early return fails exactly the entirely-early test.
- [x] **Manual Test:** one test drives a real orchestrator with a `coa_time` 0.5 s past a boundary and confirms the warning fires on a genuine configuration.
- [x] **Manual Test:** an ordinary injection, and a tail landing exactly on a boundary, both stay silent — a warning on every segment would be ignored.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Limits worth knowing

- **The half-sample threshold can hide up to one genuinely dropped sample.** That is deliberate: a sample nearer the boundary than half a sample period rounds *to* it. Measured margin — float64 spacing at a GPS epoch is 2048× under the threshold at 1024 Hz, 128× at 16384 Hz, and would need a 2.1 MHz rate to reach it.
- **The energy figures are this codebase's own measurement.** They are not anchored against an independent SNR tool.
- **A boundary-overlapping BNS chunk costs an O(samples × channels) pass.** Ordinary injections pay nothing — the sum is reached only once the condition trips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reporting when waveform content falls before a segment boundary.
  * Reports discarded duration, sample count, and signal energy fraction where applicable.

* **Bug Fixes**
  * Improved handling of empty, silent, multi-channel, off-grid, and non-overlapping waveform chunks.
  * Preserved correct discarding of content that precedes the target segment.

* **Tests**
  * Added comprehensive coverage for boundary precision, warning behavior, missing metadata, and real waveform injection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->