### PR TITLE
test(e2e): pin which bundled ET presets the device path can run

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -47,13 +47,24 @@ the installed JAX backend, not on the key: `gwmock[jax]` gives batched on the
 CPU, `gwmock[cuda]` gives a GPU. Check with
 `python -c "import jax; print(jax.devices())"`.
 
-**Not every preset can use it.** The batched path always generates with ripple,
-so a configuration naming an approximant ripple lacks is refused rather than
-served with a substitute. Verified on an RTX 2080 Ti on 2026-08-01: the four
-`signal/bbh/<network>` presets run on device (`IMRPhenomXPHM`, ~100 s to compile
-once, then cached across networks), while the four `signal/bns/<network>`
-presets cannot — `IMRPhenomPv2_NRTidalv2` is precessing _and_ tidal, a
-combination ripple does not implement.
+**Not every preset can use it.** None of the presets set `execution` — they all
+default to per-event — but if you add `execution: batched` to one, whether it
+works depends on its approximant, because the batched path only ever generates
+with ripple. A configuration naming an approximant ripple lacks is refused
+rather than served with a substitute.
+
+Measured on an RTX 2080 Ti on 2026-08-01, by adding the key to each preset: the
+four `signal/bbh/<network>` presets generated (`IMRPhenomXPHM`), while the four
+`signal/bns/<network>` presets were refused — `IMRPhenomPv2_NRTidalv2` is
+precessing _and_ tidal, a combination ripple does not implement. That run used a
+shortened 128 s span at 1024 Hz; it shows the approximant and the ET detector
+networks are usable on device, **not** that the shipped 4096 s, 4096 Hz, one-day
+configurations fit in GPU memory.
+
+`IMRPhenomXPHM` compiled once in ~100 s and then served the other three networks
+from cache. That caching holds for a fixed approximant, backend options and
+traced shapes; changing the sample rate or segment length can force another
+compile.
 
 **By detector network** — every `<network>` above is one of
 `et_triangle_sardinia`, `et_triangle_emr`, `et_2l_aligned`, `et_2l_misaligned`.
@@ -63,20 +74,20 @@ each is runnable without editing.
 
 ## Every example
 
-| Label                                              | Generates          | Network                       | Notes                                                                                                                  |
-| -------------------------------------------------- | ------------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `default_config`                                   | noise              | Triangle Sardinia             | Commented template; single 4096 s segment                                                                              |
-| `noise/uncorrelated_gaussian/quick_start`          | signal + noise     | Triangle Sardinia             | **Start here.** 1024 s, one BBH event                                                                                  |
-| `noise/uncorrelated_gaussian/et_triangle_sardinia` | noise              | Triangle Sardinia             | 1 day, `ET_10_full_cryo_psd`                                                                                           |
-| `noise/uncorrelated_gaussian/et_triangle_emr`      | noise              | Triangle EMR                  | 1 day, `ET_10_full_cryo_psd`                                                                                           |
-| `noise/uncorrelated_gaussian/et_2l_aligned`        | noise              | 2L aligned                    | 1 day, `ET_15_full_cryo_psd`                                                                                           |
-| `noise/uncorrelated_gaussian/et_2l_misaligned`     | noise              | 2L misaligned                 | 1 day, `ET_15_full_cryo_psd`                                                                                           |
-| `noise/glitches/gengli/<network>/<e1\|e2\|e3>`     | noise + glitches   | all four                      | One file **per detector**; blip glitches at 1/min. Needs `gengli`                                                      |
-| `signal/bbh/<network>`                             | signal             | all four                      | `IMRPhenomXPHM`, f<sub>min</sub> 10 Hz, Earth rotation on                                                              |
-| `signal/bns/<network>`                             | signal             | all four                      | `IMRPhenomPv2_NRTidalv2`, f<sub>min</sub> 20 Hz, Earth rotation on. **Per-event only** — ripple lacks this approximant |
-| `signal/sgwb/<network>`                            | background + noise | Triangle Sardinia, 2L aligned | 16 s; signal written as **HDF5**, noise as GWF                                                                         |
-| `signal/waveform_backend/ripple`                   | signal             | Triangle Sardinia             | Waveforms from **ripple** rather than LAL. Needs `gwmock[jax]`                                                         |
-| `signal/execution/batched`                         | signal             | Triangle Sardinia             | A segment's events generated in one batched call. Needs `gwmock[jax]`; add `gwmock[cuda]` for a GPU                    |
+| Label                                              | Generates          | Network                       | Notes                                                                                                                               |
+| -------------------------------------------------- | ------------------ | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `default_config`                                   | noise              | Triangle Sardinia             | Commented template; single 4096 s segment                                                                                           |
+| `noise/uncorrelated_gaussian/quick_start`          | signal + noise     | Triangle Sardinia             | **Start here.** 1024 s, one BBH event                                                                                               |
+| `noise/uncorrelated_gaussian/et_triangle_sardinia` | noise              | Triangle Sardinia             | 1 day, `ET_10_full_cryo_psd`                                                                                                        |
+| `noise/uncorrelated_gaussian/et_triangle_emr`      | noise              | Triangle EMR                  | 1 day, `ET_10_full_cryo_psd`                                                                                                        |
+| `noise/uncorrelated_gaussian/et_2l_aligned`        | noise              | 2L aligned                    | 1 day, `ET_15_full_cryo_psd`                                                                                                        |
+| `noise/uncorrelated_gaussian/et_2l_misaligned`     | noise              | 2L misaligned                 | 1 day, `ET_15_full_cryo_psd`                                                                                                        |
+| `noise/glitches/gengli/<network>/<e1\|e2\|e3>`     | noise + glitches   | all four                      | One file **per detector**; blip glitches at 1/min. Needs `gengli`                                                                   |
+| `signal/bbh/<network>`                             | signal             | all four                      | `IMRPhenomXPHM`, f<sub>min</sub> 10 Hz, Earth rotation on                                                                           |
+| `signal/bns/<network>`                             | signal             | all four                      | `IMRPhenomPv2_NRTidalv2`, f<sub>min</sub> 20 Hz, Earth rotation on. Cannot use `execution: batched` — ripple lacks this approximant |
+| `signal/sgwb/<network>`                            | background + noise | Triangle Sardinia, 2L aligned | 16 s; signal written as **HDF5**, noise as GWF                                                                                      |
+| `signal/waveform_backend/ripple`                   | signal             | Triangle Sardinia             | Waveforms from **ripple** rather than LAL. Needs `gwmock[jax]`                                                                      |
+| `signal/execution/batched`                         | signal             | Triangle Sardinia             | A segment's events generated in one batched call. Needs `gwmock[jax]`; add `gwmock[cuda]` for a GPU                                 |
 
 The glitch examples are per-detector rather than per-network because each
 detector draws from its own glitch population file.

