### PR TITLE
feat(examples): make the GPU path reachable, and gate batched execution end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,18 @@ jobs:
             - name: Confirm the optional stack is present
               # Otherwise a missing extra turns the whole job into a silent no-op: every gated
               # entry skips and the job still passes.
+              #
+              # The required modules are read from `E2E_MATRIX` rather than listed here, so adding a
+              # matrix entry with a new `requires` cannot leave this check behind. `gengli` is the
+              # documented exception: it is not an extra of this project, and its entry is labelled
+              # "not run" -- see NOT_HERMETIC in tests/e2e/overlay.py.
               run: |
                   uv run --no-sync python -c "
                   import importlib.util as u, sys
-                  missing = [m for m in ('ripplegw', 'jax') if u.find_spec(m) is None]
+                  sys.path.append('tests')  # append, not insert: tests/signal would shadow stdlib signal
+                  from e2e.matrix import E2E_MATRIX
+                  needed = {m for e in E2E_MATRIX for m in e.requires} - {'gengli'}
+                  missing = sorted(m for m in needed if u.find_spec(m) is None)
                   sys.exit('e2e job is missing: ' + ', '.join(missing) if missing else 0)
                   "
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,13 @@ jobs:
     # them across seven interpreter/OS combinations would multiply that for no added signal,
     # since what they exercise is orchestration rather than anything interpreter-specific.
     #
-    # `--all-extras` is load-bearing for the ripplegw-gated entries: with a plain `uv sync` those
+    # The `jax` extra is load-bearing for the ripplegw-gated entries: with a plain `uv sync` those
     # would skip, and the job would report green while testing less than it claims. The guard step
     # below turns that from a silent skip into a failure.
+    #
+    # Extras are named explicitly rather than `--all-extras`, because `cuda` pulls multi-gigabyte
+    # CUDA wheels that this runner has no GPU to use. The cost of naming them is that a new extra
+    # is not picked up here automatically -- add it to this line when one is introduced.
     #
     # It does *not* cover the gengli entry. gengli is not a declared extra of this project at all,
     # so no sync flag can install it, and that entry is separately blocked on a local glitch
@@ -80,7 +84,7 @@ jobs:
                   enable-cache: 'true'
 
             - name: Install dependencies
-              run: uv sync --group dev --all-extras
+              run: uv sync --group dev --extra sgwb --extra jax
 
             - name: Confirm the optional stack is present
               # Otherwise a missing extra turns the whole job into a silent no-op: every gated

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -316,8 +316,9 @@ signal:
 Two things to be aware of:
 
 - This selects a **library, not a compute device.** `ripple` is JAX-based, but
