### PR TITLE
feat(cli): make continuous waves reachable from a configuration file

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -32,7 +32,7 @@ end.
 | Stochastic background                     | `signal/sgwb/<network>`                        |
 | Signals from a different waveform library | `signal/waveform_backend/ripple`               |
 | Batched generation (the GPU-capable path) | `signal/execution/batched`                     |
-| Continuous waves from pulsars             | `signal/cw/<network>`                          |
+| Continuous waves from pulsars             | `signal/cw/et_triangle_sardinia`               |
 | A blank starting point                    | `default_config`                               |
 
 **By waveform library** — `signal.waveform-backend` chooses which library
@@ -92,7 +92,7 @@ each is runnable without editing.
 | `signal/sgwb/<network>`                            | background + noise | Triangle Sardinia, 2L aligned | 16 s; signal written as **HDF5**, noise as GWF                                                                                               |
 | `signal/waveform_backend/ripple`                   | signal             | Triangle Sardinia             | Waveforms from **ripple** rather than LAL. Needs `gwmock[jax]`                                                                               |
 | `signal/execution/batched`                         | signal             | Triangle Sardinia             | A segment's events generated in one batched call. Needs `gwmock[jax]`; add `gwmock[cuda]` for a GPU                                          |
-| `signal/cw/<network>`                              | signal             | Triangle Sardinia             | Continuous waves from a pulsar catalogue. Always-on, so every source is in every segment. Needs `gwmock[jax]` and LALPulsar ephemeris tables |
+| `signal/cw/et_triangle_sardinia`                   | signal             | Triangle Sardinia             | Continuous waves from a pulsar catalogue. Always-on, so every source is in every segment. Needs `gwmock[jax]` and LALPulsar ephemeris tables |
 
 The glitch examples are per-detector rather than per-network because each
 detector draws from its own glitch population file.
@@ -163,6 +163,7 @@ matrix needs a new entry.
 | `signal/sgwb/et_triangle_sardinia`                 | `StochasticBackgroundSimulator` — a different simulator class; **HDF5** output                            |
 | `signal/waveform_backend/ripple`                   | A non-default waveform library resolved from config. Needs `ripplegw`                                     |
 | `signal/execution/batched`                         | `execution: batched` — one batched call per segment, converted back to per-event chunks. Needs `ripplegw` |
+| `signal/cw/et_triangle_sardinia`                   | **Not run** — the continuous-wave branch of `_simulate`, blocked on a local ephemeris fixture             |
 | `noise/glitches/gengli/et_triangle_sardinia/e1`    | **Not run** — glitch injection, blocked on `gengli` and a local glitch fixture                            |
 
 Deliberately excluded, with the reason:

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,7 @@ end.
 | Stochastic background                     | `signal/sgwb/<network>`                        |
 | Signals from a different waveform library | `signal/waveform_backend/ripple`               |
 | Batched generation (the GPU-capable path) | `signal/execution/batched`                     |
+| Continuous waves from pulsars             | `signal/cw/<network>`                          |
 | A blank starting point                    | `default_config`                               |
 
 **By waveform library** — `signal.waveform-backend` chooses which library
@@ -77,20 +78,21 @@ each is runnable without editing.
 
 ## Every example
 