--- a/examples/README.md
+++ b/examples/README.md
@@ -47,6 +47,14 @@ the installed JAX backend, not on the key: `gwmock[jax]` gives batched on the
 CPU, `gwmock[cuda]` gives a GPU. Check with
 `python -c "import jax; print(jax.devices())"`.
 
+**Not every preset can use it.** The batched path always generates with ripple,
+so a configuration naming an approximant ripple lacks is refused rather than
+served with a substitute. Verified on an RTX 2080 Ti on 2026-08-01: the four
+`signal/bbh/<network>` presets run on device (`IMRPhenomXPHM`, ~100 s to compile
+once, then cached across networks), while the four `signal/bns/<network>`
+presets cannot — `IMRPhenomPv2_NRTidalv2` is precessing _and_ tidal, a
+combination ripple does not implement.
+
 **By detector network** — every `<network>` above is one of
 `et_triangle_sardinia`, `et_triangle_emr`, `et_2l_aligned`, `et_2l_misaligned`.
 These differ **only** in the `detectors:` entry, so you can equally take any
@@ -55,20 +63,20 @@ each is runnable without editing.
 
 ## Every example
 
-| Label                                              | Generates          | Network                       | Notes                                                                                               |
-| -------------------------------------------------- | ------------------ | ----------------------------- | --------------------------------------------------------------------------------------------------- |
-| `default_config`                                   | noise              | Triangle Sardinia             | Commented template; single 4096 s segment                                                           |
-| `noise/uncorrelated_gaussian/quick_start`          | signal + noise     | Triangle Sardinia             | **Start here.** 1024 s, one BBH event                                                               |
-| `noise/uncorrelated_gaussian/et_triangle_sardinia` | noise              | Triangle Sardinia             | 1 day, `ET_10_full_cryo_psd`                                                                        |
-| `noise/uncorrelated_gaussian/et_triangle_emr`      | noise              | Triangle EMR                  | 1 day, `ET_10_full_cryo_psd`                                                                        |
-| `noise/uncorrelated_gaussian/et_2l_aligned`        | noise              | 2L aligned                    | 1 day, `ET_15_full_cryo_psd`                                                                        |
-| `noise/uncorrelated_gaussian/et_2l_misaligned`     | noise              | 2L misaligned                 | 1 day, `ET_15_full_cryo_psd`                                                                        |
-| `noise/glitches/gengli/<network>/<e1\|e2\|e3>`     | noise + glitches   | all four                      | One file **per detector**; blip glitches at 1/min. Needs `gengli`                                   |
-| `signal/bbh/<network>`                             | signal             | all four                      | `IMRPhenomXPHM`, f<sub>min</sub> 10 Hz, Earth rotation on                                           |
-| `signal/bns/<network>`                             | signal             | all four                      | `IMRPhenomPv2_NRTidalv2`, f<sub>min</sub> 20 Hz, Earth rotation on                                  |
-| `signal/sgwb/<network>`                            | background + noise | Triangle Sardinia, 2L aligned | 16 s; signal written as **HDF5**, noise as GWF                                                      |
-| `signal/waveform_backend/ripple`                   | signal             | Triangle Sardinia             | Waveforms from **ripple** rather than LAL. Needs `gwmock[jax]`                                      |
-| `signal/execution/batched`                         | signal             | Triangle Sardinia             | A segment's events generated in one batched call. Needs `gwmock[jax]`; add `gwmock[cuda]` for a GPU |
+| Label                                              | Generates          | Network                       | Notes                                                                                                                  |
+| -------------------------------------------------- | ------------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `default_config`                                   | noise              | Triangle Sardinia             | Commented template; single 4096 s segment                                                                              |
+| `noise/uncorrelated_gaussian/quick_start`          | signal + noise     | Triangle Sardinia             | **Start here.** 1024 s, one BBH event                                                                                  |
+| `noise/uncorrelated_gaussian/et_triangle_sardinia` | noise              | Triangle Sardinia             | 1 day, `ET_10_full_cryo_psd`                                                                                           |
+| `noise/uncorrelated_gaussian/et_triangle_emr`      | noise              | Triangle EMR                  | 1 day, `ET_10_full_cryo_psd`                                                                                           |
+| `noise/uncorrelated_gaussian/et_2l_aligned`        | noise              | 2L aligned                    | 1 day, `ET_15_full_cryo_psd`                                                                                           |
+| `noise/uncorrelated_gaussian/et_2l_misaligned`     | noise              | 2L misaligned                 | 1 day, `ET_15_full_cryo_psd`                                                                                           |
+| `noise/glitches/gengli/<network>/<e1\|e2\|e3>`     | noise + glitches   | all four                      | One file **per detector**; blip glitches at 1/min. Needs `gengli`                                                      |
+| `signal/bbh/<network>`                             | signal             | all four                      | `IMRPhenomXPHM`, f<sub>min</sub> 10 Hz, Earth rotation on                                                              |
+| `signal/bns/<network>`                             | signal             | all four                      | `IMRPhenomPv2_NRTidalv2`, f<sub>min</sub> 20 Hz, Earth rotation on. **Per-event only** — ripple lacks this approximant |
+| `signal/sgwb/<network>`                            | background + noise | Triangle Sardinia, 2L aligned | 16 s; signal written as **HDF5**, noise as GWF                                                                         |
+| `signal/waveform_backend/ripple`                   | signal             | Triangle Sardinia             | Waveforms from **ripple** rather than LAL. Needs `gwmock[jax]`                                                         |
+| `signal/execution/batched`                         | signal             | Triangle Sardinia             | A segment's events generated in one batched call. Needs `gwmock[jax]`; add `gwmock[cuda]` for a GPU                    |
 
 The glitch examples are per-detector rather than per-network because each
 detector draws from its own glitch population file.

