### PR TITLE
docs(examples): say the BNS approximant is a deliberate choice

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -56,10 +56,13 @@ an approximant ripple lacks is refused rather than served with a substitute.
 Measured on an RTX 2080 Ti on 2026-08-01, by adding the key to each preset: the
 four `signal/bbh/<network>` presets generated (`IMRPhenomXPHM`), while the four
 `signal/bns/<network>` presets were refused — `IMRPhenomPv2_NRTidalv2` is
-precessing _and_ tidal, a combination ripple does not implement. That run used a
-shortened 128 s span at 1024 Hz; it shows the approximant and the ET detector
-networks are usable on device, **not** that the shipped 4096 s, 4096 Hz, one-day
-configurations fit in GPU memory.
+precessing _and_ tidal, a combination ripple does not implement. That
+approximant is a deliberate choice, being the standard LAL model for precessing
+tidal BNS, so switching these presets to a ripple-supported tidal model to
+unlock the device path would drop precession and change the physics they
+represent. That run used a shortened 128 s span at 1024 Hz; it shows the
+approximant and the ET detector networks are usable on device, **not** that the
+shipped 4096 s, 4096 Hz, one-day configurations fit in GPU memory.
 
 `IMRPhenomXPHM` compiled once in ~100 s and then served the other three networks
 from cache. That caching holds for a fixed approximant, backend options and

--- a/examples/signal/bns/et_2l_aligned/config.yaml
+++ b/examples/signal/bns/et_2l_aligned/config.yaml
@@ -7,6 +7,11 @@
 # served with a different approximant, so the failure is loud. Leave it on the default
 # per-event path, which this file already uses.
 #
+# The approximant is a deliberate choice, not an oversight: it is the standard LAL model for
+# precessing tidal BNS. Do not "fix" this by switching to a ripple-supported tidal model such
+# as `IMRPhenomD_NRTidalv2` in order to unlock the device path — that one is aligned-spin, so
+# it would quietly drop precession and change the physics this preset represents.
+#
 # Provenance for that claim: ripple 0.3.0, checked 2026-08-01. It is not left to this comment
 # to stay true — `tests/e2e/test_examples_index.py` fails if ripple ever gains the
 # approximant, which is when this note needs rewriting.

--- a/examples/signal/bns/et_2l_misaligned/config.yaml
+++ b/examples/signal/bns/et_2l_misaligned/config.yaml
@@ -7,6 +7,11 @@
 # served with a different approximant, so the failure is loud. Leave it on the default
 # per-event path, which this file already uses.
 #
+# The approximant is a deliberate choice, not an oversight: it is the standard LAL model for
+# precessing tidal BNS. Do not "fix" this by switching to a ripple-supported tidal model such
+# as `IMRPhenomD_NRTidalv2` in order to unlock the device path — that one is aligned-spin, so
+# it would quietly drop precession and change the physics this preset represents.
+#
 # Provenance for that claim: ripple 0.3.0, checked 2026-08-01. It is not left to this comment
 # to stay true — `tests/e2e/test_examples_index.py` fails if ripple ever gains the
 # approximant, which is when this note needs rewriting.

--- a/examples/signal/bns/et_triangle_emr/config.yaml
+++ b/examples/signal/bns/et_triangle_emr/config.yaml
@@ -7,6 +7,11 @@
 # served with a different approximant, so the failure is loud. Leave it on the default
 # per-event path, which this file already uses.
 #
+# The approximant is a deliberate choice, not an oversight: it is the standard LAL model for
+# precessing tidal BNS. Do not "fix" this by switching to a ripple-supported tidal model such
+# as `IMRPhenomD_NRTidalv2` in order to unlock the device path — that one is aligned-spin, so
+# it would quietly drop precession and change the physics this preset represents.
+#
 # Provenance for that claim: ripple 0.3.0, checked 2026-08-01. It is not left to this comment
 # to stay true — `tests/e2e/test_examples_index.py` fails if ripple ever gains the
 # approximant, which is when this note needs rewriting.

--- a/examples/signal/bns/et_triangle_sardinia/config.yaml
+++ b/examples/signal/bns/et_triangle_sardinia/config.yaml
@@ -7,6 +7,11 @@
 # served with a different approximant, so the failure is loud. Leave it on the default
 # per-event path, which this file already uses.
 #
+# The approximant is a deliberate choice, not an oversight: it is the standard LAL model for
+# precessing tidal BNS. Do not "fix" this by switching to a ripple-supported tidal model such
+# as `IMRPhenomD_NRTidalv2` in order to unlock the device path — that one is aligned-spin, so
+# it would quietly drop precession and change the physics this preset represents.
+#
 # Provenance for that claim: ripple 0.3.0, checked 2026-08-01. It is not left to this comment
 # to stay true — `tests/e2e/test_examples_index.py` fails if ripple ever gains the
 # approximant, which is when this note needs rewriting.


### PR DESCRIPTION
## 📝 Summary

#299 documented that the BNS presets cannot use `execution: batched`, because `IMRPhenomPv2_NRTidalv2` is precessing **and** tidal and ripple implements no such combination.

What it did not say is that the approximant is chosen **on purpose**. Read alone, the existing note invites a plausible and wrong fix: swap the presets to `IMRPhenomD_NRTidalv2`, which the same documentation says *is* device-capable, and the device path unlocks. That model is aligned-spin, so the swap would quietly drop precession and change the physics the presets represent — while every test still passed and the output still looked entirely normal.

This adds a sentence naming that specific wrong fix, in the four BNS configs and in the examples README.

The reasoning for naming it explicitly rather than writing "deliberate — do not change": someone reaching for the swap has just read that `IMRPhenomD_NRTidalv2` works on device and looks like a drop-in replacement. A general warning does not engage with that; a specific one does.

## ✨ Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [ ] 🎨 Refactoring

Comments and prose only. No source, no tests, no configuration values — the four `config.yaml` diffs are header comments.

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** 943 passed, 23 skipped — unchanged, as expected for a comment-only change.
- [x] **Manual Test:** all four BNS configs still parse as YAML after the header edit.
- [x] **Manual Test:** pre-commit clean, including prettier and markdownlint on the README.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

No test: the claim is about *intent*, which nothing executable can check. The adjacent factual claim — that ripple lacks the approximant — is already pinned by `tests/e2e/test_examples_index.py`, which fails if that ever changes.

## Context

Ripple 0.3.0 exposes ten approximants: `IMRPhenomD`, `IMRPhenomHM`, `IMRPhenomPv2`, `IMRPhenomXAS`, `IMRPhenomXHM`, `IMRPhenomXP`, `IMRPhenomXPHM`, `IMRPhenomD_NRTidalv2`, `IMRPhenomXAS_NRTidalv3`, `TaylorF2`. Its tidal work is layered on the aligned-spin `D` and `XAS` baselines — `IMRPhenom_NRTidal/__init__.py` says so — and its precessing models are point-particle. 0.3.0 is the latest on PyPI, and upstream `tedwards2412/ripple` lists no precessing-plus-tidal variant either.

LAL does implement `IMRPhenomPv2_NRTidalv2`, which is why the presets specify it and why they run correctly on the default per-event path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that precessing tidal BNS examples intentionally use the `IMRPhenomPv2_NRTidalv2` model.
  * Documented that switching to an aligned-spin alternative would remove precession and change the represented physics.
  * Added notes explaining that benchmark settings were shortened and do not confirm that full one-day configurations fit within GPU memory.
  * Updated related BNS configuration guidance to discourage replacing the selected model solely to enable device execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->