### PR TITLE
chore(deps): consume gwmock-signal 0.13.0 and take over the ripple pin

### DIFF
--- a/examples/signal/cw/et_triangle_sardinia/config.yaml
+++ b/examples/signal/cw/et_triangle_sardinia/config.yaml
@@ -17,10 +17,14 @@
 # whatever it is handed, which restarts the phase at every segment boundary -- producing data where
 # each segment looks perfectly correct and a coherent search over the run finds nothing.
 #
-# Requires the `jax` extra, and a gwmock built against a gwmock-signal that has the continuous-wave
-# simulator. Until that is on PyPI, `pip install 'gwmock[jax]'` will resolve a released
-# gwmock-signal without it and this example will fail to find the `cw` source type; install from a
-# checkout instead, where `[tool.uv.sources]` pins the right revision:
+# Requires the `jax` extra:  pip install 'gwmock[jax]'
+#
+# That is enough to resolve the continuous-wave source type -- gwmock-signal 0.13.0 registers it --
+# but not enough to *run* it. The simulator generates at the geocentre so one projection route
+# serves every source type, and released ripplegw returns NaN for every sample there
+# (`arccos(lz / rd)` is 0/0 at the Earth centre). It is refused rather than written, so a run fails
+# with a message naming the cause. Until GW-JAX-Team/ripple#141 reaches a ripplegw release, this
+# example needs a checkout of gwmock, where the pin in pyproject.toml supplies the fixed revision:
 #
 #     uv sync --extra jax
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = [
-  "gwmock-signal>=0.12.0", # 0.12.0 first exports the on-device entry points simulate_segments needs
+  "gwmock-signal>=0.13.0", # 0.13.0 is the first release carrying the continuous-wave simulator
   "gwmock-noise>=0.10.0",
   "gwmock-pop>=0.11.4",
   "typer>=0.19.0",         # Literal-type CLI options; the SPEC 0 floor (0.13) predates them
@@ -36,7 +36,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-sgwb = ["gwmock-signal[sgwb]>=0.12.0"]
+sgwb = ["gwmock-signal[sgwb]>=0.13.0"]
 # The batched signal path. Without this extra `SignalAdapter.simulate_segments` and
 # `execution: batched` raise, because gwmock-signal's batched entry points need JAX and ripple,
 # which the base install omits.
@@ -45,13 +45,19 @@ sgwb = ["gwmock-signal[sgwb]>=0.12.0"]
 # installed this way batches the work and runs it on the CPU. That is a supported configuration --
 # it is the one the test suite exercises -- but it is not device execution, and nothing at runtime
 # distinguishes the two beyond `jax.devices()`. Use the `cuda` extra below for a GPU.
-jax = ["gwmock-signal[jax]>=0.12.0"]
+jax = ["gwmock-signal[jax]>=0.13.0"]
 # The same path with an actual GPU backend. Linux x86_64 with a CUDA 12 driver only; there is no
 # macOS or Windows wheel, which is why this is separate from `jax` rather than folded into it.
-cuda = ["gwmock-signal[jax]>=0.12.0", "jax[cuda12]>=0.11.0"]
+cuda = ["gwmock-signal[jax]>=0.13.0", "jax[cuda12]>=0.11.0"]
 
 [dependency-groups]
 dev = [
+  # Declared here only so the `[tool.uv.sources]` pin below applies to it. uv honours a source
+  # for a package the project *declares*; ripplegw reaches gwmock transitively through
+  # `gwmock-signal[jax]`, and a source alone did not redirect it -- the lock resolved
+  # ripplegw 0.3.0 from the registry until this line existed. A dev group keeps it out of the
+  # published wheel, where a git dependency must never appear. Remove together with the pin.
+  "ripplegw>=0.3",
   "prek>=0.4.11",
   "pytest-cov>=7.1.0",
   "pytest-mock>=3.15.1",
@@ -181,21 +187,27 @@ docstring-code-format = true # Format code in docstrings
 # PLC0415: allow import statements not at the top level
 # PLR2004: allow magic values in the unit tests
 
-# TEMPORARY development pin. Remove when gwmock-signal cuts a release containing the
-# continuous-wave simulator, then raise the floor in `dependencies` to that version.
+# TEMPORARY development pin. Remove when a ripplegw release carries the geocentre fix
+# (GW-JAX-Team/ripple#141), then raise the floor in the `jax` extra to that version.
 #
 # Development-only: `[tool.uv.sources]` is not carried into the published wheel, so nobody
 # installing gwmock from PyPI inherits a git dependency. Build with `uv build --no-sources` while
 # this is present.
 #
-# One pin is enough, which is worth stating because it is not obvious. gwmock-signal carries its
-# own sources pin of ripplegw to the geocentre fix (GW-JAX-Team/ripple#141), and uv honours that
-# when gwmock-signal is consumed as a git dependency -- verified by removing an explicit ripplegw
-# pin here and re-resolving with `--upgrade-package ripplegw`, which still produced
-# ripplegw 0.3.1.dev3 from the git URL. Duplicating it here would only create a second place to
-# drift from.
+# Why it moved here. Until gwmock-signal 0.13.0 this file pinned *gwmock-signal* to a git
+# revision, and that was enough on its own: gwmock-signal carries its own sources pin of ripplegw,
+# and uv honours a git dependency's sources. Consuming the release instead breaks that inheritance
+# -- a wheel does not carry `[tool.uv.sources]` -- so resolving `gwmock-signal[jax]>=0.13.0` from
+# PyPI produces ripplegw 0.3.0, the version without the fix. Measured, not assumed: a scratch
+# project depending only on `gwmock-signal[jax]>=0.13.0` locks `ripplegw 0.3.0` from the registry.
+#
+# What that costs without this pin. The continuous-wave simulator generates polarizations at the
+# geocentre so one projection route serves every source type; released ripplegw evaluates the
+# detector latitude as `arccos(lz / rd)`, which is 0/0 there, and returns NaN for every sample.
+# gwmock-signal 0.13.0 refuses that rather than writing it, so the failure is loud -- but
+# continuous waves would simply not work in this repository's own development and CI.
 [tool.uv.sources]
-gwmock-signal = { git = "https://github.com/Leuven-Gravity-Institute/gwmock-signal.git", rev = "589da1c" }
+ripplegw = { git = "https://github.com/GW-JAX-Team/ripple.git", rev = "400afb4" }
 
 [[tool.uv.index]]
 name = "testpypi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,19 +45,22 @@ sgwb = ["gwmock-signal[sgwb]>=0.13.0"]
 # installed this way batches the work and runs it on the CPU. That is a supported configuration --
 # it is the one the test suite exercises -- but it is not device execution, and nothing at runtime
 # distinguishes the two beyond `jax.devices()`. Use the `cuda` extra below for a GPU.
-jax = ["gwmock-signal[jax]>=0.13.0"]
+# `ripplegw` is named explicitly so the development pin at the bottom of this file applies
+# to it. uv honours a source only for a package the project *declares*, and ripple would
+# otherwise arrive transitively through `gwmock-signal[jax]`; a source alone left the lock
+# resolving ripplegw 0.3.0 from the registry. Declaring it here rather than in a dev group
+# keeps it on the extras that need it -- a dev group would put ripple and JAX into every
+# plain `uv sync`, which would un-skip the ripple-gated tests in the default CI job and make
+# that job quietly test something other than what it claims. The published wheel gains only
+# `ripplegw>=0.3` under these extras, a registry floor that was already transitive, and no
+# git URL: verified with a plain `uv build`, which is what the release workflow runs.
+jax = ["gwmock-signal[jax]>=0.13.0", "ripplegw>=0.3"]
 # The same path with an actual GPU backend. Linux x86_64 with a CUDA 12 driver only; there is no
 # macOS or Windows wheel, which is why this is separate from `jax` rather than folded into it.
-cuda = ["gwmock-signal[jax]>=0.13.0", "jax[cuda12]>=0.11.0"]
+cuda = ["gwmock-signal[jax]>=0.13.0", "ripplegw>=0.3", "jax[cuda12]>=0.11.0"]
 
 [dependency-groups]
 dev = [
-  # Declared here only so the `[tool.uv.sources]` pin below applies to it. uv honours a source
-  # for a package the project *declares*; ripplegw reaches gwmock transitively through
-  # `gwmock-signal[jax]`, and a source alone did not redirect it -- the lock resolved
-  # ripplegw 0.3.0 from the registry until this line existed. A dev group keeps it out of the
-  # published wheel, where a git dependency must never appear. Remove together with the pin.
-  "ripplegw>=0.3",
   "prek>=0.4.11",
   "pytest-cov>=7.1.0",
   "pytest-mock>=3.15.1",
@@ -187,8 +190,17 @@ docstring-code-format = true # Format code in docstrings
 # PLC0415: allow import statements not at the top level
 # PLR2004: allow magic values in the unit tests
 
-# TEMPORARY development pin. Remove when a ripplegw release carries the geocentre fix
-# (GW-JAX-Team/ripple#141), then raise the floor in the `jax` extra to that version.
+# TEMPORARY development pin. When a ripplegw release carries the geocentre fix
+# (GW-JAX-Team/ripple#141), do all of this together, or the paths below silently fall back to a
+# ripple without the fix:
+#
+#   1. delete this table;
+#   2. raise the `ripplegw>=0.3` floor in the `jax` and `cuda` extras above to that release;
+#   3. do the same in gwmock-signal, which carries its own copy of this pin;
+#   4. re-lock.
+#
+# Leaving the declarations without the table, or the table without the declarations, resolves
+# ripplegw 0.3.0 again -- and that is the version that returns NaN at the geocentre.
 #
 # Development-only: `[tool.uv.sources]` is not carried into the published wheel, so nobody
 # installing gwmock from PyPI inherits a git dependency. Build with `uv build --no-sources` while

--- a/uv.lock
+++ b/uv.lock
@@ -667,9 +667,11 @@ dependencies = [
 cuda = [
     { name = "gwmock-signal", extra = ["jax"] },
     { name = "jax", extra = ["cuda12"] },
+    { name = "ripplegw" },
 ]
 jax = [
     { name = "gwmock-signal", extra = ["jax"] },
+    { name = "ripplegw" },
 ]
 sgwb = [
     { name = "gwmock-signal", extra = ["sgwb"] },
@@ -686,7 +688,6 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-mock" },
-    { name = "ripplegw" },
 ]
 docs = [
     { name = "mkdocstrings-python" },
@@ -710,6 +711,8 @@ requires-dist = [
     { name = "psutil", specifier = ">=6.1.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
     { name = "pymap3d", specifier = ">=3.2.0" },
+    { name = "ripplegw", marker = "extra == 'cuda'", git = "https://github.com/GW-JAX-Team/ripple.git?rev=400afb4" },
+    { name = "ripplegw", marker = "extra == 'jax'", git = "https://github.com/GW-JAX-Team/ripple.git?rev=400afb4" },
     { name = "textual", specifier = ">=2.0.0" },
     { name = "tqdm", specifier = ">=4.67.0" },
     { name = "typer", specifier = ">=0.19.0" },
@@ -725,7 +728,6 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.4.2" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
-    { name = "ripplegw", git = "https://github.com/GW-JAX-Team/ripple.git?rev=400afb4" },
 ]
 docs = [
     { name = "mkdocstrings-python", specifier = ">=2.0.5" },

--- a/uv.lock
+++ b/uv.lock
@@ -686,6 +686,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-mock" },
+    { name = "ripplegw" },
 ]
 docs = [
     { name = "mkdocstrings-python" },
@@ -700,10 +701,10 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.16.0" },
     { name = "gwmock-noise", specifier = ">=0.10.0" },
     { name = "gwmock-pop", specifier = ">=0.11.4" },
-    { name = "gwmock-signal", git = "https://github.com/Leuven-Gravity-Institute/gwmock-signal.git?rev=589da1c" },
-    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'cuda'", git = "https://github.com/Leuven-Gravity-Institute/gwmock-signal.git?rev=589da1c" },
-    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'jax'", git = "https://github.com/Leuven-Gravity-Institute/gwmock-signal.git?rev=589da1c" },
-    { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", git = "https://github.com/Leuven-Gravity-Institute/gwmock-signal.git?rev=589da1c" },
+    { name = "gwmock-signal", specifier = ">=0.13.0" },
+    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'cuda'", specifier = ">=0.13.0" },
+    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'jax'", specifier = ">=0.13.0" },
+    { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", specifier = ">=0.13.0" },
     { name = "h5py", specifier = ">=3.12.1" },
     { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda'", specifier = ">=0.11.0" },
     { name = "psutil", specifier = ">=6.1.0" },
@@ -724,6 +725,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-github-actions-annotate-failures", specifier = ">=0.4.2" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "ripplegw", git = "https://github.com/GW-JAX-Team/ripple.git?rev=400afb4" },
 ]
 docs = [
     { name = "mkdocstrings-python", specifier = ">=2.0.5" },
@@ -768,13 +770,17 @@ wheels = [
 
 [[package]]
 name = "gwmock-signal"
-version = "0.12.1.dev6+g589da1ceb"
-source = { git = "https://github.com/Leuven-Gravity-Institute/gwmock-signal.git?rev=589da1c#589da1ceba8c631f397390b4afd708ca8f145059" }
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gwpy" },
     { name = "lalsuite" },
     { name = "pyyaml" },
     { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/ac/ef9fd787daae0b03c5d6b0ed5d09c973484e6cba6f57cddddac1fe50e8c0/gwmock_signal-0.13.0.tar.gz", hash = "sha256:72838b14ca0545ff25dcf36c61e42a6e1e46319677eecacfc0a756ec9fc40513", size = 437126, upload-time = "2026-08-03T11:39:51.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/6e/2eaa611c36e9c695678cf373f4e1d77d897b9bf2c55b82ed4940565aff99/gwmock_signal-0.13.0-py3-none-any.whl", hash = "sha256:31feb76bd44a1835a8dbe1f218a7e3ada81d9541b183fc813c0d6afdc5ab6f0c", size = 162065, upload-time = "2026-08-03T11:39:49.839Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 📝 Summary

gwmock-signal 0.13.0 is the first release carrying the continuous-wave simulator,
the device projection path, and the guard that refuses a non-finite geocentre
signal. The git pin on gwmock-signal comes out; the floors move to `>=0.13.0` in
`dependencies` and the `sgwb` / `jax` / `cuda` extras.

### The ripple pin has to move here, in the same change

Until now this file pinned *gwmock-signal* to a git revision, and that was
sufficient on its own: gwmock-signal carries its own `[tool.uv.sources]` pin of
ripplegw to the geocentre fix (GW-JAX-Team/ripple#141 — merged upstream as `ee148b6`, but not yet in a release), and uv
honours a git dependency's sources.

A wheel does not carry `[tool.uv.sources]`, so consuming the release breaks that
inheritance. Measured, not assumed — a scratch project depending only on
`gwmock-signal[jax]>=0.13.0` locks **ripplegw 0.3.0**, the version without the
fix. Without a pin here, continuous waves would not work in this repository's own
development or CI. They would fail loudly rather than silently, since 0.13.0
refuses NaN output, but they would not work.

### `[tool.uv.sources]` alone was not enough

uv applies a source to a package the project *declares*, and ripplegw reaches
gwmock only transitively through `gwmock-signal[jax]`. Adding the sources entry
changed nothing — the lock still resolved 0.3.0 from the registry — until
`ripplegw>=0.3` was declared in the `dev` group. A dev group is the right home:
development-only, so a git dependency cannot reach the published wheel.

Caught by re-reading `uv.lock` rather than trusting the edit. A pin that silently
does nothing looks identical to one that works, until continuous waves produce
NaN.

### A comment that stopped being true

The note claiming "one pin is enough" was correct only while gwmock-signal was a
git dependency. Rewritten, with the measurement, rather than left to mislead.

## ✨ Type of Change

- [x] 🎨 Refactoring (no functional changes, no API changes)

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** `uv run pytest` — 965 passed, 23 skipped
- [x] **Manual Test:** built the wheel with `uv build --no-sources` and read its
      metadata; re-resolved the lock; ran the continuous-wave suites against the
      released gwmock-signal.

| check | result |
|---|---|
| lock | gwmock-signal 0.13.0 (PyPI), ripplegw 0.3.1.dev3 (fork) |
| wheel metadata | `gwmock-signal>=0.13.0`, no git URL, ripplegw absent |
| continuous wave | 20 tests pass against the released gwmock-signal |

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Both pins come out together

#141 is merged upstream; what is missing is a ripplegw *release*. When one
appears: delete `[tool.uv.sources]`, raise the `ripplegw>=0.3` floor in the `jax`
and `cuda` extras to that release, do the same in gwmock-signal, and re-lock. The
four steps are written into `pyproject.toml`, with the reason they have to be done
as a unit — leaving either half alone resolves ripplegw 0.3.0 again.

The pinned revision `400afb4` is an ancestor of upstream `main`, so it stays
fetchable even after the source branch is deleted. That was worth checking: a pin
to a PR-head commit that only lived on a deleted branch would break every lock and
CI run. Until then continuous waves need a checkout, not a
PyPI install — and a PyPI install says so rather than writing NaN.

Not addressed here, tracked as `gwmock/cw-tests-never-run-in-ci`: gwmock's own
continuous-wave orchestration tests gate on a locally cached ephemeris, so they
skip in CI, and the CW e2e entry is marked not-run for the same reason. The fix
ports from gwmock-signal #364.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum compatibility requirements for the signal-processing package and optional integrations.
  * Added RippleGW to the development toolchain.
  * Updated development dependency sourcing for RippleGW.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