--- a/examples/README.md
+++ b/examples/README.md
@@ -47,11 +47,11 @@ the installed JAX backend, not on the key: `gwmock[jax]` gives batched on the
 CPU, `gwmock[cuda]` gives a GPU. Check with
 `python -c "import jax; print(jax.devices())"`.
 
-**Not every preset can use it.** None of the presets set `execution` — they all
-default to per-event — but if you add `execution: batched` to one, whether it
-works depends on its approximant, because the batched path only ever generates
-with ripple. A configuration naming an approximant ripple lacks is refused
-rather than served with a substitute.
+**Not every preset can use it.** Apart from `signal/execution/batched` itself,
+the presets leave `execution` unset and so default to per-event — but if you add
+`execution: batched` to one, whether it works depends on its approximant,
+because the batched path only ever generates with ripple. A configuration naming
+an approximant ripple lacks is refused rather than served with a substitute.
 
 Measured on an RTX 2080 Ti on 2026-08-01, by adding the key to each preset: the
 four `signal/bbh/<network>` presets generated (`IMRPhenomXPHM`), while the four

--- a/examples/signal/bns/et_2l_aligned/config.yaml
+++ b/examples/signal/bns/et_2l_aligned/config.yaml
@@ -3,9 +3,13 @@
 # NOTE: this preset cannot use `execution: batched`. It generates with
 # `IMRPhenomPv2_NRTidalv2`, which is precessing *and* tidal; ripple — the only library the
 # batched path generates with — implements precessing models and tidal models, but not that