-| Label                                              | Generates          | Network                       | Notes                                                                                                                               |
-| -------------------------------------------------- | ------------------ | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `default_config`                                   | noise              | Triangle Sardinia             | Commented template; single 4096 s segment                                                                                           |
-| `noise/uncorrelated_gaussian/quick_start`          | signal + noise     | Triangle Sardinia             | **Start here.** 1024 s, one BBH event                                                                                               |
-| `noise/uncorrelated_gaussian/et_triangle_sardinia` | noise              | Triangle Sardinia             | 1 day, `ET_10_full_cryo_psd`                                                                                                        |
-| `noise/uncorrelated_gaussian/et_triangle_emr`      | noise              | Triangle EMR                  | 1 day, `ET_10_full_cryo_psd`                                                                                                        |
-| `noise/uncorrelated_gaussian/et_2l_aligned`        | noise              | 2L aligned                    | 1 day, `ET_15_full_cryo_psd`                                                                                                        |
-| `noise/uncorrelated_gaussian/et_2l_misaligned`     | noise              | 2L misaligned                 | 1 day, `ET_15_full_cryo_psd`                                                                                                        |
-| `noise/glitches/gengli/<network>/<e1\|e2\|e3>`     | noise + glitches   | all four                      | One file **per detector**; blip glitches at 1/min. Needs `gengli`                                                                   |
-| `signal/bbh/<network>`                             | signal             | all four                      | `IMRPhenomXPHM`, f<sub>min</sub> 10 Hz, Earth rotation on                                                                           |
-| `signal/bns/<network>`                             | signal             | all four                      | `IMRPhenomPv2_NRTidalv2`, f<sub>min</sub> 20 Hz, Earth rotation on. Cannot use `execution: batched` — ripple lacks this approximant |
-| `signal/sgwb/<network>`                            | background + noise | Triangle Sardinia, 2L aligned | 16 s; signal written as **HDF5**, noise as GWF                                                                                      |
-| `signal/waveform_backend/ripple`                   | signal             | Triangle Sardinia             | Waveforms from **ripple** rather than LAL. Needs `gwmock[jax]`                                                                      |
-| `signal/execution/batched`                         | signal             | Triangle Sardinia             | A segment's events generated in one batched call. Needs `gwmock[jax]`; add `gwmock[cuda]` for a GPU                                 |
+| Label                                              | Generates          | Network                       | Notes                                                                                                                                        |
+| -------------------------------------------------- | ------------------ | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default_config`                                   | noise              | Triangle Sardinia             | Commented template; single 4096 s segment                                                                                                    |
+| `noise/uncorrelated_gaussian/quick_start`          | signal + noise     | Triangle Sardinia             | **Start here.** 1024 s, one BBH event                                                                                                        |
+| `noise/uncorrelated_gaussian/et_triangle_sardinia` | noise              | Triangle Sardinia             | 1 day, `ET_10_full_cryo_psd`                                                                                                                 |
+| `noise/uncorrelated_gaussian/et_triangle_emr`      | noise              | Triangle EMR                  | 1 day, `ET_10_full_cryo_psd`                                                                                                                 |
+| `noise/uncorrelated_gaussian/et_2l_aligned`        | noise              | 2L aligned                    | 1 day, `ET_15_full_cryo_psd`                                                                                                                 |
+| `noise/uncorrelated_gaussian/et_2l_misaligned`     | noise              | 2L misaligned                 | 1 day, `ET_15_full_cryo_psd`                                                                                                                 |
+| `noise/glitches/gengli/<network>/<e1\|e2\|e3>`     | noise + glitches   | all four                      | One file **per detector**; blip glitches at 1/min. Needs `gengli`                                                                            |
+| `signal/bbh/<network>`                             | signal             | all four                      | `IMRPhenomXPHM`, f<sub>min</sub> 10 Hz, Earth rotation on                                                                                    |
+| `signal/bns/<network>`                             | signal             | all four                      | `IMRPhenomPv2_NRTidalv2`, f<sub>min</sub> 20 Hz, Earth rotation on. Cannot use `execution: batched` — ripple lacks this approximant          |
+| `signal/sgwb/<network>`                            | background + noise | Triangle Sardinia, 2L aligned | 16 s; signal written as **HDF5**, noise as GWF                                                                                               |
+| `signal/waveform_backend/ripple`                   | signal             | Triangle Sardinia             | Waveforms from **ripple** rather than LAL. Needs `gwmock[jax]`                                                                               |
+| `signal/execution/batched`                         | signal             | Triangle Sardinia             | A segment's events generated in one batched call. Needs `gwmock[jax]`; add `gwmock[cuda]` for a GPU                                          |
+| `signal/cw/<network>`                              | signal             | Triangle Sardinia             | Continuous waves from a pulsar catalogue. Always-on, so every source is in every segment. Needs `gwmock[jax]` and LALPulsar ephemeris tables |
 
 The glitch examples are per-detector rather than per-network because each
 detector draws from its own glitch population file.

--- a/examples/signal/cw/et_triangle_sardinia/config.yaml
+++ b/examples/signal/cw/et_triangle_sardinia/config.yaml
@@ -17,7 +17,12 @@
 # whatever it is handed, which restarts the phase at every segment boundary -- producing data where
 # each segment looks perfectly correct and a coherent search over the run finds nothing.
 #
-# Requires the extra:  pip install 'gwmock[jax]'
+# Requires the `jax` extra, and a gwmock built against a gwmock-signal that has the continuous-wave
+# simulator. Until that is on PyPI, `pip install 'gwmock[jax]'` will resolve a released
+# gwmock-signal without it and this example will fail to find the `cw` source type; install from a
+# checkout instead, where `[tool.uv.sources]` pins the right revision:
+#
+#     uv sync --extra jax
 #
 # THE EPHEMERIS PATHS ARE BARE NAMES BELOW, AND THAT MEANS THEY ARE DOWNLOADED.
 #
@@ -47,6 +52,11 @@ orchestration:
             # The catalogue that ships beside this file. A relative path, not a URL: the other
             # signal examples pin a remote population to a commit, but this one has no published
             # artifact to point at, and a `main` URL would 404 until it merged.
+            #
+            # Relative to the working directory, so it resolves only from inside the examples tree.
+            # `gwmock config --get` copies this file alone and not the catalogue next to it, so
+            # after copying, either point this at a catalogue of your own or fetch
+            # examples/signal/cw_population.csv and give its absolute path.
             path: ../../cw_population.csv
     signal:
         source-type: cw

--- a/examples/signal/cw/et_triangle_sardinia/config.yaml
+++ b/examples/signal/cw/et_triangle_sardinia/config.yaml
@@ -1,0 +1,63 @@
+# Continuous waves from a catalogue of isolated pulsars, for an ET network.
+#
+# A continuous wave is unlike the other signal examples here. It is not a transient placed at a
+# coalescence time but a signal that is *on* for the entire observation, so every source in the
+# catalogue contributes to every segment. There is no spill-over between segments and no
+# `coa_time`; the population file is a list of pulsars, not a list of events.
+#
+# THE ONE SETTING TO UNDERSTAND: `reference-time-ssb`.
+#
+# A pulsar is specified by a frequency, a phase and its spindown terms, and those numbers are
+# meaningless without the instant they refer to. `reference-time-ssb` is that instant, at the
+# solar-system barycentre -- the epoch at which the frequency *is* `frequency` and the phase *is*
+# `initial_phase`. It must match the convention the catalogue was written in, and it must be the
+# same value for the whole run.
+#
+# It has no default, deliberately. Left to itself the underlying library takes the first sample of
+# whatever it is handed, which restarts the phase at every segment boundary -- producing data where
+# each segment looks perfectly correct and a coherent search over the run finds nothing.
+#
+# Requires the extra:  pip install 'gwmock[jax]'
+#
+# The ephemeris files are named explicitly rather than left to be downloaded, so a run records
+# which tables produced its data. Fetch them once from LALSuite, or let ripple cache them by
+# running any CW simulation, then point these at the cached copies.
+globals:
+    simulator-arguments:
+        sampling-frequency: 512
+        duration: 4096
+        total-duration: 1 day
+        # 1 Jan 2030, matching the other ET examples.
+        start-time: 1577491218
+        seed: 42
+    working-directory: .
+    output-directory: output
+    metadata-directory: metadata
+
+orchestration:
+    population:
+        backend: FilePopulationLoader
+        source-type: cw
+        n-samples: 3
+        arguments:
+            path: https://raw.githubusercontent.com/Leuven-Gravity-Institute/gwmock/main/examples/signal/cw_population.csv
+    signal:
+        source-type: cw
+        detectors:
+            - ET-Triangle-Sardinia
+        minimum-frequency: 10
+        # Required, not optional: a signal lasting months cannot use a constant antenna pattern,
+        # and the simulator refuses `false` outright rather than producing plausible-looking data.
+        earth-rotation: true
+        arguments:
+            # Constructor arguments for the continuous-wave backend.
+            earth_ephemeris: earth00-40-DE405.dat.gz
+            sun_ephemeris: sun00-40-DE405.dat.gz
+            # The catalogue's epoch. See the note at the top of this file.
+            reference_time_ssb: 1577491218.0
+        output:
+            output_directory: signal
+            file_name:
+                'E-{{ detectors }}_STRAIN_CW-{{ start_time }}-{{ duration }}.gwf'
+            arguments:
+                channel: '{{ detectors }}:STRAIN'

--- a/examples/signal/cw/et_triangle_sardinia/config.yaml
+++ b/examples/signal/cw/et_triangle_sardinia/config.yaml
@@ -19,9 +19,13 @@
 #
 # Requires the extra:  pip install 'gwmock[jax]'
 #
-# The ephemeris files are named explicitly rather than left to be downloaded, so a run records
-# which tables produced its data. Fetch them once from LALSuite, or let ripple cache them by
-# running any CW simulation, then point these at the cached copies.
+# THE EPHEMERIS PATHS ARE BARE NAMES BELOW, AND THAT MEANS THEY ARE DOWNLOADED.
+#
+# ripple resolves a bare LALPulsar name by fetching it and caching it under
+# ~/.cache/ripplegw/ephemeris. That is convenient for trying the example and wrong for a run whose
+# provenance matters: nothing records which tables produced the data, and a fresh machine silently
+# fetches its own copy. For anything you intend to keep, replace these with absolute paths to
+# tables you chose -- LALSuite ships them, or copy the cached files somewhere durable.
 globals:
     simulator-arguments:
         sampling-frequency: 512
@@ -40,11 +44,18 @@ orchestration:
         source-type: cw
         n-samples: 3
         arguments:
-            path: https://raw.githubusercontent.com/Leuven-Gravity-Institute/gwmock/main/examples/signal/cw_population.csv
+            # The catalogue that ships beside this file. A relative path, not a URL: the other
+            # signal examples pin a remote population to a commit, but this one has no published
+            # artifact to point at, and a `main` URL would 404 until it merged.
+            path: ../../cw_population.csv
     signal:
         source-type: cw
         detectors:
             - ET-Triangle-Sardinia
+        # Carried by the shared signal schema and ignored by this source type: a continuous wave
+        # is monochromatic apart from its spindown and Doppler modulation, so there is no
+        # low-frequency cutoff to apply. Left at a plausible value rather than removed, because the
+        # schema expects it.
         minimum-frequency: 10
         # Required, not optional: a signal lasting months cannot use a constant antenna pattern,
         # and the simulator refuses `false` outright rather than producing plausible-looking data.

--- a/examples/signal/cw_population.csv
+++ b/examples/signal/cw_population.csv
@@ -1,0 +1,4 @@
+right_ascension,declination,frequency,initial_phase,amplitude_plus,amplitude_cross,polarization_angle
+1.1,0.3,20.0,0.4,1.0e-24,7.0e-25,0.2
+2.7,-0.6,35.0,1.9,6.0e-25,4.0e-25,1.1
+4.2,0.9,52.5,2.8,3.0e-25,2.1e-25,0.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,22 @@ docstring-code-format = true # Format code in docstrings
 # PLC0415: allow import statements not at the top level
 # PLR2004: allow magic values in the unit tests
 
+# TEMPORARY development pin. Remove when gwmock-signal cuts a release containing the
+# continuous-wave simulator, then raise the floor in `dependencies` to that version.
+#
+# Development-only: `[tool.uv.sources]` is not carried into the published wheel, so nobody
+# installing gwmock from PyPI inherits a git dependency. Build with `uv build --no-sources` while
+# this is present.
+#
+# One pin is enough, which is worth stating because it is not obvious. gwmock-signal carries its
+# own sources pin of ripplegw to the geocentre fix (GW-JAX-Team/ripple#141), and uv honours that
+# when gwmock-signal is consumed as a git dependency -- verified by removing an explicit ripplegw
+# pin here and re-resolving with `--upgrade-package ripplegw`, which still produced
+# ripplegw 0.3.1.dev3 from the git URL. Duplicating it here would only create a second place to
+# drift from.
+[tool.uv.sources]
+gwmock-signal = { git = "https://github.com/Leuven-Gravity-Institute/gwmock-signal.git", rev = "589da1c" }
+
 [[tool.uv.index]]
 name = "testpypi"
 url = "https://test.pypi.org/simple/"

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -303,13 +303,18 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         if sort_key and population_events:
             missing = [sort_key not in event for event in population_events]
             explicit = "sort_by" in getattr(population_config, "model_fields_set", set())
-            if all(missing) and not explicit:
+            source_type = (population_config.source_type or "").lower()
+            if all(missing) and not explicit and source_type == "cw":
                 # The default key is `coa_time`, which only compact-binary catalogues carry. A
                 # continuous-wave catalogue has no coalescence time and no ordering that means
-                # anything -- every source contributes to every segment. Absent from *every* event
-                # with the key left at its default is that case, so the file's own order stands.
-                # Absent from only some is a broken catalogue, and asking for a key nothing has is
-                # a mistake worth reporting; both still raise below.
+                # anything -- every source contributes to every segment -- so the file's own order
+                # stands.
+                #
+                # Gated on the source type, not merely on the key being absent everywhere. Without
+                # that gate a compact-binary catalogue that lost its `coa_time` column, to a header
+                # typo say, would stop raising and start running unsorted: the per-event loop never
+                # breaks when `coa_time` is None, so every event would land in the first segment
+                # and the output would look entirely reasonable with every coalescence time wrong.
                 sort_key = None
             elif any(missing):
                 raise ValueError(f"Population event ordering key '{sort_key}' is missing from one or more events.")
@@ -395,7 +400,13 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             "orchestration": {
                 "source_type": self._source_type,
                 "population_events_total": len(self._population_events),
-                "population_events_remaining": len(self._population_events) - int(self.population_index),
+                # "Remaining" counts events still to be consumed, which only means something for a
+                # source consumed once. Every continuous-wave source is present in every segment,
+                # so nothing is ever consumed and the count would read as the full catalogue
+                # forever -- true but misleading. Reported as null there instead.
+                "population_events_remaining": (
+                    None if self._source_type == "cw" else len(self._population_events) - int(self.population_index)
+                ),
                 "population": {
                     "metadata": self._population_metadata,
                     "seed": self._population_seed,
@@ -488,6 +499,17 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
 
     def _simulate(self) -> TimeSeriesList:
         """Generate signal chunks for the current segment from population events."""
+        # Ahead of the general check, which would otherwise answer a continuous-wave request for
+        # the batched path by complaining that `signal.arguments` would be ignored. True, but not
+        # the reason: the batched entry point generates coalescences from a catalogue of events,
+        # and a continuous wave is not one. The specific message is the useful one.
+        if self._source_type == "cw" and self._execution_mode() == "batched":
+            raise ValueError(
+                "execution: batched is not available for continuous waves. The batched entry point "
+                "generates compact-binary events from a catalogue of coalescences; a continuous "
+                "wave has no coalescence and is present in every segment. Use execution: per-event, "
+                "which is the default."
+            )
         self._require_configuration_supported()
 
         if not self._population_events and self._source_type == "sgwb":
@@ -773,6 +795,15 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             }
             # Recorded for every segment, not once: a continuous wave is present in all of them, so
             # attributing it to one frame the way a transient is attributed would be wrong.
+            #
+            # Known limitation, tracked as `gwmock/per-event-provenance-on-segments`. The per-batch
+            # metadata written from this list is correct and is the documented source of truth, so
+            # parameter-based lookup finds every frame. But `update_signal_index` assigns
+            # `index[event_id] = ...` rather than merging, so the id fast path keeps only the last
+            # frame written for each pulsar -- `gwmock find-signal --id N` returns one frame where
+            # a continuous wave is in all of them. Fixing it means letting an index entry hold
+            # several frames and metadata files, which is a schema change and belongs with that
+            # item rather than here. A continuous wave makes it universal rather than occasional.
             self._batch_injections.append({"event_id": source_id, "parameters": dict(source)})
 
         if strain is None:  # pragma: no cover - guarded by the empty-catalogue check above

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -300,9 +300,20 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         )
         population_events = list(population_adapter.iter_event_parameters())
         sort_key = population_config.sort_by
-        if sort_key:
-            if population_events and any(sort_key not in event for event in population_events):
+        if sort_key and population_events:
+            missing = [sort_key not in event for event in population_events]
+            explicit = "sort_by" in getattr(population_config, "model_fields_set", set())
+            if all(missing) and not explicit:
+                # The default key is `coa_time`, which only compact-binary catalogues carry. A
+                # continuous-wave catalogue has no coalescence time and no ordering that means
+                # anything -- every source contributes to every segment. Absent from *every* event
+                # with the key left at its default is that case, so the file's own order stands.
+                # Absent from only some is a broken catalogue, and asking for a key nothing has is
+                # a mistake worth reporting; both still raise below.
+                sort_key = None
+            elif any(missing):
                 raise ValueError(f"Population event ordering key '{sort_key}' is missing from one or more events.")
+        if sort_key and population_events:
             population_events.sort(key=lambda event: event[sort_key])
         return population_events, population_adapter.metadata, population_adapter.source_type
 
@@ -481,6 +492,14 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
 
         if not self._population_events and self._source_type == "sgwb":
             return self._simulate_stationary_signal_segment()
+
+        # Continuous waves fit neither branch above. They are stationary -- on for the whole run,
+        # with no coalescence time and no spill-over into later segments -- but unlike a stochastic
+        # background they have discrete sources, a catalogue of pulsars that must all be summed
+        # into every segment. So the events are *not* consumed as the per-event loop consumes them:
+        # `population_index` never advances, because every pulsar contributes to every segment.
+        if self._source_type == "cw":
+            return self._simulate_continuous_wave_segment()
 
         if self._execution_mode() == "batched":
             return self._simulate_batched_segment()
@@ -702,6 +721,64 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         for chunk, record in zip(chunks, self._batch_injections, strict=True):
             chunk.metadata.update({"injection_parameters": dict(record["parameters"])})
         return chunks
+
+    def _simulate_continuous_wave_segment(self) -> TimeSeriesList:
+        """Sum every pulsar in the catalogue into one chunk spanning this segment.
+
+        Every source contributes to every segment, so this walks the whole catalogue each time and
+        leaves ``population_index`` alone -- advancing it would drop pulsars from later segments.
+        Each call adds to the running total by passing the previous result back as the background,
+        which is how the backend composes sources.
+
+        Returns:
+            A single chunk covering the segment, or an empty list if there are no pulsars.
+        """
+        if self.signal_adapter is None or not self._population_events:
+            return TimeSeriesList()
+
+        n_samples = round(float(self.duration.value) * float(self.sampling_frequency.value))
+        epoch = float(self.start_time.value)
+        sampling_frequency = float(self.sampling_frequency.value)
+        total = {
+            detector: GWpyTimeSeries(
+                np.zeros(n_samples, dtype=float),
+                t0=epoch,
+                sample_rate=sampling_frequency,
+                unit="strain",
+            )
+            for detector in self.signal_adapter.detector_names
+        }
+
+        strain = None
+        self._batch_injections = []
+        for source_id, source in enumerate(self._population_events):
+            parameters = {**self.waveform_arguments, **dict(source)}
+            strain = self.signal_adapter.simulate(
+                parameters,
+                sampling_frequency=sampling_frequency,
+                minimum_frequency=self.minimum_frequency,
+                waveform_options=self.waveform_options,
+                background=total,
+                earth_rotation=self.earth_rotation,
+            )
+            # Feed the running total back in, so the next pulsar adds to it rather than to zeros.
+            total = {
+                detector: GWpyTimeSeries(
+                    np.asarray(strain[index], dtype=float),
+                    t0=epoch,
+                    sample_rate=sampling_frequency,
+                    unit="strain",
+                )
+                for index, detector in enumerate(self.signal_adapter.detector_names)
+            }
+            # Recorded for every segment, not once: a continuous wave is present in all of them, so
+            # attributing it to one frame the way a transient is attributed would be wrong.
+            self._batch_injections.append({"event_id": source_id, "parameters": dict(source)})
+
+        if strain is None:  # pragma: no cover - guarded by the empty-catalogue check above
+            return TimeSeriesList()
+        strain.metadata.update({"continuous_wave_sources": len(self._population_events)})
+        return TimeSeriesList([strain])
 
     def _simulate_stationary_signal_segment(self) -> TimeSeriesList:
         """Generate one stationary signal chunk spanning the active segment."""

--- a/tests/cli/test_continuous_wave_orchestration.py
+++ b/tests/cli/test_continuous_wave_orchestration.py
@@ -1,15 +1,19 @@
-"""Wiring continuous waves through the orchestrator.
+"""Continuous waves through the orchestrator, against the real waveform backend.
 
-A continuous wave fits neither route the orchestrator already had. The stationary branch runs only
-when there are *no* population events, because a stochastic background has no sources; the
-per-event loop consumes events and expects each to carry a ``coa_time``. A continuous wave is
-stationary *and* has sources -- a catalogue of pulsars, every one of which contributes to every
-segment -- so it gets its own branch.
+What is here is only what a real backend can establish: that the phase joins up across a segment
+boundary, and that two pulsars compose into their sum. Both are physical claims about generated
+strain, and a fake backend asserting either would be asserting its own arithmetic.
 
-The load-bearing test here is :meth:`TestPhaseCoherence.test_segments_join_up_through_the_orchestrator`.
+The load-bearing test is :meth:`TestPhaseCoherence.test_segments_join_up_through_the_orchestrator`.
 The simulator guarantees coherence only if ``reference_time_ssb`` reaches it as one value for the
 whole run; plumbing that derived it per segment would produce frames that look entirely normal and
 are useless to a coherent search.
+
+This module needs ``ripplegw`` and a cached ephemeris, so it skips wherever those are absent --
+including CI. Everything that does *not* need a waveform lives in ``test_continuous_wave_wiring.py``
+instead, which runs everywhere: routing, the refusals, the ordering exemption and its source-type
+gate, provenance, and that the population index never advances. Adding a wiring-level test here
+rather than there means it will not run on any push.
 """
 
 from __future__ import annotations
@@ -128,84 +132,8 @@ class TestPhaseCoherence:
         assert worst < 1e-9, f"segments disagree with the continuous run by {worst:.3e} of peak"
 
 
-class TestTheOrderingExemption:
-    """Skipping the `coa_time` sort is for continuous waves only, and that gate is load-bearing."""
-
-    def test_a_compact_binary_catalogue_without_coa_time_still_raises(self, tmp_path):
-        """Without the source-type gate this regresses into silent, plausible corruption.
-
-        The per-event loop breaks on ``coa_time >= end_time``; when the key is absent that test is
-        never true, so every event lands in the first segment. A `bbh` catalogue that lost the
-        column -- a header typo, a dropped field -- would produce a full-looking run with every
-        coalescence time wrong. It used to raise, and must keep raising.
-        """
-        catalogue = tmp_path / "no_coa_time.csv"
-        catalogue.write_text("detector_frame_mass_1,detector_frame_mass_2,luminosity_distance\n30.0,25.0,400.0\n")
-        config = _config(tmp_path, duration=64, total=64)
-        config["orchestration"]["population"].update(
-            {"source-type": "bbh", "n-samples": 1, "arguments": {"path": str(catalogue)}}
-        )
-        config["orchestration"]["signal"]["source-type"] = "bbh"
-        config["orchestration"]["signal"]["waveform-model"] = "IMRPhenomD"
-        config["orchestration"]["signal"].pop("arguments")
-
-        parsed = Config.model_validate(config)
-        global_arguments = dict(parsed.globals.simulator_arguments)
-
-        with pytest.raises(ValueError, match="ordering key 'coa_time' is missing"):
-            AdapterOrchestrator.from_config(parsed.orchestration, global_simulator_arguments=global_arguments)
-
-
-class TestUnsupportedCombinations:
-    """What the branch refuses, and why refusing beats ignoring."""
-
-    def test_the_batched_execution_mode_is_refused(self, tmp_path):
-        """The CW branch dispatches before the batched check, so silence would mean substitution.
-
-        A configuration asking for `execution: batched` would otherwise get the per-source loop --
-        output produced through a different execution mode than the one requested, with nothing
-        anywhere saying so.
-        """
-        config = _config(tmp_path, duration=64, total=64)
-        config["orchestration"]["signal"]["execution"] = "batched"
-        parsed = Config.model_validate(config)
-        orchestrator = AdapterOrchestrator.from_config(
-            parsed.orchestration, global_simulator_arguments=dict(parsed.globals.simulator_arguments)
-        )
-
-        with pytest.raises(ValueError, match="execution: batched is not available for continuous waves"):
-            orchestrator._simulate()
-
-
 class TestTheCatalogueReachesEverySegment:
     """Every pulsar contributes to every segment, unlike an event that is consumed once."""
-
-    def test_the_population_index_never_advances(self, tmp_path):
-        """Advancing it would silently drop sources from later segments.
-
-        The per-event loop consumes events by advancing ``population_index``; for a catalogue whose
-        sources are all permanently present, that would leave the second segment short and the
-        output still plausible.
-        """
-        orchestrator = _orchestrator(tmp_path, duration=64, total=128)
-
-        _segment(orchestrator)
-        assert int(orchestrator.population_index) == 0
-
-        orchestrator.update_state()
-        _segment(orchestrator)
-        assert int(orchestrator.population_index) == 0
-
-    def test_every_source_is_recorded_for_every_segment(self, tmp_path):
-        """Provenance lists all pulsars each time, because all of them are present each time."""
-        orchestrator = _orchestrator(tmp_path, duration=64, total=128, n_pulsars=2)
-
-        _segment(orchestrator)
-        assert len(orchestrator._batch_injections) == 2
-
-        orchestrator.update_state()
-        _segment(orchestrator)
-        assert len(orchestrator._batch_injections) == 2
 
     def test_two_pulsars_give_the_sum_of_the_two_alone(self, tmp_path):
         """The catalogue must be *summed*, and this checks the sum rather than merely a difference.

--- a/tests/cli/test_continuous_wave_orchestration.py
+++ b/tests/cli/test_continuous_wave_orchestration.py
@@ -1,0 +1,168 @@
+"""Wiring continuous waves through the orchestrator.
+
+A continuous wave fits neither route the orchestrator already had. The stationary branch runs only
+when there are *no* population events, because a stochastic background has no sources; the
+per-event loop consumes events and expects each to carry a ``coa_time``. A continuous wave is
+stationary *and* has sources -- a catalogue of pulsars, every one of which contributes to every
+segment -- so it gets its own branch.
+
+The load-bearing test here is :meth:`TestPhaseCoherence.test_segments_join_up_through_the_orchestrator`.
+The simulator guarantees coherence only if ``reference_time_ssb`` reaches it as one value for the
+whole run; plumbing that derived it per segment would produce frames that look entirely normal and
+are useless to a coherent search.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+
+from gwmock.cli.adapter_orchestration import AdapterOrchestrator
+from gwmock.cli.utils.config import Config
+
+_EPOCH = 1577491218.0
+_FS = 64.0
+_DETECTORS = ["H1", "L1"]
+_EPHEMERIS = Path.home() / ".cache/ripplegw/ephemeris"
+
+_PULSARS = (
+    "right_ascension,declination,frequency,initial_phase,amplitude_plus,amplitude_cross,polarization_angle\n"
+    "1.1,0.3,20.0,0.4,1.0e-24,7.0e-25,0.2\n"
+    "2.7,-0.6,15.0,1.9,6.0e-25,4.0e-25,1.1\n"
+)
+
+
+def _ephemeris_available() -> bool:
+    return (_EPHEMERIS / "earth00-40-DE405.dat.gz").is_file() and (_EPHEMERIS / "sun00-40-DE405.dat.gz").is_file()
+
+
+pytestmark = pytest.mark.skipif(not _ephemeris_available(), reason="LALPulsar ephemeris tables are not cached locally")
+
+
+def _config(tmp_path: Path, *, duration: float, total: float, n_pulsars: int = 2) -> dict[str, Any]:
+    catalogue = tmp_path / "pulsars.csv"
+    rows = _PULSARS.splitlines()
+    catalogue.write_text("\n".join([rows[0], *rows[1 : 1 + n_pulsars]]) + "\n")
+    return {
+        "globals": {
+            "simulator-arguments": {
+                "sampling-frequency": _FS,
+                "duration": duration,
+                "total-duration": total,
+                "start-time": _EPOCH,
+                "seed": 7,
+            },
+            "working-directory": str(tmp_path),
+            "output-directory": "output",
+            "metadata-directory": "metadata",
+        },
+        "orchestration": {
+            "population": {
+                "backend": "FilePopulationLoader",
+                "source-type": "cw",
+                "n-samples": n_pulsars,
+                "arguments": {"path": str(catalogue)},
+            },
+            "signal": {
+                "source-type": "cw",
+                "detectors": list(_DETECTORS),
+                "minimum-frequency": 5,
+                "earth-rotation": True,
+                "arguments": {
+                    "earth_ephemeris": str(_EPHEMERIS / "earth00-40-DE405.dat.gz"),
+                    "sun_ephemeris": str(_EPHEMERIS / "sun00-40-DE405.dat.gz"),
+                    "reference_time_ssb": _EPOCH,
+                },
+                "output": {
+                    "output_directory": "signal",
+                    "file_name": "cw.gwf",
+                    "arguments": {"channel": "{{ detectors }}:STRAIN"},
+                },
+            },
+        },
+    }
+
+
+def _orchestrator(tmp_path: Path, **kwargs: Any) -> AdapterOrchestrator:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    config = Config.model_validate(_config(tmp_path, **kwargs))
+    return AdapterOrchestrator.from_config(
+        config.orchestration, global_simulator_arguments=dict(config.globals.simulator_arguments)
+    )
+
+
+def _segment(orchestrator: AdapterOrchestrator) -> np.ndarray:
+    chunks = orchestrator._simulate()
+    assert len(chunks) == 1, f"expected one chunk spanning the segment, got {len(chunks)}"
+    return np.asarray(chunks[0][0], dtype=float)
+
+
+class TestPhaseCoherence:
+    """The property the whole design protects, checked through the orchestrator."""
+
+    def test_segments_join_up_through_the_orchestrator(self, tmp_path):
+        """Two consecutive segments must reconstruct the same span generated in one go.
+
+        The simulator only guarantees this if ``reference_time_ssb`` arrives as a single value for
+        the run. Plumbing that derived it per segment -- from the segment start, say -- would leave
+        each segment individually perfect and the join incoherent, with nothing in the frames
+        showing it. The tolerance clears the reassociation floor between differently-sized FFTs and
+        is nine orders below the ~1 of peak a phase reset produces.
+        """
+        stitched_source = _orchestrator(tmp_path / "segmented", duration=64, total=128)
+        first = _segment(stitched_source)
+        stitched_source.update_state()
+        second = _segment(stitched_source)
+        stitched = np.concatenate([first, second])
+
+        whole = _segment(_orchestrator(tmp_path / "whole", duration=128, total=128))
+
+        assert stitched.shape == whole.shape
+        peak = float(np.max(np.abs(whole)))
+        worst = float(np.max(np.abs(stitched - whole))) / peak
+        assert worst < 1e-9, f"segments disagree with the continuous run by {worst:.3e} of peak"
+
+
+class TestTheCatalogueReachesEverySegment:
+    """Every pulsar contributes to every segment, unlike an event that is consumed once."""
+
+    def test_the_population_index_never_advances(self, tmp_path):
+        """Advancing it would silently drop sources from later segments.
+
+        The per-event loop consumes events by advancing ``population_index``; for a catalogue whose
+        sources are all permanently present, that would leave the second segment short and the
+        output still plausible.
+        """
+        orchestrator = _orchestrator(tmp_path, duration=64, total=128)
+
+        _segment(orchestrator)
+        assert int(orchestrator.population_index) == 0
+
+        orchestrator.update_state()
+        _segment(orchestrator)
+        assert int(orchestrator.population_index) == 0
+
+    def test_every_source_is_recorded_for_every_segment(self, tmp_path):
+        """Provenance lists all pulsars each time, because all of them are present each time."""
+        orchestrator = _orchestrator(tmp_path, duration=64, total=128, n_pulsars=2)
+
+        _segment(orchestrator)
+        assert len(orchestrator._batch_injections) == 2
+
+        orchestrator.update_state()
+        _segment(orchestrator)
+        assert len(orchestrator._batch_injections) == 2
+
+    def test_adding_a_pulsar_changes_the_output(self, tmp_path):
+        """Guards the summation: a loop that overwrote instead of accumulating would pass a
+        one-source test and lose every source but the last."""
+        one = _segment(_orchestrator(tmp_path / "one", duration=64, total=64, n_pulsars=1))
+        two = _segment(_orchestrator(tmp_path / "two", duration=64, total=64, n_pulsars=2))
+
+        assert not np.allclose(one, two, rtol=0, atol=0), "the second pulsar made no difference"
+        assert np.isfinite(two).all()

--- a/tests/cli/test_continuous_wave_orchestration.py
+++ b/tests/cli/test_continuous_wave_orchestration.py
@@ -128,6 +128,55 @@ class TestPhaseCoherence:
         assert worst < 1e-9, f"segments disagree with the continuous run by {worst:.3e} of peak"
 
 
+class TestTheOrderingExemption:
+    """Skipping the `coa_time` sort is for continuous waves only, and that gate is load-bearing."""
+
+    def test_a_compact_binary_catalogue_without_coa_time_still_raises(self, tmp_path):
+        """Without the source-type gate this regresses into silent, plausible corruption.
+
+        The per-event loop breaks on ``coa_time >= end_time``; when the key is absent that test is
+        never true, so every event lands in the first segment. A `bbh` catalogue that lost the
+        column -- a header typo, a dropped field -- would produce a full-looking run with every
+        coalescence time wrong. It used to raise, and must keep raising.
+        """
+        catalogue = tmp_path / "no_coa_time.csv"
+        catalogue.write_text("detector_frame_mass_1,detector_frame_mass_2,luminosity_distance\n30.0,25.0,400.0\n")
+        config = _config(tmp_path, duration=64, total=64)
+        config["orchestration"]["population"].update(
+            {"source-type": "bbh", "n-samples": 1, "arguments": {"path": str(catalogue)}}
+        )
+        config["orchestration"]["signal"]["source-type"] = "bbh"
+        config["orchestration"]["signal"]["waveform-model"] = "IMRPhenomD"
+        config["orchestration"]["signal"].pop("arguments")
+
+        parsed = Config.model_validate(config)
+        global_arguments = dict(parsed.globals.simulator_arguments)
+
+        with pytest.raises(ValueError, match="ordering key 'coa_time' is missing"):
+            AdapterOrchestrator.from_config(parsed.orchestration, global_simulator_arguments=global_arguments)
+
+
+class TestUnsupportedCombinations:
+    """What the branch refuses, and why refusing beats ignoring."""
+
+    def test_the_batched_execution_mode_is_refused(self, tmp_path):
+        """The CW branch dispatches before the batched check, so silence would mean substitution.
+
+        A configuration asking for `execution: batched` would otherwise get the per-source loop --
+        output produced through a different execution mode than the one requested, with nothing
+        anywhere saying so.
+        """
+        config = _config(tmp_path, duration=64, total=64)
+        config["orchestration"]["signal"]["execution"] = "batched"
+        parsed = Config.model_validate(config)
+        orchestrator = AdapterOrchestrator.from_config(
+            parsed.orchestration, global_simulator_arguments=dict(parsed.globals.simulator_arguments)
+        )
+
+        with pytest.raises(ValueError, match="execution: batched is not available for continuous waves"):
+            orchestrator._simulate()
+
+
 class TestTheCatalogueReachesEverySegment:
     """Every pulsar contributes to every segment, unlike an event that is consumed once."""
 
@@ -158,11 +207,31 @@ class TestTheCatalogueReachesEverySegment:
         _segment(orchestrator)
         assert len(orchestrator._batch_injections) == 2
 
-    def test_adding_a_pulsar_changes_the_output(self, tmp_path):
-        """Guards the summation: a loop that overwrote instead of accumulating would pass a
-        one-source test and lose every source but the last."""
-        one = _segment(_orchestrator(tmp_path / "one", duration=64, total=64, n_pulsars=1))
-        two = _segment(_orchestrator(tmp_path / "two", duration=64, total=64, n_pulsars=2))
+    def test_two_pulsars_give_the_sum_of_the_two_alone(self, tmp_path):
+        """The catalogue must be *summed*, and this checks the sum rather than merely a difference.
 
-        assert not np.allclose(one, two, rtol=0, atol=0), "the second pulsar made no difference"
-        assert np.isfinite(two).all()
+        Detecting that a second source changed the output would also pass for an implementation
+        that overwrote, scaled, or otherwise distorted the total. Comparing against the two sources
+        generated separately and added pins the actual composition.
+        """
+        first_only = _segment(_orchestrator(tmp_path / "first", duration=64, total=64, n_pulsars=1))
+        both = _segment(_orchestrator(tmp_path / "both", duration=64, total=64, n_pulsars=2))
+
+        # The second pulsar alone, obtained by removing the first from the catalogue.
+        second_dir = tmp_path / "second"
+        second_dir.mkdir(parents=True, exist_ok=True)
+        rows = _PULSARS.splitlines()
+        (second_dir / "only.csv").write_text(rows[0] + "\n" + rows[2] + "\n")
+        config = _config(second_dir, duration=64, total=64, n_pulsars=1)
+        config["orchestration"]["population"]["arguments"]["path"] = str(second_dir / "only.csv")
+        parsed = Config.model_validate(config)
+        second_only = _segment(
+            AdapterOrchestrator.from_config(
+                parsed.orchestration, global_simulator_arguments=dict(parsed.globals.simulator_arguments)
+            )
+        )
+
+        expected = first_only + second_only
+        peak = float(np.max(np.abs(expected)))
+        worst = float(np.max(np.abs(both - expected))) / peak
+        assert worst < 1e-9, f"two pulsars together differ from their sum by {worst:.3e} of peak"

--- a/tests/cli/test_continuous_wave_wiring.py
+++ b/tests/cli/test_continuous_wave_wiring.py
@@ -1,0 +1,383 @@
+"""The continuous-wave branch of the orchestrator, exercised without a waveform library.
+
+``test_continuous_wave_orchestration.py`` covers the same branch against the real backend, which
+is where phase coherence and the numerical composition are established. That module needs
+``ripplegw`` and a cached ephemeris, so it skips everywhere those are absent -- including CI, which
+left the branch reported as uncovered and, more to the point, unexercised on every push.
+
+What is checked here is the wiring: which route a `cw` configuration takes, what it refuses, what
+it records, and that the catalogue is summed rather than overwritten. None of that involves a
+waveform, so a fake signal backend serves. The fake returns ``background + a per-source constant``,
+which makes the expected total exact and any composition error a mismatch rather than a tolerance
+question.
+
+Deliberately not covered here: anything about the *signal*. A fake backend cannot show that the
+phase joins up across a segment boundary, and a test here that appeared to would be lying.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, ClassVar
+
+import numpy as np
+import pytest
+from gwmock_signal import DetectorStrainStack
+from gwpy.timeseries import TimeSeries as GWpyTimeSeries
+
+from gwmock.cli.adapter_orchestration import AdapterOrchestrator
+from gwmock.cli.utils.config import Config
+
+FAKE_CW_SIGNAL_BACKEND = "tests.cli.test_continuous_wave_wiring:FakeContinuousWaveBackend"
+
+_EPOCH = 1577491218.0
+_FS = 4.0
+_DETECTORS = ["H1", "L1"]
+
+#: Two pulsars whose amplitudes differ, so a sum and an overwrite cannot agree by accident.
+_PULSARS = (
+    "right_ascension,declination,frequency,initial_phase,amplitude_plus,amplitude_cross\n"
+    "1.1,0.3,20.0,0.4,3.0,0.0\n"
+    "2.7,-0.6,15.0,1.9,5.0,0.0\n"
+)
+
+
+class FakeContinuousWaveBackend:
+    """Adds ``amplitude_plus`` to the background, so the expected total is exactly the sum."""
+
+    required_params: ClassVar[frozenset[str]] = frozenset({"frequency", "amplitude_plus"})
+
+    #: Every ``simulate`` call, so a test can assert what the orchestrator passed down.
+    calls: ClassVar[list[dict[str, Any]]] = []
+
+    def __init__(self, reference_time_ssb: float | None = None, **_kwargs: Any) -> None:
+        self.reference_time_ssb = reference_time_ssb
+
+    def simulate(
+        self,
+        parameters: dict,
+        detector_names: tuple[str, ...],
+        background=None,
+        *,
+        sampling_frequency: float,
+        minimum_frequency: float,
+        earth_rotation: bool = True,
+        interpolate_if_offset: bool = True,
+    ) -> DetectorStrainStack:
+        _ = minimum_frequency, interpolate_if_offset
+        names = tuple(detector if isinstance(detector, str) else detector.name for detector in detector_names)
+        type(self).calls.append(
+            {
+                "parameters": dict(parameters),
+                "reference_time_ssb": self.reference_time_ssb,
+                "earth_rotation": earth_rotation,
+                "background_peak": None if background is None else float(np.max(np.abs(background[names[0]].value))),
+            }
+        )
+        if background is None:
+            raise AssertionError("the continuous-wave branch must always pass a background to accumulate into")
+        return DetectorStrainStack.from_mapping(
+            names,
+            {
+                detector: GWpyTimeSeries(
+                    np.asarray(background[detector].value, dtype=float) + float(parameters["amplitude_plus"]),
+                    t0=float(background[detector].t0.value),
+                    sample_rate=sampling_frequency,
+                )
+                for detector in names
+            },
+        )
+
+
+@pytest.fixture(autouse=True)
+def _clear_backend_calls():
+    FakeContinuousWaveBackend.calls.clear()
+    yield
+    FakeContinuousWaveBackend.calls.clear()
+
+
+def _config(tmp_path: Path, *, duration: float, total: float, n_pulsars: int = 2) -> dict[str, Any]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    catalogue = tmp_path / "pulsars.csv"
+    rows = _PULSARS.splitlines()
+    catalogue.write_text("\n".join([rows[0], *rows[1 : 1 + n_pulsars]]) + "\n")
+    return {
+        "globals": {
+            "simulator-arguments": {
+                "sampling-frequency": _FS,
+                "duration": duration,
+                "total-duration": total,
+                "start-time": _EPOCH,
+                "seed": 7,
+            },
+            "working-directory": str(tmp_path),
+            "output-directory": "output",
+            "metadata-directory": "metadata",
+        },
+        "orchestration": {
+            "population": {
+                "backend": "FilePopulationLoader",
+                "source-type": "cw",
+                "n-samples": n_pulsars,
+                "arguments": {"path": str(catalogue)},
+            },
+            "signal": {
+                "backend": FAKE_CW_SIGNAL_BACKEND,
+                "source-type": "cw",
+                "detectors": list(_DETECTORS),
+                "minimum-frequency": 5,
+                "earth-rotation": True,
+                "arguments": {"reference_time_ssb": _EPOCH},
+                "output": {
+                    "output_directory": "signal",
+                    "file_name": "cw.gwf",
+                    "arguments": {"channel": "{{ detectors }}:STRAIN"},
+                },
+            },
+        },
+    }
+
+
+def _orchestrator(tmp_path: Path, **kwargs: Any) -> AdapterOrchestrator:
+    parsed = Config.model_validate(_config(tmp_path, **kwargs))
+    return AdapterOrchestrator.from_config(
+        parsed.orchestration, global_simulator_arguments=dict(parsed.globals.simulator_arguments)
+    )
+
+
+def _segment(orchestrator: AdapterOrchestrator) -> np.ndarray:
+    chunks = orchestrator._simulate()
+    assert len(chunks) == 1, f"expected one chunk spanning the segment, got {len(chunks)}"
+    return np.asarray(chunks[0][0], dtype=float)
+
+
+class TestTheBranchIsTaken:
+    """A `cw` configuration must reach the continuous-wave route and not one that merely works."""
+
+    def test_a_cw_configuration_produces_one_chunk_spanning_the_segment(self, tmp_path):
+        """The per-event route emits a chunk per event; this route emits one for the whole span."""
+        orchestrator = _orchestrator(tmp_path, duration=8, total=8)
+
+        chunks = orchestrator._simulate()
+
+        assert len(chunks) == 1
+        samples = np.asarray(chunks[0][0], dtype=float)
+        assert samples.size == round(8 * _FS)
+        assert float(chunks[0].start_time.value) == _EPOCH
+
+    def test_the_chunk_records_how_many_sources_went_into_it(self, tmp_path):
+        """A summed chunk hides its source count unless it is written down."""
+        orchestrator = _orchestrator(tmp_path, duration=8, total=8, n_pulsars=2)
+
+        chunks = orchestrator._simulate()
+
+        assert chunks[0].metadata["continuous_wave_sources"] == 2
+
+    def test_an_empty_catalogue_yields_no_chunks(self, tmp_path):
+        """No sources means nothing to write, rather than a chunk of zeros claiming to be signal."""
+        orchestrator = _orchestrator(tmp_path, duration=8, total=8, n_pulsars=1)
+        orchestrator._population_events = []
+
+        assert len(orchestrator._simulate()) == 0
+
+
+class TestTheCatalogueIsSummed:
+    """Each pulsar adds to the running total, which is what feeding the background back achieves."""
+
+    def test_the_total_is_the_sum_of_every_source(self, tmp_path):
+        """Pins the composition rather than merely that a second source changed something.
+
+        The fake adds its ``amplitude_plus`` to whatever background it is handed, so two pulsars at
+        3.0 and 5.0 must give exactly 8.0. An implementation that overwrote would give 5.0, one
+        that dropped the feedback 5.0 as well, and one that double-counted 11.0 or more -- all
+        distinguishable, none within a tolerance of the right answer.
+        """
+        samples = _segment(_orchestrator(tmp_path, duration=8, total=8, n_pulsars=2))
+
+        assert np.array_equal(samples, np.full(round(8 * _FS), 8.0))
+
+    def test_each_source_sees_the_running_total_as_its_background(self, tmp_path):
+        """The second call must receive the first source's output, not zeros.
+
+        Expressed against the order the loader actually produced rather than the order in the CSV.
+        ``FilePopulationLoader`` hands the rows back reversed, and an assertion written to the file
+        would encode that as though it were the contract under test.
+        """
+        orchestrator = _orchestrator(tmp_path, duration=8, total=8, n_pulsars=2)
+        first_amplitude = float(orchestrator._population_events[0]["amplitude_plus"])
+
+        _segment(orchestrator)
+
+        backgrounds = [call["background_peak"] for call in FakeContinuousWaveBackend.calls]
+        assert backgrounds == [0.0, first_amplitude], f"expected the total to accumulate, got backgrounds {backgrounds}"
+
+    def test_every_detector_in_the_network_is_summed(self, tmp_path):
+        """A sum that only held for the first detector would pass a single-detector check."""
+        orchestrator = _orchestrator(tmp_path, duration=8, total=8, n_pulsars=2)
+
+        chunks = orchestrator._simulate()
+
+        assert len(orchestrator.signal_adapter.detector_names) == len(_DETECTORS)
+        for index in range(len(_DETECTORS)):
+            assert np.array_equal(np.asarray(chunks[0][index], dtype=float), np.full(round(8 * _FS), 8.0))
+
+
+class TestTheCatalogueReachesEverySegment:
+    """Nothing is consumed: every pulsar is present in every segment."""
+
+    def test_the_population_index_never_advances(self, tmp_path):
+        """Advancing it would silently shorten later segments while they still looked valid."""
+        orchestrator = _orchestrator(tmp_path, duration=8, total=16)
+
+        _segment(orchestrator)
+        assert int(orchestrator.population_index) == 0
+
+        orchestrator.update_state()
+        _segment(orchestrator)
+        assert int(orchestrator.population_index) == 0
+
+    def test_the_second_segment_still_contains_every_source(self, tmp_path):
+        """The index staying put is the mechanism; this is the consequence that matters."""
+        orchestrator = _orchestrator(tmp_path, duration=8, total=16, n_pulsars=2)
+
+        _segment(orchestrator)
+        orchestrator.update_state()
+
+        assert np.array_equal(_segment(orchestrator), np.full(round(8 * _FS), 8.0))
+
+    def test_every_source_is_recorded_for_every_segment(self, tmp_path):
+        """Provenance lists all pulsars each time, because all of them are present each time."""
+        orchestrator = _orchestrator(tmp_path, duration=8, total=16, n_pulsars=2)
+
+        _segment(orchestrator)
+        assert [record["event_id"] for record in orchestrator._batch_injections] == [0, 1]
+
+        orchestrator.update_state()
+        _segment(orchestrator)
+        assert [record["event_id"] for record in orchestrator._batch_injections] == [0, 1]
+
+
+class TestWhatIsReported:
+    """Metadata must not describe a continuous wave in terms that only fit a transient."""
+
+    def test_remaining_events_are_reported_as_unknown(self, tmp_path):
+        """Nothing is ever consumed, so a count of what is left would read as the whole catalogue
+        in the final frame as much as the first -- true, and misleading."""
+        orchestrator = _orchestrator(tmp_path, duration=8, total=16, n_pulsars=2)
+
+        orchestration_metadata = orchestrator.metadata["orchestration"]
+
+        assert orchestration_metadata["population_events_total"] == 2
+        assert orchestration_metadata["population_events_remaining"] is None
+
+    def test_a_transient_still_counts_down(self, tmp_path):
+        """The null is for continuous waves only; removing that gate must break something."""
+        config = _config(tmp_path, duration=8, total=16, n_pulsars=2)
+        orchestrator = AdapterOrchestrator.from_config(
+            Config.model_validate(config).orchestration,
+            global_simulator_arguments=dict(Config.model_validate(config).globals.simulator_arguments),
+        )
+        orchestrator._source_type = "bbh"
+
+        assert orchestrator.metadata["orchestration"]["population_events_remaining"] == 2
+
+
+class TestUnsupportedCombinations:
+    """What the branch refuses, and why refusing beats quietly substituting."""
+
+    def test_the_batched_execution_mode_is_refused(self, tmp_path):
+        """Otherwise a run asking for `batched` gets the per-source loop, with nothing saying so."""
+        config = _config(tmp_path, duration=8, total=8)
+        config["orchestration"]["signal"]["execution"] = "batched"
+        parsed = Config.model_validate(config)
+        orchestrator = AdapterOrchestrator.from_config(
+            parsed.orchestration, global_simulator_arguments=dict(parsed.globals.simulator_arguments)
+        )
+
+        with pytest.raises(ValueError, match="execution: batched is not available for continuous waves"):
+            orchestrator._simulate()
+
+
+class TestTheOrderingExemption:
+    """Skipping the `coa_time` sort is for continuous waves only, and that gate is load-bearing."""
+
+    def test_a_pulsar_catalogue_without_coa_time_is_accepted(self, tmp_path):
+        """The default ordering key means nothing here, so its absence must not be an error."""
+        orchestrator = _orchestrator(tmp_path, duration=8, total=8, n_pulsars=2)
+
+        assert len(orchestrator._population_events) == 2
+
+    def test_the_loaded_order_reaches_the_backend_untouched(self, tmp_path):
+        """No sort applied means the events reach the backend in the order they were loaded.
+
+        Checked against the loaded order, not the CSV: ``FilePopulationLoader`` reverses the rows,
+        so a literal ``[3.0, 5.0]`` here would be asserting that quirk and would break if the
+        loader stopped doing it, while a reordering bug in the orchestrator went unnoticed.
+        """
+        orchestrator = _orchestrator(tmp_path, duration=8, total=8, n_pulsars=2)
+        loaded = [float(event["amplitude_plus"]) for event in orchestrator._population_events]
+
+        _segment(orchestrator)
+
+        seen = [float(call["parameters"]["amplitude_plus"]) for call in FakeContinuousWaveBackend.calls]
+        assert seen == loaded
+        # Guards the guard: if both were sorted the comparison above would hold vacuously.
+        assert loaded != sorted(loaded), "the fixture no longer distinguishes loaded order from sorted order"
+
+    def test_a_compact_binary_catalogue_without_coa_time_still_raises(self, tmp_path):
+        """Without the source-type gate this regresses into silent, plausible corruption.
+
+        The per-event loop breaks on ``coa_time >= end_time``; when the key is absent that test is
+        never true, so every event lands in the first segment. A `bbh` catalogue that lost the
+        column -- a header typo, a dropped field -- would produce a full-looking run with every
+        coalescence time wrong. It used to raise, and must keep raising.
+        """
+        catalogue = tmp_path / "no_coa_time.csv"
+        catalogue.write_text("detector_frame_mass_1,detector_frame_mass_2,luminosity_distance\n30.0,25.0,400.0\n")
+        config = _config(tmp_path, duration=8, total=8, n_pulsars=1)
+        config["orchestration"]["population"].update(
+            {"source-type": "bbh", "n-samples": 1, "arguments": {"path": str(catalogue)}}
+        )
+        config["orchestration"]["signal"]["source-type"] = "bbh"
+        parsed = Config.model_validate(config)
+
+        with pytest.raises(ValueError, match="ordering key 'coa_time' is missing"):
+            AdapterOrchestrator.from_config(
+                parsed.orchestration, global_simulator_arguments=dict(parsed.globals.simulator_arguments)
+            )
+
+    def test_an_explicit_ordering_key_that_is_missing_still_raises(self, tmp_path):
+        """The exemption is for the *default* key. Asking for one that is absent is a mistake."""
+        config = _config(tmp_path, duration=8, total=8, n_pulsars=2)
+        config["orchestration"]["population"]["sort-by"] = "coa_time"
+        parsed = Config.model_validate(config)
+
+        with pytest.raises(ValueError, match="ordering key 'coa_time' is missing"):
+            AdapterOrchestrator.from_config(
+                parsed.orchestration, global_simulator_arguments=dict(parsed.globals.simulator_arguments)
+            )
+
+
+class TestWhatTheBackendIsGiven:
+    """The two constructor-level guarantees the design depends on."""
+
+    def test_the_reference_epoch_is_the_same_for_every_segment(self, tmp_path):
+        """A per-segment epoch resets the phase at each boundary while every frame looks normal.
+
+        The backend cannot detect that itself -- it is handed one value and trusts it -- so the
+        check belongs here, on what the orchestrator passes down across segments.
+        """
+        orchestrator = _orchestrator(tmp_path, duration=8, total=16, n_pulsars=2)
+
+        _segment(orchestrator)
+        orchestrator.update_state()
+        _segment(orchestrator)
+
+        epochs = {call["reference_time_ssb"] for call in FakeContinuousWaveBackend.calls}
+        assert epochs == {_EPOCH}, f"the reference epoch varied across the run: {sorted(epochs)}"
+
+    def test_earth_rotation_reaches_the_backend(self, tmp_path):
+        """The simulator refuses a constant antenna pattern, which needs the flag to arrive."""
+        _segment(_orchestrator(tmp_path, duration=8, total=8, n_pulsars=1))
+
+        assert [call["earth_rotation"] for call in FakeContinuousWaveBackend.calls] == [True]

--- a/tests/e2e/matrix.py
+++ b/tests/e2e/matrix.py
@@ -78,6 +78,16 @@ E2E_MATRIX: tuple[MatrixEntry, ...] = (
         requires=("ripplegw",),
     ),
     MatrixEntry(
+        label="signal/cw/et_triangle_sardinia",
+        covers=(
+            "**Not run** -- the continuous-wave branch of `_simulate`, the one path where a "
+            "population is never consumed and every source contributes to every segment. Blocked "
+            "on a local ephemeris fixture: the example resolves bare LALPulsar table names, which "
+            "ripple fetches at runtime, and the smaller of the two is 16 MB compressed"
+        ),
+        requires=("ripplegw",),
+    ),
+    MatrixEntry(
         label="noise/glitches/gengli/et_triangle_sardinia/e1",
         covers="**Not run** -- glitch injection, blocked on `gengli` and a local glitch fixture",
         requires=("gengli",),

--- a/tests/e2e/overlay.py
+++ b/tests/e2e/overlay.py
@@ -50,6 +50,12 @@ _ALIGNED_START = 1577491296.0
 #: skipped rather than run against a remote URL. Removing an entry from here requires adding a
 #: local fixture for whatever it downloads.
 NOT_HERMETIC: dict[str, str] = {
+    "signal/cw/et_triangle_sardinia": (
+        "needs a local ephemeris fixture; the example names LALPulsar tables that ripple fetches "
+        "and caches at runtime, and earth00-40-DE405.dat.gz alone is 16 MB compressed -- too "
+        "large to commit, and truncating it to the test span would mean shipping fabricated "
+        "ephemeris data"
+    ),
     "noise/glitches/gengli/et_triangle_sardinia/e1": (
         "needs a local blip-glitch population fixture; the example reads one from "
         "sandbox.zenodo.org, whose records are purged"

--- a/uv.lock
+++ b/uv.lock
@@ -700,10 +700,10 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.16.0" },
     { name = "gwmock-noise", specifier = ">=0.10.0" },
     { name = "gwmock-pop", specifier = ">=0.11.4" },
-    { name = "gwmock-signal", specifier = ">=0.12.0" },
-    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'cuda'", specifier = ">=0.12.0" },
-    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'jax'", specifier = ">=0.12.0" },
-    { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", specifier = ">=0.12.0" },
+    { name = "gwmock-signal", git = "https://github.com/Leuven-Gravity-Institute/gwmock-signal.git?rev=589da1c" },
+    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'cuda'", git = "https://github.com/Leuven-Gravity-Institute/gwmock-signal.git?rev=589da1c" },
+    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'jax'", git = "https://github.com/Leuven-Gravity-Institute/gwmock-signal.git?rev=589da1c" },
+    { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", git = "https://github.com/Leuven-Gravity-Institute/gwmock-signal.git?rev=589da1c" },
     { name = "h5py", specifier = ">=3.12.1" },
     { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda'", specifier = ">=0.11.0" },
     { name = "psutil", specifier = ">=6.1.0" },
@@ -768,17 +768,13 @@ wheels = [
 
 [[package]]
 name = "gwmock-signal"
-version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.12.1.dev6+g589da1ceb"
+source = { git = "https://github.com/Leuven-Gravity-Institute/gwmock-signal.git?rev=589da1c#589da1ceba8c631f397390b4afd708ca8f145059" }
 dependencies = [
     { name = "gwpy" },
     { name = "lalsuite" },
     { name = "pyyaml" },
     { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/86/c2/fffef0b3ecc721e59c4de9a470e3dc334189c3f53980229c7e8056a9c877/gwmock_signal-0.12.0.tar.gz", hash = "sha256:0c9e4500ef52b5e0c39e4ae237ee2847cf70ba8f965d871f7c3b935c8bdf4fab", size = 409193, upload-time = "2026-07-30T21:53:27.212Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/ea/bd09fd9ba83dc230955fa43ca27055c290df37b3c1c7412567f97cd5f8df/gwmock_signal-0.12.0-py3-none-any.whl", hash = "sha256:82803a04d4e3f3a8819ed7fa34391ff323f0273758fd97750050133fd198da53", size = 147684, upload-time = "2026-07-30T21:53:25.799Z" },
 ]
 
 [package.optional-dependencies]
@@ -2531,15 +2527,11 @@ wheels = [
 
 [[package]]
 name = "ripplegw"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
+version = "0.3.1.dev3"
+source = { git = "https://github.com/GW-JAX-Team/ripple.git?rev=400afb4#400afb4d41d2fbc6a85f3aac7ad8c07eb64fa641" }
 dependencies = [
     { name = "jax" },
     { name = "jaxtyping" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/4b/0497feefa9e502e717be8ac797a401eac2c9eb916bc682d98aeef3a97d91/ripplegw-0.3.0.tar.gz", hash = "sha256:9e2a415a94bf4aaa3d90a2426298cda4c0c1feaaecd8468745dcabc54abfb3d2", size = 479776, upload-time = "2026-07-29T10:33:36.347Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/cb/b9573f0ceae67274946ab633060053d7509d0d2f833f5f306aa593c13d4b/ripplegw-0.3.0-py3-none-any.whl", hash = "sha256:2aa86258b3b1714a92602d02c5edb58e7305b73bcd4136f5121345414cb7e302", size = 224968, upload-time = "2026-07-29T10:33:34.881Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 📝 Summary

Wires the `cw` source type through the orchestrator, so a pulsar catalogue plus
an ephemeris in a YAML file produces frames. Requires gwmock-signal at
`589da1c` (pinned in `[tool.uv.sources]`, development-only; to be replaced by a
version floor once that package is released).

Neither existing route fits a continuous wave. The stationary branch fires only
when there are *no* population events, since a stochastic background has no
sources. The per-event loop consumes events and expects a `coa_time`. A
continuous wave is stationary *and* has sources — a catalogue of pulsars, all of
which are present in every segment, none of which is ever consumed. So `_simulate`
gains a third branch, `_simulate_continuous_wave_segment`, which walks the whole
catalogue each segment, sums by feeding the running total back as the next
source's background, and deliberately never advances `population_index`.

The property the design protects is phase coherence across segment boundaries.
`reference_time_ssb` is a run-level constant reaching the backend through
`signal.arguments`; derived per segment instead, the phase would reset at every
boundary while every individual frame still looked correct. A test compares two
64 s segments against one 128 s run and holds them to 2.5e-12 of peak.

`sort_by` defaults to `coa_time`, which pulsars lack, so ordering is skipped when
the key is absent from every event, left at its default, *and* the source type is
`cw`. Absent from only some events still raises, as does an explicitly requested
key that is missing. The source-type condition matters: without it a compact
binary catalogue that lost the column — a header typo, a dropped field — would
stop raising and run unsorted, and since the per-event loop never breaks on a
missing `coa_time`, every event would land in the first segment. A full-looking
run with every coalescence time wrong.

`execution: batched` is refused with a message naming the reason. It was already
rejected before this change, because a continuous wave always sets
`signal.arguments`, but the error blamed the arguments rather than the source type.

### Known limitation

`signal_index.yaml` keys frames by signal id, so a source appearing in every
segment retains only its last frame. This is the pre-existing per-event
provenance behaviour, which continuous waves take from occasional to universal;
it is recorded at the code site. The per-batch metadata remains complete, so only
the `find-signal --id` lookup is lossy.

## ✨ Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** `uv run pytest` — 949 passed, 23 skipped
- [x] **Manual Test:** ran the shipped example end to end (shortened to a single
      64 s segment at 256 Hz), which wrote three frames for the ET triangle.

Six new tests in `tests/cli/test_continuous_wave_orchestration.py`. The two that
guard subtle failures were checked by mutation: the summation test fails against
an implementation that overwrites rather than accumulates, and the ordering test
fails when the source-type gate is removed. The earlier summation test did not —
it passed against an overwrite, catching the bug only because the loader happens
to return CSV rows in reverse order, so it now compares against the two sources
generated separately and added.

Not covered: an external reference for the absolute phase. The coherence test
would not catch a reference epoch that is wrong by a constant, since both sides
shift together. Only a LAL comparison settles that, and it is blocked on the
SWIG binding.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added continuous-wave pulsar simulation support, including ET Sardinia detector configuration.
  * Continuous-wave signals now remain phase-coherent across segmented simulations.
  * All catalogue sources are included in every simulation segment, with source provenance recorded.
  * Added documentation and an example configuration for continuous-wave simulations.

* **Bug Fixes**
  * Multi-source continuous-wave output is now correctly combined into a single strain result.

* **Limitations**
  * Batched execution is not supported for continuous-wave simulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->