-  it runs through the same per-event path as LAL; gwmock does not yet drive
-  ripple's batched on-device entry point from a configuration file.
+  on its own it runs through the same per-event path as LAL. The batched
+  on-device entry point is selected separately, with
+  [`signal.execution`](#choosing-the-execution-mode).
 - The same approximant from two libraries agrees closely but not exactly, so the
   choice changes the data. It is recorded in the run metadata as
   `orchestration.signal.waveform_backend` for that reason.
@@ -327,6 +328,45 @@ each waveform model on first use — measured on a single 8-second segment,
 `IMRPhenomD` took ~10 s end to end against ~0.7 s for LAL, and the precessing
 `IMRPhenomXPHM` ~72 s. The cost is paid once per process, so it amortises over a
 long run.
+
+### Choosing the execution mode
+
+`signal.execution` selects **how** a segment's events are computed,
+independently of which library computes them:
+
+| Value                 | Behaviour                                                                  |
+| --------------------- | -------------------------------------------------------------------------- |
+| `per-event` (default) | Loop over the segment's events, one waveform at a time.                    |
+| `batched`             | Hand the whole segment to gwmock-signal's batched entry point in one call. |
+
+```yaml
+orchestration:
+    signal:
+        execution: batched
+        waveform-model: IMRPhenomD
+        waveform-backend: ripple
+```
+
+Batched is the **GPU-capable** path, but this key does not choose a device.
+Whether it runs on a GPU depends only on the installed JAX backend:
+
+- `pip install 'gwmock[jax]'` — batched, on the CPU.
+- `pip install 'gwmock[cuda]'` — batched, on a GPU (Linux x86_64, CUDA 12).
+
+Nothing in the output distinguishes the two and no warning is raised for the CPU
+case. Check with `python -c "import jax; print(jax.devices())"`.
+
+Two constraints. The batched path always generates with `ripple` whatever
+`waveform-backend` names — a different library is refused rather than silently
+substituted. And it refuses any signal setting it cannot apply
+(`waveform-options`, `signal.arguments`, `signal.parameters`), so a
+configuration that reaches the generator unchanged is the only one that runs.
+
+GPU and CPU results are **not** bit-identical. Measured on an RTX 2080 Ti, they
+agree to ~4e-13 of peak — a sub-sample time shift, not an accuracy difference.
+Neither is known to be more correct.
+
+See `examples/signal/execution/batched` for a runnable configuration.
 
 For SGWB studies, use `signal.source-type: sgwb`. Constructor options for the
 SGWB backend belong under `signal.arguments`, while spectrum parameters passed

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -351,7 +351,9 @@ Batched is the **GPU-capable** path, but this key does not choose a device.
 Whether it runs on a GPU depends only on the installed JAX backend:
 
 - `pip install 'gwmock[jax]'` — batched, on the CPU.
-- `pip install 'gwmock[cuda]'` — batched, on a GPU (Linux x86_64, CUDA 12).
+- `pip install 'gwmock[cuda]'` — installs the CUDA backend (Linux x86_64, CUDA
+  12); runs on a GPU when a compatible device and driver are present, and
+  silently falls back to the CPU when they are not.
 
 Nothing in the output distinguishes the two and no warning is raised for the CPU
 case. Check with `python -c "import jax; print(jax.devices())"`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,9 +37,15 @@ end.
 **By waveform library** — `signal.waveform-backend` chooses which library
 generates the polarizations: `lal` (the default), `pycbc`, `ripple`, or
 `gwsignal`. Any signal example accepts it. It names a **library, not a compute
-device** — `ripple` generates ripple waveforms through the same per-event path,
-since gwmock does not yet drive ripple's batched on-device path from a
-configuration file.
+device** — `ripple` alone still generates through the per-event path.
+
+**By execution mode** — `signal.execution` is the separate key that chooses
+_how_ a segment's events are computed: `per-event` (the default) or `batched`,
+which hands the whole segment to gwmock-signal's batched entry point in one
+call. Batched is the GPU-capable path, but whether it _runs_ on a GPU depends on
+the installed JAX backend, not on the key: `gwmock[jax]` gives batched on the
+CPU, `gwmock[cuda]` gives a GPU. Check with
+`python -c "import jax; print(jax.devices())"`.
 
 **By detector network** — every `<network>` above is one of
 `et_triangle_sardinia`, `et_triangle_emr`, `et_2l_aligned`, `et_2l_misaligned`.
@@ -73,7 +79,9 @@ A **subset** of these examples is the end-to-end matrix: the configs driven
 through the real CLI by the `e2e` test suite.
 
 Those tests are excluded from the default run — they generate data — and run in
-their own CI job with every extra installed. To run them yourself:
+their own CI job, which installs the `sgwb` and `jax` extras. `cuda` is
+deliberately left out there: the runner has no GPU, and its wheels are
+multi-gigabyte. To run them yourself:
 
 ```bash
 uv run pytest -m e2e --no-cov

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,6 +31,7 @@ end.
 | Signals **and** noise together            | `noise/uncorrelated_gaussian/quick_start`      |
 | Stochastic background                     | `signal/sgwb/<network>`                        |
 | Signals from a different waveform library | `signal/waveform_backend/ripple`               |
+| Batched generation (the GPU-capable path) | `signal/execution/batched`                     |
 | A blank starting point                    | `default_config`                               |
 
 **By waveform library** — `signal.waveform-backend` chooses which library
@@ -48,19 +49,20 @@ each is runnable without editing.
 
 ## Every example
 
-| Label                                              | Generates          | Network                       | Notes                                                              |
-| -------------------------------------------------- | ------------------ | ----------------------------- | ------------------------------------------------------------------ |
-| `default_config`                                   | noise              | Triangle Sardinia             | Commented template; single 4096 s segment                          |
-| `noise/uncorrelated_gaussian/quick_start`          | signal + noise     | Triangle Sardinia             | **Start here.** 1024 s, one BBH event                              |
-| `noise/uncorrelated_gaussian/et_triangle_sardinia` | noise              | Triangle Sardinia             | 1 day, `ET_10_full_cryo_psd`                                       |
-| `noise/uncorrelated_gaussian/et_triangle_emr`      | noise              | Triangle EMR                  | 1 day, `ET_10_full_cryo_psd`                                       |
-| `noise/uncorrelated_gaussian/et_2l_aligned`        | noise              | 2L aligned                    | 1 day, `ET_15_full_cryo_psd`                                       |
-| `noise/uncorrelated_gaussian/et_2l_misaligned`     | noise              | 2L misaligned                 | 1 day, `ET_15_full_cryo_psd`                                       |
-| `noise/glitches/gengli/<network>/<e1\|e2\|e3>`     | noise + glitches   | all four                      | One file **per detector**; blip glitches at 1/min. Needs `gengli`  |
-| `signal/bbh/<network>`                             | signal             | all four                      | `IMRPhenomXPHM`, f<sub>min</sub> 10 Hz, Earth rotation on          |
-| `signal/bns/<network>`                             | signal             | all four                      | `IMRPhenomPv2_NRTidalv2`, f<sub>min</sub> 20 Hz, Earth rotation on |
-| `signal/sgwb/<network>`                            | background + noise | Triangle Sardinia, 2L aligned | 16 s; signal written as **HDF5**, noise as GWF                     |
-| `signal/waveform_backend/ripple`                   | signal             | Triangle Sardinia             | Waveforms from **ripple** rather than LAL. Needs `gwmock[jax]`     |
+| Label                                              | Generates          | Network                       | Notes                                                                                               |
+| -------------------------------------------------- | ------------------ | ----------------------------- | --------------------------------------------------------------------------------------------------- |
+| `default_config`                                   | noise              | Triangle Sardinia             | Commented template; single 4096 s segment                                                           |
+| `noise/uncorrelated_gaussian/quick_start`          | signal + noise     | Triangle Sardinia             | **Start here.** 1024 s, one BBH event                                                               |
+| `noise/uncorrelated_gaussian/et_triangle_sardinia` | noise              | Triangle Sardinia             | 1 day, `ET_10_full_cryo_psd`                                                                        |
+| `noise/uncorrelated_gaussian/et_triangle_emr`      | noise              | Triangle EMR                  | 1 day, `ET_10_full_cryo_psd`                                                                        |
+| `noise/uncorrelated_gaussian/et_2l_aligned`        | noise              | 2L aligned                    | 1 day, `ET_15_full_cryo_psd`                                                                        |
+| `noise/uncorrelated_gaussian/et_2l_misaligned`     | noise              | 2L misaligned                 | 1 day, `ET_15_full_cryo_psd`                                                                        |
+| `noise/glitches/gengli/<network>/<e1\|e2\|e3>`     | noise + glitches   | all four                      | One file **per detector**; blip glitches at 1/min. Needs `gengli`                                   |
+| `signal/bbh/<network>`                             | signal             | all four                      | `IMRPhenomXPHM`, f<sub>min</sub> 10 Hz, Earth rotation on                                           |
+| `signal/bns/<network>`                             | signal             | all four                      | `IMRPhenomPv2_NRTidalv2`, f<sub>min</sub> 20 Hz, Earth rotation on                                  |
+| `signal/sgwb/<network>`                            | background + noise | Triangle Sardinia, 2L aligned | 16 s; signal written as **HDF5**, noise as GWF                                                      |
+| `signal/waveform_backend/ripple`                   | signal             | Triangle Sardinia             | Waveforms from **ripple** rather than LAL. Needs `gwmock[jax]`                                      |
+| `signal/execution/batched`                         | signal             | Triangle Sardinia             | A segment's events generated in one batched call. Needs `gwmock[jax]`; add `gwmock[cuda]` for a GPU |
 
 The glitch examples are per-detector rather than per-network because each
 detector draws from its own glitch population file.

--- a/examples/README.md
+++ b/examples/README.md
@@ -122,15 +122,16 @@ what guarantee the others follow. That assumption is the reason the subset is
 legitimate; if a change makes two examples take genuinely different paths, the
 matrix needs a new entry.
 
-| Label                                              | Code path it is intended to cover                                              |
-| -------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `default_config`                                   | The blank template must run unedited; noise-only, single segment               |
-| `noise/uncorrelated_gaussian/quick_start`          | Signal **and** noise in one run; CBC; GWF output                               |
-| `noise/uncorrelated_gaussian/et_triangle_sardinia` | Noise-only across **many** segments (chunking, per-segment seeds)              |
-| `signal/bbh/et_triangle_sardinia`                  | Signal-only CBC; Earth rotation; population loaded from file                   |
-| `signal/sgwb/et_triangle_sardinia`                 | `StochasticBackgroundSimulator` — a different simulator class; **HDF5** output |
-| `signal/waveform_backend/ripple`                   | A non-default waveform library resolved from config. Needs `ripplegw`          |
-| `noise/glitches/gengli/et_triangle_sardinia/e1`    | **Not run** — glitch injection, blocked on `gengli` and a local glitch fixture |
+| Label                                              | Code path it is intended to cover                                                                         |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `default_config`                                   | The blank template must run unedited; noise-only, single segment                                          |
+| `noise/uncorrelated_gaussian/quick_start`          | Signal **and** noise in one run; CBC; GWF output                                                          |
+| `noise/uncorrelated_gaussian/et_triangle_sardinia` | Noise-only across **many** segments (chunking, per-segment seeds)                                         |
+| `signal/bbh/et_triangle_sardinia`                  | Signal-only CBC; Earth rotation; population loaded from file                                              |
+| `signal/sgwb/et_triangle_sardinia`                 | `StochasticBackgroundSimulator` — a different simulator class; **HDF5** output                            |
+| `signal/waveform_backend/ripple`                   | A non-default waveform library resolved from config. Needs `ripplegw`                                     |
+| `signal/execution/batched`                         | `execution: batched` — one batched call per segment, converted back to per-event chunks. Needs `ripplegw` |
+| `noise/glitches/gengli/et_triangle_sardinia/e1`    | **Not run** — glitch injection, blocked on `gengli` and a local glitch fixture                            |
 
 Deliberately excluded, with the reason:
 

--- a/examples/signal/execution/batched/config.yaml
+++ b/examples/signal/execution/batched/config.yaml
@@ -1,0 +1,69 @@
+# Generate a segment's events together, through gwmock-signal's batched entry point.
+#
+# `execution: batched` changes HOW the waveforms are computed, not what they are. Instead of
+# looping over a segment's events one at a time, the whole segment's events are handed to
+# gwmock-signal's `simulate_cbc_batch` in one call. The chunks that come back are still
+# per-event, so gwmock's own assembler places them and per-injection provenance is unchanged.
+#
+# Otherwise identical to signal/waveform_backend/ripple -- diff the two to see only the
+# `execution` key change.
+#
+# WHAT THIS DOES AND DOES NOT GIVE YOU
+#
+# Batched is the path that CAN run on a GPU. Whether it DOES depends entirely on the JAX
+# backend present, not on this key:
+#
+#   pip install 'gwmock[jax]'    ->  batched, on the CPU
+#   pip install 'gwmock[cuda]'   ->  batched, on a GPU (Linux x86_64, CUDA 12 driver)
+#
+# Nothing in the output distinguishes the two, and no warning is raised for the CPU case.
+# Check with:  python -c "import jax; print(jax.devices())"
+#
+# CONSTRAINTS
+#
+# The batched path always generates with ripple, whatever `waveform-backend` says -- naming a
+# different library is refused rather than silently substituted. It also refuses any signal
+# setting it cannot apply (`waveform-options`, `arguments`, `parameters`), so a configuration
+# that reaches the generator unchanged is the only one that runs.
+#
+# Requires the extra:  pip install 'gwmock[jax]'   (or 'gwmock[cuda]')
+globals:
+    simulator-arguments:
+        sampling-frequency: 4096
+        duration: 4096
+        total-duration: 4096
+        # 1 Jan 2030, as the noise examples use. Chosen to contain the population's event
+        # (GPS 1577491300).
+        start-time: 1577491218
+        seed: 42
+    working-directory: .
+    output-directory: output
+    metadata-directory: metadata
+
+orchestration:
+    population:
+        backend: FilePopulationLoader
+        source-type: bbh
+        n-samples: 1
+        arguments:
+            # Pinned to a commit rather than `main`, so the input to this example cannot change
+            # under it -- the same reasoning as the ripple example it is derived from.
+            path: https://raw.githubusercontent.com/Leuven-Gravity-Institute/gwmock/9fa389516dfd8b818670b0ae4359e9be04f30e5e/examples/signal/bbh_population.csv
+    signal:
+        # The one key that separates this from signal/waveform_backend/ripple.
+        execution: batched
+        waveform-model: IMRPhenomD
+        waveform-backend: ripple
+        waveform-backend-arguments:
+            taper_fraction: 0.05
+        minimum-frequency: 20
+        earth-rotation: true
+        detectors:
+            - ET-Triangle-Sardinia
+        output:
+            output_directory: signal
+            file_name:
+                'E-{{ detectors }}_STRAIN_BBH-{{ start_time }}-{{ duration
+                }}.gwf'
+            arguments:
+                channel: '{{ detectors }}:STRAIN'

--- a/examples/signal/waveform_backend/ripple/config.yaml
+++ b/examples/signal/waveform_backend/ripple/config.yaml
@@ -4,8 +4,8 @@
 # identical to signal/bbh/et_triangle_sardinia -- diff the two to see only that key change.
 #
 # This selects a LIBRARY, not a compute device. ripple runs through the same per-event path
-# as LAL here; gwmock does not yet drive ripple's batched on-device entry point from a
-# configuration file.
+# as LAL here. To drive ripple's batched entry point instead, see
+# signal/execution/batched, which is this example plus `execution: batched`.
 #
 # Requires the extra:  pip install 'gwmock[jax]'
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,18 @@ dependencies = [
 
 [project.optional-dependencies]
 sgwb = ["gwmock-signal[sgwb]>=0.12.0"]
-# The on-device (GPU) signal path. Without this extra `SignalAdapter.simulate_segments` raises,
-# because gwmock-signal's batched entry points need JAX and ripple, which the base install omits.
+# The batched signal path. Without this extra `SignalAdapter.simulate_segments` and
+# `execution: batched` raise, because gwmock-signal's batched entry points need JAX and ripple,
+# which the base install omits.
+#
+# **This is CPU JAX.** The wheels resolved here carry no GPU backend, so `execution: batched`
+# installed this way batches the work and runs it on the CPU. That is a supported configuration --
+# it is the one the test suite exercises -- but it is not device execution, and nothing at runtime
+# distinguishes the two beyond `jax.devices()`. Use the `cuda` extra below for a GPU.
 jax = ["gwmock-signal[jax]>=0.12.0"]
+# The same path with an actual GPU backend. Linux x86_64 with a CUDA 12 driver only; there is no
+# macOS or Windows wheel, which is why this is separate from `jax` rather than folded into it.
+cuda = ["gwmock-signal[jax]>=0.12.0", "jax[cuda12]>=0.11.0"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,8 +133,8 @@ markers = [
   "unit: fast offline tests",
   # Drives an example configuration through the real CLI. Excluded from the default run via
   # `-m "not e2e"` below, because these generate data and are minutes rather than seconds; the
-  # `e2e` CI job runs them, and it installs every extra so the optional-stack entries in
-  # tests/e2e/matrix.py actually execute rather than silently skipping.
+  # `e2e` CI job runs them, and it installs the extras the matrix needs so the optional-stack
+  # entries in tests/e2e/matrix.py actually execute rather than silently skipping.
   "e2e: end-to-end tests that run an example config through the CLI",
 ]
 

--- a/tests/e2e/matrix.py
+++ b/tests/e2e/matrix.py
@@ -68,6 +68,16 @@ E2E_MATRIX: tuple[MatrixEntry, ...] = (
         requires=("ripplegw",),
     ),
     MatrixEntry(
+        label="signal/execution/batched",
+        covers=(
+            "`execution: batched` -- a segment's events generated in one call through "
+            "gwmock-signal's batched entry point, then converted back to per-event chunks. "
+            "Runs on whatever JAX backend is present, so this entry is CPU here; measured on an "
+            "RTX 2080 Ti, GPU and CPU agree far inside the gate. Needs `ripplegw`"
+        ),
+        requires=("ripplegw",),
+    ),
+    MatrixEntry(
         label="noise/glitches/gengli/et_triangle_sardinia/e1",
         covers="**Not run** -- glitch injection, blocked on `gengli` and a local glitch fixture",
         requires=("gengli",),

--- a/tests/e2e/overlay.py
+++ b/tests/e2e/overlay.py
@@ -123,6 +123,20 @@ _OVERLAYS: dict[str, dict[str, Any]] = {
         },
         "orchestration": {"population": {"arguments": {"path": str(POPULATION_FIXTURE)}}},
     },
+    # Deliberately the same overlay as the ripple entry above: the two configs differ only by
+    # `execution`, and holding the span, rate and population identical is what makes their stored
+    # references comparable. The batched path JIT-compiles like the per-event ripple one.
+    "signal/execution/batched": {
+        "globals": {
+            "simulator-arguments": {
+                "sampling-frequency": 1024,
+                "duration": 16,
+                "total-duration": 16,
+                "start-time": _ALIGNED_START,
+            }
+        },
+        "orchestration": {"population": {"arguments": {"path": str(POPULATION_FIXTURE)}}},
+    },
 }
 
 #: Entries whose span is expected to contain a gravitational-wave signal, so an all-zero output
@@ -133,6 +147,7 @@ CONTAINS_SIGNAL: frozenset[str] = frozenset(
         "noise/uncorrelated_gaussian/quick_start",
         "signal/bbh/et_triangle_sardinia",
         "signal/waveform_backend/ripple",
+        "signal/execution/batched",
     }
 )
 

--- a/tests/e2e/references/signal__execution__batched.json
+++ b/tests/e2e/references/signal__execution__batched.json
@@ -1,0 +1,51 @@
+{
+  "environment": {
+    "gwmock": "0.12.0.post17+1e40c74",
+    "gwmock-noise": "0.10.0",
+    "gwmock-pop": "0.11.4",
+    "gwmock-signal": "0.12.0",
+    "jax": "0.11.0",
+    "lalsuite": "7.26.15",
+    "numpy": "2.5.1",
+    "ripplegw": "0.3.0",
+    "scipy": "1.18.0"
+  },
+  "fingerprint": {
+    "machine": "x86_64",
+    "python": "3.12",
+    "system": "Linux"
+  },
+  "label": "signal/execution/batched",
+  "outputs": {
+    "output/signal/E-ET1_SARD_STRAIN_BBH-1577491296-16.gwf": {
+      "argmax": 4076,
+      "content_hash": "sha256:26feca19ccdc28f3d75b7cf1fad760a4b984400611cffd609a1cd4a46e6345b8",
+      "mean": 6.162626140627517e-29,
+      "n": 16384,
+      "nonzero": 4557,
+      "peak": 8.37155992267342e-22,
+      "rms": 5.450588182388899e-23,
+      "signed_peak": -8.37155992267342e-22
+    },
+    "output/signal/E-ET2_SARD_STRAIN_BBH-1577491296-16.gwf": {
+      "argmax": 4077,
+      "content_hash": "sha256:5bf0af886545494e1b3f55d0c78d2da61cc0a20c08ef499afa9f1936625b820b",
+      "mean": 3.899884972437172e-29,
+      "n": 16384,
+      "nonzero": 4557,
+      "peak": 8.88996420670017e-22,
+      "rms": 5.515358197316947e-23,
+      "signed_peak": 8.88996420670017e-22
+    },
+    "output/signal/E-ET3_SARD_STRAIN_BBH-1577491296-16.gwf": {
+      "argmax": 4078,
+      "content_hash": "sha256:22193c03be81b01630841b95cbd0676282eb018e2e14b3f6e818f50f7deb9a7f",
+      "mean": -1.008862385299467e-28,
+      "n": 16384,
+      "nonzero": 4557,
+      "peak": 8.291569211105587e-22,
+      "rms": 5.23765677059786e-23,
+      "signed_peak": -8.291569211105587e-22
+    }
+  }
+}

--- a/tests/e2e/test_examples_end_to_end.py
+++ b/tests/e2e/test_examples_end_to_end.py
@@ -5,7 +5,8 @@ configuration -- shortened by :mod:`tests.e2e.overlay`, never edited in place --
 run completed and wrote data of the expected shape.
 
 Marked ``e2e`` and therefore excluded from the default run: they generate data and take seconds
-to minutes each. The ``e2e`` CI job runs them with every extra installed.
+to minutes each. The ``e2e`` CI job runs them with the ``sgwb`` and ``jax`` extras installed (not ``cuda``:
+the runner has no GPU).
 
 Scope of what is checked here is deliberately structural. Whether the output *matches a stored
 reference* comes later, and depends on first establishing that each path is reproducible at all.

--- a/uv.lock
+++ b/uv.lock
@@ -664,6 +664,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+cuda = [
+    { name = "gwmock-signal", extra = ["jax"] },
+    { name = "jax", extra = ["cuda12"] },
+]
 jax = [
     { name = "gwmock-signal", extra = ["jax"] },
 ]
@@ -697,9 +701,11 @@ requires-dist = [
     { name = "gwmock-noise", specifier = ">=0.10.0" },
     { name = "gwmock-pop", specifier = ">=0.11.4" },
     { name = "gwmock-signal", specifier = ">=0.12.0" },
+    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'cuda'", specifier = ">=0.12.0" },
     { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'jax'", specifier = ">=0.12.0" },
     { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", specifier = ">=0.12.0" },
     { name = "h5py", specifier = ">=3.12.1" },
+    { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda'", specifier = ">=0.11.0" },
     { name = "psutil", specifier = ">=6.1.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
     { name = "pymap3d", specifier = ">=3.2.0" },
@@ -707,7 +713,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67.0" },
     { name = "typer", specifier = ">=0.19.0" },
 ]
-provides-extras = ["jax", "sgwb"]
+provides-extras = ["cuda", "jax", "sgwb"]
 
 [package.metadata.requires-dev]
 build = [{ name = "hatch", specifier = ">=1.17.1" }]
@@ -1099,6 +1105,55 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/20/90a137c178de8f2b9170bd4dfb934e261213fdaac67e5c5183b132be85e7/jax-0.11.0.tar.gz", hash = "sha256:a2feb7cfa48bb35d36b8ecec16a4ec24044dec01935f779b28b017213697b195", size = 2813185, upload-time = "2026-07-16T19:00:14.519Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/5a/26a1305f8978bc41f889a4172198c7d8976e8e394fc4d03597d9edfd6b7e/jax-0.11.0-py3-none-any.whl", hash = "sha256:b31ed66c4321d5c9e48b861f51a72ed5f7960c93514296202d2041cbb9ac45bf", size = 3255281, upload-time = "2026-07-16T18:58:25.02Z" },
+]
+
+[package.optional-dependencies]
+cuda12 = [
+    { name = "jax-cuda12-plugin", extra = ["with-cuda"] },
+    { name = "jaxlib" },
+]
+
+[[package]]
+name = "jax-cuda12-pjrt"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/f5/d3c0db11be08d5180d4634327e996597ef7847fcfa0c5e53282dd9256485/jax_cuda12_pjrt-0.11.0-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:67ec5915e7e494775d5dc0d73d1e33cb74a47b6a6bb1089eef7b517e4e873e33", size = 170618370, upload-time = "2026-07-16T18:58:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/73/dfe1781a2f752dbb25bd7abcc0f5a7ed74f7df3c78c4d53db32a591b01cd/jax_cuda12_pjrt-0.11.0-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:242df99c90827a2937df1c444983d4076173f9836dc0bc1d20df86960144f35a", size = 175803444, upload-time = "2026-07-16T18:58:35.744Z" },
+]
+
+[[package]]
+name = "jax-cuda12-plugin"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax-cuda12-pjrt" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/5d35d4e3ac48e3976a07616dcb82403ec05d91fb764da4306c83cd980169/jax_cuda12_plugin-0.11.0-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:3e95cb9deac2988e15226c6d8927e72bffc841505d236231e4843a8b16679f25", size = 8209123, upload-time = "2026-07-16T18:58:39.248Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ba/c6a2168852154cb32aa7021074f8b849407a99bb5b7f88fe35d34cfa43c8/jax_cuda12_plugin-0.11.0-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:31ffe245d0e2fd1cf4ee57254ffc4c88505bb8e7f5eb7f6b3a37d691d736650a", size = 8229603, upload-time = "2026-07-16T18:58:41.37Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0e/fff3d0eaf710b8dd3b76b3f177b0d26ff8cfed493b4d3bedd9ccdb8b687b/jax_cuda12_plugin-0.11.0-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:ef103b35364795708c4a4380376d8d73fc3d487356a7037fcf20cab735fb59a6", size = 8208891, upload-time = "2026-07-16T18:58:42.877Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/36/fb9714a8c71cf33c114ab7ca22426c615516cf1532744b7224019e4a45d3/jax_cuda12_plugin-0.11.0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:b6f706d6c10fe9bfafe0334c5d52e40e6e99f343c24d8e74f045ac67b7f7ace2", size = 8230117, upload-time = "2026-07-16T18:58:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/38/bf/935faeaa1834a31ef4324a55288bc3cf547dc90c4f24e578361e269950f5/jax_cuda12_plugin-0.11.0-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:2f8dcc6ff34833158251b52b711a3b5c73785ec364771294bc3827aaaea75450", size = 8209555, upload-time = "2026-07-16T18:58:46.313Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2a/af0001e6b8e59792ace3f0c1d11e1fb81a278f57cf2d0aeb4b2e8c7a15ca/jax_cuda12_plugin-0.11.0-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:4b6b060fe73ffde206e62c2637079618c34c2b4b74be5cb0371b22a43a907c4a", size = 8230380, upload-time = "2026-07-16T18:58:48.081Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/46/e21fc196562672d45f0d0166d8d34f73001badd48a29c9a2be883270739d/jax_cuda12_plugin-0.11.0-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:1dd78abc57481d542876ff7d1a2c460bee7d8b191059617a0cb2c5fb4b191630", size = 8223073, upload-time = "2026-07-16T18:58:49.605Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/90/bade91ca305f3bc7b9e2cc67715978cc3a8a4d428d170fc1656815575c53/jax_cuda12_plugin-0.11.0-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:fbd22d6bbfa636f22bf27e4a3d6ca3e9424b7fcb7f5ccae698634a3ea5b6a242", size = 8239448, upload-time = "2026-07-16T18:58:51.71Z" },
+]
+
+[package.optional-dependencies]
+with-cuda = [
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1687,6 +1742,143 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
     { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
     { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.9.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/a2/c96163a0fff1839c0c9548bbdeae7b853b867009e33b9b9264adc238b1cf/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:5572131a59c3eebeeb1c4c8144f772d49372c20124916e072a0e3fc30df421d5", size = 575012079, upload-time = "2026-04-08T18:51:47.303Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c0/0a517bfe63ccd3b92eb254d264e28fca3c7cab75d07daea315250fb1bf73/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e4f53a8ca8c5d6e8c492d0d0a3d565ecb59a751b19cfdaa4f6da0ab2104c1702", size = 581240110, upload-time = "2026-04-08T18:52:31.532Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cccl-cu12"
+version = "12.9.27"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/7e/82e49956b046bdc506c789235c587d9b3ef58b8bc1782258c1e247229647/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7898b38aa68beaa234d48f0868273702342a196d6e2e9d0ef058dca2390ebea", size = 3152245, upload-time = "2025-05-01T19:32:04.802Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2a/d4cd8506d2044e082f8cd921be57392e6a9b5ccd3ffdf050362430a3d5d5/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37869e17ce2e1ecec6eddf1927cca0f8c34e64fd848d40453df559091e2d7117", size = 3152243, upload-time = "2025-05-01T19:32:13.955Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.9.79"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/78/351b5c8cdbd9a6b4fb0d6ee73fb176dcdc1b6b6ad47c2ffff5ae8ca4a1f7/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:791853b030602c6a11d08b5578edfb957cadea06e9d3b26adbf8d036135a4afe", size = 10077166, upload-time = "2025-06-05T20:01:01.385Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/2e/b84e32197e33f39907b455b83395a017e697c07a449a2b15fd07fc1c9981/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:096bcf334f13e1984ba36685ad4c1d6347db214de03dbb6eebb237b41d9d934f", size = 10814997, upload-time = "2025-06-05T20:01:10.168Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvcc-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/48/b54a06168a2190572a312bfe4ce443687773eb61367ced31e064953dd2f7/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:5d6a0d32fdc7ea39917c20065614ae93add6f577d840233237ff08e9a38f58f0", size = 40546229, upload-time = "2025-06-05T20:01:53.357Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/8cc072436787104bbbcbde1f76ab4a0d89e68f7cebc758dd2ad7913a43d0/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:44e1eca4d08926193a558d2434b1bf83d57b4d5743e0c431c0c83d51da1df62b", size = 39411138, upload-time = "2025-06-05T20:01:43.182Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
+    { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.9.79"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e0/0279bd94539fda525e0c8538db29b72a5a8495b0c12173113471d28bce78/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83469a846206f2a733db0c42e223589ab62fd2fabac4432d2f8802de4bded0a4", size = 3515012, upload-time = "2025-06-05T20:00:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3", size = 3493179, upload-time = "2025-06-05T20:00:53.735Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.24.0.43"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/f1/cd42563325fa827f54ff30da05686c747652bdbd4cb5654cea54d7d0ad4f/nvidia_cudnn_cu12-9.24.0.43-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:a42996943f0cd78ddfd61c8bf59361672a19b63e0491aa22a53d6fe63a3f854a", size = 856490582, upload-time = "2026-07-02T16:21:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/10/13/b8887c869cf2471339a24b60d3c28e761facbb534935f572b61423371abb/nvidia_cudnn_cu12-9.24.0.43-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:f424192dd85e7d29f44be18df2dae4c80d32c67a29c0d42f5c283c40cfdf871c", size = 799083985, upload-time = "2026-07-02T16:25:37.467Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.4.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/2b/76445b0af890da61b501fde30650a1a4bd910607261b209cccb5235d3daa/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf", size = 200822453, upload-time = "2025-06-05T20:05:27.889Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28", size = 200877592, upload-time = "2025-06-05T20:05:45.862Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.5.82"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/99/686ff9bf3a82a531c62b1a5c614476e8dfa24a9d89067aeedf3592ee4538/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:62efa83e4ace59a4c734d052bb72158e888aa7b770e1a5f601682f16fe5b4fd2", size = 337869834, upload-time = "2025-06-05T20:06:53.125Z" },
+    { url = "https://files.pythonhosted.org/packages/33/40/79b0c64d44d6c166c0964ec1d803d067f4a145cca23e23925fd351d0e642/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:15da72d1340d29b5b3cf3fd100e3cd53421dde36002eda6ed93811af63c40d88", size = 338117415, upload-time = "2025-06-05T20:07:16.809Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.10.65"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/6f/8710fbd17cdd1d0fc3fea7d36d5b65ce1933611c31e1861da330206b253a/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:221c73e7482dd93eda44e65ce567c031c07e2f93f6fa0ecd3ba876a195023e83", size = 366359408, upload-time = "2025-06-05T20:07:42.501Z" },
+    { url = "https://files.pythonhosted.org/packages/12/46/b0fd4b04f86577921feb97d8e2cf028afe04f614d17fb5013de9282c9216/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:73060ce019ac064a057267c585bf1fd5a353734151f87472ff02b2c5c9984e78", size = 366465088, upload-time = "2025-06-05T20:08:20.413Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.30.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/8c/554bb020501d6c04ad8127d83f728137f8f9123f991666efbdcf9095a221/nvidia_nccl_cu12-2.30.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:03ecd776fd1d58fd2c9a0a687dcf8db9ecd0057382dba646fa3d65786d4a9ea1", size = 303277471, upload-time = "2026-06-09T03:24:16.327Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/e7ffa9c324ae260e5dbb4af2cd557bf7a8d155c8ac7b79a785fe1796fb92/nvidia_nccl_cu12-2.30.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:8ce1b8213f61f2bfac132e6df890af6450b77cbd140c6ce4e98cb0c2d8e678c9", size = 303361239, upload-time = "2026-06-09T03:24:53.816Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9", size = 39748338, upload-time = "2025-06-05T20:10:25.613Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bc/2dcba8e70cf3115b400fef54f213bcd6715a3195eba000f8330f11e40c45/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca", size = 39514880, upload-time = "2025-06-05T20:10:04.89Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-cccl-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/a1/9ca9cc3338217311cee21f7ba795dad4f38b7a279a6da7d3d549258f60b1/nvidia_nvshmem_cu12-3.7.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:98495de30994f1401a12cc8158ffacbeada44579f54185d75665381468056faa", size = 229963056, upload-time = "2026-07-17T19:23:44.067Z" },
+    { url = "https://files.pythonhosted.org/packages/63/03/cde130e3ff706784f9efd47204f299b15113ea08203e98a556603dac245d/nvidia_nvshmem_cu12-3.7.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02b6d3482d90ea8ba214bc400362297f573257763990a98c9846ec5c786a7227", size = 230171132, upload-time = "2026-07-17T19:25:07.092Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 📝 Summary

The batched path could run on a GPU, but nothing a user installs or reads would get them there, and the e2e gate did not cover it. Four related gaps.

### `[jax]` said GPU and delivered CPU

The extra was commented as *"the on-device (GPU) signal path"*, but it resolves CPU-only wheels: `jax.default_backend()` returns `cpu` and `jax-cuda12-plugin` is absent. Installing it and setting `execution: batched` gives batched execution **on the CPU**, with nothing at runtime saying so.

The comment now states that plainly, and a new **`cuda` extra** adds `jax[cuda12]`. Kept separate rather than folded into `jax` because the CUDA wheels are Linux x86_64 only.

Verified on real hardware rather than by reading the lockfile: `uv sync --extra cuda` on an RTX 2080 Ti node installs `jax-cuda12-plugin` and `jax-cuda12-pjrt`, and JAX then reports `backend: gpu`, `devices: [CudaDevice(id=0)]`.

### No example selected the batched path

`grep -rn "execution" examples/` returned nothing, so the single config key that reaches the device path was undiscoverable from the examples. `signal/execution/batched` is the ripple example plus `execution: batched` — diff the two and the key is the only change.

Run end to end at 1024 Hz over 128 s: three ET frames, 4608 non-zero samples each, peak 8.4e-22.

### Adding `cuda` would have quietly slowed CI

The e2e job synced `--all-extras`, so a `cuda` extra would have pulled multi-gigabyte CUDA wheels onto a runner with no GPU on every run. It now names `sgwb` and `jax` explicitly. The cost is that a future extra must be added to that line deliberately, which the comment says.

### The batched path was not in the e2e matrix

Every execution path was gated except this one, so an orchestration regression here would have escaped the gate built for exactly that. The new entry reuses the ripple entry's overlay — same span, rate and population — so the two configs differ only by `execution` and their references are comparable.

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** 940 passed, 23 skipped; e2e 41 passed (up from 35), 9 skipped.
- [x] **Manual Test:** the batched example run end to end on CPU, output checked for real signal rather than exit status — an early run wrote all zeros because a shortened window excluded the event, which is what a broken example also looks like.
- [x] **Manual Test:** `[cuda]` verified on an actual GPU (HTCondor, `stadius-nc-5`, RTX 2080 Ti, driver 580.159.04). **First time gwmock's device path has executed on a GPU** — every prior measurement was CPU JAX.
- [x] **Manual Test:** GPU/CPU agreement measured before adding the e2e entry, to confirm one entry can gate both.

## Can one reference gate both devices? Yes, measured

Raw-sample agreement was not sufficient to answer this, because the gate matches `n`, `nonzero` and `argmax` **exactly**:

| gated statistic | GPU vs CPU |
| --- | --- |
| `n`, `nonzero`, `argmax` | **exact match** on all three channels |
| `peak`, `rms`, `signed_peak` | worst divergence **8.99e-14** against a 1e-6 tolerance |

`argmax` landed on the same sample (83948 / 83949 / 83950), so the peak is not near a tie. The entry therefore passes on either backend with no tolerance change.

Stating the limitation honestly: a 10⁷ margin means the gate certifies *same physics*, not *same bits*. It cannot detect a GPU/CPU divergence, and is not intended to.

## Why the two devices differ at all

Investigated to a conclusion rather than waved at, because "floating point" is not an answer. Full write-up with all five refuted hypotheses is in the workspace at `_investigations/software/gwmock/2026-08-01-gpu-cpu-batched-discrepancy.md`.

The difference originates in **ripple's frequency-domain waveform generation**, not the FFT, the projection, or gwmock's own code. With byte-identical input, every downstream stage sits at eps level — production inverse-FFT kernel 1.8 eps, static projection 1.1, rotating projection 21.2 — against 1422 eps end-to-end. Ripple's FD phase differs by 3840 eps while its magnitude differs by 26, a 150:1 split.

Its character is a **global time shift of −2.32e-16 s**, which is 1.05 ulp of a seconds-scale internal quantity and explains **95.9%** of the phase-difference variance. That is 2.4e-13 of one sample: the same waveform, imperceptibly translated. Benign.

**Not established:** which backend is more accurate. CPU `irfft` is bit-identical to `numpy.fft.irfft` and GPU is not, but that plausibly reflects a shared implementation rather than accuracy; settling it needs a higher-precision reference that was not run.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [ ] 🎨 Refactoring

No generated data changes, so existing e2e references are untouched; the only new reference is the new entry's.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Also corrected

The ripple example still claimed gwmock *"does not yet drive ripple's batched on-device entry point from a configuration file."* It has since #295.

## Not in this PR

Per-PR GPU regression testing. GitHub-hosted GPU runners are larger runners, which are always billed and unavailable on this org's free plan; a self-hosted runner is possible but GitHub explicitly advises against self-hosted runners on public repositories, since a fork's pull request can execute arbitrary code on the machine. GPU verification stays manual via HTCondor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a batched signal-execution example supporting CPU and GPU workflows with Ripple waveforms and ET detector output.
  * Added optional dependency configurations for CPU-based JAX and CUDA 12 GPU support.

* **Documentation**
  * Documented batched execution setup, requirements, behavior, and supported hardware.
  * Clarified Ripple backend usage and updated example guidance.

* **Tests**
  * Added end-to-end coverage and reference validation for batched signal generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->