-# combination. Selecting `execution: batched` here is refused outright rather than silently
-# served with a different approximant. Use the default per-event path, which uses LAL.
-# Verified against ripple 0.3.0 on 2026-08-01.
+# combination. Adding `execution: batched` here is refused outright rather than silently
+# served with a different approximant, so the failure is loud. Leave it on the default
+# per-event path, which this file already uses.
+#
+# Provenance for that claim: ripple 0.3.0, checked 2026-08-01. It is not left to this comment
+# to stay true — `tests/e2e/test_examples_index.py` fails if ripple ever gains the
+# approximant, which is when this note needs rewriting.
 globals:
     simulator-arguments:
         sampling-frequency: 4096

--- a/examples/signal/bns/et_2l_aligned/config.yaml
+++ b/examples/signal/bns/et_2l_aligned/config.yaml
@@ -1,3 +1,11 @@
+# Binary-neutron-star signals for an ET network.
+#
+# NOTE: this preset cannot use `execution: batched`. It generates with
+# `IMRPhenomPv2_NRTidalv2`, which is precessing *and* tidal; ripple — the only library the
+# batched path generates with — implements precessing models and tidal models, but not that
+# combination. Selecting `execution: batched` here is refused outright rather than silently
+# served with a different approximant. Use the default per-event path, which uses LAL.
+# Verified against ripple 0.3.0 on 2026-08-01.
 globals:
     simulator-arguments:
         sampling-frequency: 4096

--- a/examples/signal/bns/et_2l_misaligned/config.yaml
+++ b/examples/signal/bns/et_2l_misaligned/config.yaml
@@ -3,9 +3,13 @@
 # NOTE: this preset cannot use `execution: batched`. It generates with
 # `IMRPhenomPv2_NRTidalv2`, which is precessing *and* tidal; ripple — the only library the
 # batched path generates with — implements precessing models and tidal models, but not that
-# combination. Selecting `execution: batched` here is refused outright rather than silently
-# served with a different approximant. Use the default per-event path, which uses LAL.
-# Verified against ripple 0.3.0 on 2026-08-01.
+# combination. Adding `execution: batched` here is refused outright rather than silently
+# served with a different approximant, so the failure is loud. Leave it on the default
+# per-event path, which this file already uses.
+#
+# Provenance for that claim: ripple 0.3.0, checked 2026-08-01. It is not left to this comment
+# to stay true — `tests/e2e/test_examples_index.py` fails if ripple ever gains the
+# approximant, which is when this note needs rewriting.
 globals:
     simulator-arguments:
         sampling-frequency: 4096

--- a/examples/signal/bns/et_2l_misaligned/config.yaml
+++ b/examples/signal/bns/et_2l_misaligned/config.yaml
@@ -1,3 +1,11 @@
+# Binary-neutron-star signals for an ET network.
+#
+# NOTE: this preset cannot use `execution: batched`. It generates with
+# `IMRPhenomPv2_NRTidalv2`, which is precessing *and* tidal; ripple — the only library the
+# batched path generates with — implements precessing models and tidal models, but not that
+# combination. Selecting `execution: batched` here is refused outright rather than silently
+# served with a different approximant. Use the default per-event path, which uses LAL.
+# Verified against ripple 0.3.0 on 2026-08-01.
 globals:
     simulator-arguments:
         sampling-frequency: 4096

--- a/examples/signal/bns/et_triangle_emr/config.yaml
+++ b/examples/signal/bns/et_triangle_emr/config.yaml
@@ -3,9 +3,13 @@
 # NOTE: this preset cannot use `execution: batched`. It generates with
 # `IMRPhenomPv2_NRTidalv2`, which is precessing *and* tidal; ripple — the only library the
 # batched path generates with — implements precessing models and tidal models, but not that
-# combination. Selecting `execution: batched` here is refused outright rather than silently
-# served with a different approximant. Use the default per-event path, which uses LAL.
-# Verified against ripple 0.3.0 on 2026-08-01.
+# combination. Adding `execution: batched` here is refused outright rather than silently
+# served with a different approximant, so the failure is loud. Leave it on the default
+# per-event path, which this file already uses.
+#
+# Provenance for that claim: ripple 0.3.0, checked 2026-08-01. It is not left to this comment
+# to stay true — `tests/e2e/test_examples_index.py` fails if ripple ever gains the
+# approximant, which is when this note needs rewriting.
 globals:
     simulator-arguments:
         sampling-frequency: 4096

--- a/examples/signal/bns/et_triangle_emr/config.yaml
+++ b/examples/signal/bns/et_triangle_emr/config.yaml
@@ -1,3 +1,11 @@
+# Binary-neutron-star signals for an ET network.
+#
+# NOTE: this preset cannot use `execution: batched`. It generates with
+# `IMRPhenomPv2_NRTidalv2`, which is precessing *and* tidal; ripple — the only library the
+# batched path generates with — implements precessing models and tidal models, but not that
+# combination. Selecting `execution: batched` here is refused outright rather than silently
+# served with a different approximant. Use the default per-event path, which uses LAL.
+# Verified against ripple 0.3.0 on 2026-08-01.
 globals:
     simulator-arguments:
         sampling-frequency: 4096

--- a/examples/signal/bns/et_triangle_sardinia/config.yaml
+++ b/examples/signal/bns/et_triangle_sardinia/config.yaml
@@ -3,9 +3,13 @@
 # NOTE: this preset cannot use `execution: batched`. It generates with
 # `IMRPhenomPv2_NRTidalv2`, which is precessing *and* tidal; ripple — the only library the
 # batched path generates with — implements precessing models and tidal models, but not that
-# combination. Selecting `execution: batched` here is refused outright rather than silently
-# served with a different approximant. Use the default per-event path, which uses LAL.
-# Verified against ripple 0.3.0 on 2026-08-01.
+# combination. Adding `execution: batched` here is refused outright rather than silently
+# served with a different approximant, so the failure is loud. Leave it on the default
+# per-event path, which this file already uses.
+#
+# Provenance for that claim: ripple 0.3.0, checked 2026-08-01. It is not left to this comment
+# to stay true — `tests/e2e/test_examples_index.py` fails if ripple ever gains the
+# approximant, which is when this note needs rewriting.
 globals:
     simulator-arguments:
         sampling-frequency: 4096

--- a/examples/signal/bns/et_triangle_sardinia/config.yaml
+++ b/examples/signal/bns/et_triangle_sardinia/config.yaml
@@ -1,3 +1,11 @@
+# Binary-neutron-star signals for an ET network.
+#
+# NOTE: this preset cannot use `execution: batched`. It generates with
+# `IMRPhenomPv2_NRTidalv2`, which is precessing *and* tidal; ripple — the only library the
+# batched path generates with — implements precessing models and tidal models, but not that
+# combination. Selecting `execution: batched` here is refused outright rather than silently
+# served with a different approximant. Use the default per-event path, which uses LAL.
+# Verified against ripple 0.3.0 on 2026-08-01.
 globals:
     simulator-arguments:
         sampling-frequency: 4096

--- a/tests/e2e/test_examples_index.py
+++ b/tests/e2e/test_examples_index.py
@@ -158,6 +158,11 @@ class TestBundledPresetsAgainstTheBatchedPath:
         config = yaml.safe_load((_EXAMPLES / label / "config.yaml").read_text())
         return config["orchestration"]["signal"]["waveform-model"]
 
+    #: Every ET network a CBC preset ships for. Asserted exactly, not merely as "non-empty": a
+    #: subset would otherwise satisfy the tests below while leaving presets unchecked, which is the
+    #: weaker form of the bug that already let an earlier version pass over an empty set.
+    _NETWORKS = frozenset({"et_2l_aligned", "et_2l_misaligned", "et_triangle_emr", "et_triangle_sardinia"})
+
     def _models_under(self, source_type: str) -> dict[str, str]:
         """Map network name -> approximant for every preset of one source type.
 
@@ -174,8 +179,11 @@ class TestBundledPresetsAgainstTheBatchedPath:
         supported = self._supported()
         models = self._models_under("bbh")
 
-        assert models, "no BBH presets found; this test has stopped checking anything"
+        assert set(models) == self._NETWORKS, f"BBH presets are {sorted(models)}, expected {sorted(self._NETWORKS)}"
         for label, model in models.items():
+            # The exact model, not just "something supported": a preset silently changing
+            # approximant changes the physics it represents and what was measured on device.
+            assert model == "IMRPhenomXPHM", f"bbh/{label} now uses {model}; the device check covered IMRPhenomXPHM"
             assert model in supported, f"bbh/{label} uses {model}, which the batched path cannot generate"
 
     def test_the_bns_presets_name_an_approximant_ripple_does_not(self):
@@ -189,8 +197,12 @@ class TestBundledPresetsAgainstTheBatchedPath:
         supported = self._supported()
         models = self._models_under("bns")
 
-        assert models, "no BNS presets found; this test has stopped checking anything"
+        assert set(models) == self._NETWORKS, f"BNS presets are {sorted(models)}, expected {sorted(self._NETWORKS)}"
         for label, model in models.items():
+            assert model == "IMRPhenomPv2_NRTidalv2", (
+                f"bns/{label} now uses {model}; whether the batched path is still blocked depends on "
+                f"that model, so the config headers and README need rechecking"
+            )
             assert model not in supported, (
                 f"bns/{label} uses {model}, which ripple now implements — the batched path is no "
                 f"longer blocked for the BNS presets, so this test, the config headers and the "

--- a/tests/e2e/test_examples_index.py
+++ b/tests/e2e/test_examples_index.py
@@ -125,44 +125,85 @@ def test_each_matrix_entry_states_a_distinct_code_path():
 
 
 class TestBundledPresetsAgainstTheBatchedPath:
-    """Which shipped example configs can actually use `execution: batched`.
+    """Which shipped example configs *could* use `execution: batched`, if it were added.
 
-    Verified on an RTX 2080 Ti (HTCondor, 2026-08-01): all four BBH ET presets run on the device,
-    `IMRPhenomXPHM` compiling once in ~100 s and then serving every network from cache. The BNS
-    presets cannot run there at all, and that is a property of the *shipped configurations* rather
-    than of any code in this repository -- so it is pinned here, against the real files.
+    None of the presets set `execution` — they all default to the per-event path. What is pinned
+    here is narrower and is the thing that surprises people: whether a preset's approximant is one
+    the batched path could generate at all, since that path only ever generates with ripple.
 
-    ``tests/signal/test_adapter_batch.py`` already covers the refusal *mechanism* with a synthetic
-    approximant. What that cannot catch is a preset drifting onto an approximant Ripple lacks, or a
-    future allow-list quietly accepting one it does not implement.
+    Measured on an RTX 2080 Ti (HTCondor, 2026-08-01) by injecting `execution: batched` into each
+    preset: the four BBH ones ran, `IMRPhenomXPHM` compiling once in ~100 s and then serving the
+    other networks from cache. The four BNS ones were refused before generating anything.
+
+    ``tests/signal/test_adapter_batch.py`` covers the refusal *mechanism* with a synthetic
+    approximant. What that cannot catch is a shipped preset drifting onto an approximant ripple
+    lacks, or ripple gaining one it currently lacks.
     """
+
+    @staticmethod
+    def _supported() -> frozenset[str]:
+        """Ripple's approximant list, read without constructing a backend.
+
+        ``RippleBackend()`` raises ``ImportError`` when the ``[jax]`` extra is absent, so building
+        one would make these tests skip — or worse, error — in the default CI job, which installs no
+        extras. The module-level tuple needs neither jax nor ripplegw, so the check runs everywhere.
+        ``test_the_private_list_still_matches_the_public_api`` keeps that shortcut honest.
+        """
+        from gwmock_signal.waveform.backends import ripple
+
+        return frozenset(ripple._SUPPORTED_APPROXIMANTS)
 
     @staticmethod
     def _waveform_model(label: str) -> str:
         config = yaml.safe_load((_EXAMPLES / label / "config.yaml").read_text())
         return config["orchestration"]["signal"]["waveform-model"]
 
-    def test_the_bbh_presets_use_an_approximant_ripple_implements(self):
-        ripple = pytest.importorskip("gwmock_signal.waveform.backends.ripple")
-        available = set(ripple.RippleBackend().available_approximants())
+    def _models_under(self, source_type: str) -> dict[str, str]:
+        """Map network name -> approximant for every preset of one source type.
 
-        for label in sorted(p.parent.name for p in (_EXAMPLES / "bbh").glob("*/config.yaml")):
-            model = self._waveform_model(f"bbh/{label}")
-            assert model in available, f"bbh/{label} uses {model}, which the device path cannot generate"
-
-    def test_the_bns_presets_use_an_approximant_ripple_does_not_implement(self):
-        """Pins a known limitation, so that lifting it is a deliberate act rather than a surprise.
-
-        `IMRPhenomPv2_NRTidalv2` is precessing *and* tidal. Ripple has precessing models and tidal
-        models but not that combination, so `execution: batched` refuses these outright. If ripple
-        ever gains it, this test fails and the BNS presets become device-capable -- update it then.
+        The empty-result guards in the tests below are load-bearing: an earlier version of this
+        pointed at ``examples/<source_type>`` rather than ``examples/signal/<source_type>``, found
+        nothing, and passed vacuously while checking no configuration at all.
         """
-        ripple = pytest.importorskip("gwmock_signal.waveform.backends.ripple")
-        available = set(ripple.RippleBackend().available_approximants())
+        return {
+            path.parent.name: self._waveform_model(f"signal/{source_type}/{path.parent.name}")
+            for path in sorted((_EXAMPLES / "signal" / source_type).glob("*/config.yaml"))
+        }
 
-        for label in sorted(p.parent.name for p in (_EXAMPLES / "bns").glob("*/config.yaml")):
-            model = self._waveform_model(f"bns/{label}")
-            assert model not in available, (
+    def test_the_bbh_presets_name_an_approximant_ripple_implements(self):
+        supported = self._supported()
+        models = self._models_under("bbh")
+
+        assert models, "no BBH presets found; this test has stopped checking anything"
+        for label, model in models.items():
+            assert model in supported, f"bbh/{label} uses {model}, which the batched path cannot generate"
+
+    def test_the_bns_presets_name_an_approximant_ripple_does_not(self):
+        """Pins a known limitation, so lifting it is deliberate rather than a surprise.
+
+        ``IMRPhenomPv2_NRTidalv2`` is precessing *and* tidal. Ripple has precessing models and tidal
+        models but not that combination, so `execution: batched` refuses these outright. If ripple
+        gains it, this fails — at which point the BNS presets become batched-capable and this test,
+        their header comments and the README all need updating together.
+        """
+        supported = self._supported()
+        models = self._models_under("bns")
+
+        assert models, "no BNS presets found; this test has stopped checking anything"
+        for label, model in models.items():
+            assert model not in supported, (
                 f"bns/{label} uses {model}, which ripple now implements — the batched path is no "
-                f"longer blocked for the BNS presets, so this test and their comments need updating"
+                f"longer blocked for the BNS presets, so this test, the config headers and the "
+                f"README all need updating"
             )
+
+    def test_the_private_list_still_matches_the_public_api(self):
+        """The two tests above read a private tuple to stay runnable without the extras.
+
+        That is only sound while it agrees with what a constructed backend reports. Gated, because
+        constructing one needs ripplegw.
+        """
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        from gwmock_signal.waveform.backends.ripple import RippleBackend
+
+        assert frozenset(RippleBackend().available_approximants()) == self._supported()

--- a/tests/e2e/test_examples_index.py
+++ b/tests/e2e/test_examples_index.py
@@ -15,6 +15,7 @@ import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 from .matrix import E2E_MATRIX
 
@@ -121,3 +122,47 @@ def test_each_matrix_entry_states_a_distinct_code_path():
     """Two entries claiming the same coverage means one of them is not earning its runtime."""
     claims = [entry.covers for entry in E2E_MATRIX]
     assert len(set(claims)) == len(claims), "two matrix entries claim to cover the same code path"
+
+
+class TestBundledPresetsAgainstTheBatchedPath:
+    """Which shipped example configs can actually use `execution: batched`.
+
+    Verified on an RTX 2080 Ti (HTCondor, 2026-08-01): all four BBH ET presets run on the device,
+    `IMRPhenomXPHM` compiling once in ~100 s and then serving every network from cache. The BNS
+    presets cannot run there at all, and that is a property of the *shipped configurations* rather
+    than of any code in this repository -- so it is pinned here, against the real files.
+
+    ``tests/signal/test_adapter_batch.py`` already covers the refusal *mechanism* with a synthetic
+    approximant. What that cannot catch is a preset drifting onto an approximant Ripple lacks, or a
+    future allow-list quietly accepting one it does not implement.
+    """
+
+    @staticmethod
+    def _waveform_model(label: str) -> str:
+        config = yaml.safe_load((_EXAMPLES / label / "config.yaml").read_text())
+        return config["orchestration"]["signal"]["waveform-model"]
+
+    def test_the_bbh_presets_use_an_approximant_ripple_implements(self):
+        ripple = pytest.importorskip("gwmock_signal.waveform.backends.ripple")
+        available = set(ripple.RippleBackend().available_approximants())
+
+        for label in sorted(p.parent.name for p in (_EXAMPLES / "bbh").glob("*/config.yaml")):
+            model = self._waveform_model(f"bbh/{label}")
+            assert model in available, f"bbh/{label} uses {model}, which the device path cannot generate"
+
+    def test_the_bns_presets_use_an_approximant_ripple_does_not_implement(self):
+        """Pins a known limitation, so that lifting it is a deliberate act rather than a surprise.
+
+        `IMRPhenomPv2_NRTidalv2` is precessing *and* tidal. Ripple has precessing models and tidal
+        models but not that combination, so `execution: batched` refuses these outright. If ripple
+        ever gains it, this test fails and the BNS presets become device-capable -- update it then.
+        """
+        ripple = pytest.importorskip("gwmock_signal.waveform.backends.ripple")
+        available = set(ripple.RippleBackend().available_approximants())
+
+        for label in sorted(p.parent.name for p in (_EXAMPLES / "bns").glob("*/config.yaml")):
+            model = self._waveform_model(f"bns/{label}")
+            assert model not in available, (
+                f"bns/{label} uses {model}, which ripple now implements — the batched path is no "
+                f"longer blocked for the BNS presets, so this test and their comments need updating"
+            )


### PR DESCRIPTION
## 📝 Summary

Closes the tracker item asking whether the bundled ET presets actually work on the device path. They were run on a GPU (HTCondor, RTX 2080 Ti) rather than reasoned about, and the answer splits:

| presets | approximant | `execution: batched` |
| --- | --- | --- |
| `signal/bbh/<network>` ×4 | `IMRPhenomXPHM` | ✅ generates |
| `signal/bns/<network>` ×4 | `IMRPhenomPv2_NRTidalv2` | ❌ **refused** |

### The BNS presets cannot use the batched path

`IMRPhenomPv2_NRTidalv2` is precessing **and** tidal. Ripple implements precessing models (`IMRPhenomPv2`, `IMRPhenomXP`, `IMRPhenomXPHM`) and tidal models (`TaylorF2`, `IMRPhenomD_NRTidalv2`, `IMRPhenomXAS_NRTidalv3`), but not the combination — and the batched path only ever generates with ripple.

The failure is loud: refused before generating anything, with a message saying it is rejected rather than substituted. That is the guard from #286 doing its job; a silent substitution would have produced plausible-looking but wrong BNS waveforms. Nothing recorded that the *shipped configurations* were affected, which is what this adds.

### The BBH presets work, with a useful surprise

All four networks generate on device, including the 2L and triangle `CustomDetector` networks. Non-zero sample counts scale exactly with detector count (2×14580, 3×14580); peaks 0.89–1.04e-21.

`IMRPhenomXPHM` compiled **once in ~100 s and then served the other three networks from cache at ~0.1 s.** The concern recorded against this item was ~121 s *per call*; it is once per process, for a fixed approximant, backend options and traced shapes. Changing sample rate or segment length can force another compile.

## What is pinned

Two tests over the **shipped files**. `tests/signal/test_adapter_batch.py` already covers the refusal *mechanism* with a synthetic approximant; what it cannot catch is a preset drifting onto an approximant ripple lacks, or ripple gaining one it currently lacks. Both directions now fail loudly, so lifting the BNS limitation is a deliberate act.

They read ripple's module-level approximant tuple rather than constructing a `RippleBackend`, which raises `ImportError` without the `[jax]` extra — so they run in the default CI job instead of skipping. A third, gated test pins that the private tuple still equals `available_approximants()`.

## ✨ Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [x] 🎨 Refactoring (tests only)

No source changes: this is verification, tests and documentation.

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** 943 passed, 23 skipped; e2e 41 passed, 9 skipped.
- [x] **Manual Test:** all eight ET presets driven through `execution: batched` on an RTX 2080 Ti.
- [x] **Manual Test:** the BNS presets confirmed to still generate on the per-event path (LAL, 3 detectors, 12288 non-zero, peak 8.16e-22) — the config headers claim this, so it is no longer only asserted.
- [x] **Manual Test:** both new tests confirmed to discriminate in both directions.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Scope of the GPU check — what it does *not* establish

One event over a **128 s span at 1024 Hz**, with `execution: batched` injected. The presets themselves ship as per-event, and the real configurations are 4096 s segments at 4096 Hz over a day. This shows the approximant and the ET networks are usable on device; it does **not** show the shipped configurations fit in GPU memory. That remains untested.

## Review history worth knowing

The first version of these tests **passed vacuously** — they globbed `examples/<source_type>` rather than `examples/signal/<source_type>`, matched nothing, and asserted over an empty set. My red-checks had verified the comparison logic discriminated without verifying it was reading real files. The empty-result guards that now catch this are load-bearing.

Review also caught that constructing `RippleBackend()` would have failed the default CI job, and that an earlier draft of the README claimed the presets "run on device" when none of them set `execution` at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented execution constraints for batched processing, including supported waveform types and BNS limitations.
  - Added benchmark guidance covering runtime conditions, GPU usage, caching, and shape-dependent recompilation.
  - Clarified why selected BNS presets use per-event execution.

- **Tests**
  - Added end-to-end validation for bundled BBH and BNS presets.
  - Added checks confirming supported waveform models match the backend’s available capabilities.
  - Improved preset discovery validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->