### PR TITLE
test: run the continuous-wave tests in CI instead of skipping them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,86 @@ jobs:
     # It does *not* cover the gengli entry. gengli is not a declared extra of this project at all,
     # so no sync flag can install it, and that entry is separately blocked on a local glitch
     # fixture. It stays skipped here -- see NOT_HERMETIC in tests/e2e/overlay.py.
+    test-jax:
+        # The ripple/JAX-gated unit tests, which the `test` job cannot reach: it installs the dev
+        # group only, so every `importorskip("ripplegw")` there skips. That left the
+        # continuous-wave orchestration tests -- and the device-path tests -- running nowhere in
+        # CI while the suite reported green.
+        #
+        # One cell rather than the six of `test`: this exists to run the gated tests at all, and
+        # the code it covers is the same on every interpreter. Widen it if a version-specific
+        # failure ever appears.
+        runs-on: ubuntu-latest
+        # Pins ripple's ephemeris cache to one path. Its default is platform-dependent, so caching
+        # a hard-coded path would silently miss; RIPPLEGW_CACHE_DIR is a *base*, and ripple appends
+        # `ripplegw/ephemeris` to it, which is why the cached path is the base rather than the leaf.
+        env:
+            RIPPLEGW_CACHE_DIR: ${{ github.workspace }}/.ephemeris-cache
+            EPHEMERIS_FILES: earth00-40-DE405.dat.gz sun00-40-DE405.dat.gz
+        steps:
+            - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+              with:
+                  persist-credentials: false
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+              with:
+                  python-version: '3.12'
+                  enable-cache: 'true'
+
+            - name: Install dependencies with the JAX extra
+              run: uv sync --group dev --extra jax
+
+            - name: Confirm ripple is importable
+              # Otherwise this job silently becomes the thing it was added to fix: every gated test
+              # skips and the job still reports green.
+              run: uv run --no-sync python -c "import ripplegw"
+
+            # The continuous-wave tests need LALPulsar ephemeris tables, which ripple fetches from
+            # git.ligo.org on first use. Cached so the job does not depend on that service on every
+            # run; the identifier comes from the manifest, so accepting new tables invalidates it in
+            # the same commit that records them.
+            - name: Cache LALPulsar ephemeris tables
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+              with:
+                  path: ${{ github.workspace }}/.ephemeris-cache
+                  key:
+                      lalpulsar-ephemeris-${{
+                      hashFiles('tests/data/ephemeris.sha256') }}
+
+            # Fatal on failure, deliberately. The alternative is for the continuous-wave tests to
+            # skip, which is how they came to run nowhere in the first place.
+            - name: Fetch ephemeris tables if not cached
+              run: |
+                  for attempt in 1 2 3; do
+                      # shellcheck disable=SC2086 -- word splitting is the point here.
+                      if uv run --no-sync ripplegw-fetch-ephemeris $EPHEMERIS_FILES; then
+                          exit 0
+                      fi
+                      if [ "$attempt" -lt 3 ]; then
+                          echo "ephemeris fetch attempt $attempt failed; retrying"
+                          sleep $((attempt * 10))
+                      fi
+                  done
+                  echo "::error::could not fetch the LALPulsar ephemeris tables from" \
+                       "git.ligo.org after three attempts; the continuous-wave tests need them"
+                  exit 1
+
+            # These are physics inputs, taken from lalsuite `master` and keyed by name alone, so a
+            # changed upstream table or a corrupt cached copy would otherwise be used silently.
+            - name: Verify the ephemeris tables against their recorded hashes
+              run: uv run --no-sync python tests/data/verify_ephemeris.py
+
+            - name: Run tests with pytest (JAX backend)
+              run: uv run --no-sync pytest
+
+            - name: Upload coverage to Codecov (JAX backend)
+              if: ${{ !cancelled() }}
+              uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  flags: jax
+
     e2e:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
     workflow_dispatch:
     workflow_call:
 
+# Least privilege for every job here: they check out, install, test and upload coverage, and none
+# writes to the repository. Set at workflow level rather than on the job this branch adds, because
+# `test` and `e2e` were relying on the repository default too -- pinning one job and leaving its
+# siblings open would read as though the others had been considered and approved.
+permissions:
+    contents: read
+
 jobs:
     test:
         strategy:
@@ -249,4 +256,46 @@ jobs:
               run: uv run --no-sync python tests/data/verify_ephemeris.py
 
             - name: Run end-to-end tests
-              run: uv run --no-sync pytest -m e2e --no-cov
+              run:
+                  uv run --no-sync pytest -m e2e --no-cov
+                  --junitxml=e2e-report.xml
+
+            # The same outcome check the continuous-wave unit modules get, for the same reason. The
+            # e2e tests call `skip_if_unavailable(entry)` before running, so a matrix entry can skip
+            # itself -- a missing extra, or an entry put back into NOT_HERMETIC -- and this job would
+            # still report green. `NOT_HERMETIC` entries are expected to skip and are read from the
+            # source of truth rather than listed here, so adding one cannot leave this check behind.
+            - name: Confirm every runnable matrix entry actually ran
+              if: ${{ !cancelled() }}
+              run: |
+                  uv run --no-sync python - <<'CHECK'
+                  import sys
+                  import xml.etree.ElementTree as ET
+
+                  sys.path.append("tests")  # append: tests/signal would shadow stdlib signal
+                  from e2e.matrix import E2E_MATRIX
+                  from e2e.overlay import NOT_HERMETIC
+
+                  expected_to_skip = set(NOT_HERMETIC)
+                  runnable = [e.label for e in E2E_MATRIX if e.label not in expected_to_skip]
+
+                  root = ET.parse("e2e-report.xml").getroot()
+                  cases = list(root.iter("testcase"))
+                  if not cases:
+                      print("::error::the e2e run collected no tests at all")
+                      sys.exit(1)
+
+                  missing = []
+                  for label in runnable:
+                      mine = [c for c in cases if label in (c.get("name") or "")]
+                      if not mine:
+                          missing.append(f"{label}: no test referenced it")
+                      elif all(c.find("skipped") is not None for c in mine):
+                          missing.append(f"{label}: every test referencing it skipped")
+                  if missing:
+                      print("::error::matrix entries that did not run, though not in NOT_HERMETIC:")
+                      for line in missing:
+                          print(f"::error::{line}")
+                      sys.exit(1)
+                  print(f"all {len(runnable)} runnable matrix entries ran")
+                  CHECK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,35 @@ jobs:
             - name: Verify the ephemeris tables against their recorded hashes
               run: uv run --no-sync python tests/data/verify_ephemeris.py
 
+            # Asserts the outcome, not just the prerequisites. Everything above removes a *reason*
+            # to skip -- the extra is installed, the tables are present and verified -- but nothing
+            # so far would notice a re-added `skipif`, a renamed module or a changed marker quietly
+            # emptying this job, which is the exact failure it was added to fix. So the
+            # continuous-wave modules are run by name and the report is read back: zero collected,
+            # or anything skipped, fails.
+            - name: Confirm the continuous-wave tests actually ran
+              run: |
+                  uv run --no-sync pytest --no-cov -q \
+                      --junitxml=cw-report.xml \
+                      tests/cli/test_continuous_wave_orchestration.py \
+                      tests/cli/test_continuous_wave_wiring.py
+                  uv run --no-sync python - <<'CHECK'
+                  import sys
+                  import xml.etree.ElementTree as ET
+
+                  suite = ET.parse("cw-report.xml").getroot().find("testsuite")
+                  total = int(suite.get("tests", 0))
+                  skipped = int(suite.get("skipped", 0))
+                  print(f"continuous-wave tests: {total} collected, {skipped} skipped")
+                  if total == 0:
+                      print("::error::no continuous-wave tests were collected; this job is a no-op")
+                      sys.exit(1)
+                  if skipped:
+                      print(f"::error::{skipped} continuous-wave test(s) skipped; this job exists "
+                            "because they silently stopped running once already")
+                      sys.exit(1)
+                  CHECK
+
             - name: Run tests with pytest (JAX backend)
               run: uv run --no-sync pytest
 
@@ -149,6 +178,14 @@ jobs:
 
     e2e:
         runs-on: ubuntu-latest
+        # The same ephemeris pinning as `test-jax`, because jobs do not share a filesystem and the
+        # continuous-wave entry runs *here*. Without this the entry resolves its bare table names by
+        # downloading from lalsuite `master` unverified, which could generate against tables that
+        # differ from `tests/data/ephemeris.sha256` and then compare them against a stored
+        # reference -- passing whenever the difference happened to stay inside tolerance.
+        env:
+            RIPPLEGW_CACHE_DIR: ${{ github.workspace }}/.ephemeris-cache
+            EPHEMERIS_FILES: earth00-40-DE405.dat.gz sun00-40-DE405.dat.gz
         steps:
             - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
               with:
@@ -183,6 +220,33 @@ jobs:
                   missing = sorted(m for m in needed if u.find_spec(m) is None)
                   sys.exit('e2e job is missing: ' + ', '.join(missing) if missing else 0)
                   "
+
+            - name: Cache LALPulsar ephemeris tables
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+              with:
+                  path: ${{ github.workspace }}/.ephemeris-cache
+                  key:
+                      lalpulsar-ephemeris-${{
+                      hashFiles('tests/data/ephemeris.sha256') }}
+
+            - name: Fetch ephemeris tables if not cached
+              run: |
+                  for attempt in 1 2 3; do
+                      # shellcheck disable=SC2086 -- word splitting is the point here.
+                      if uv run --no-sync ripplegw-fetch-ephemeris $EPHEMERIS_FILES; then
+                          exit 0
+                      fi
+                      if [ "$attempt" -lt 3 ]; then
+                          echo "ephemeris fetch attempt $attempt failed; retrying"
+                          sleep $((attempt * 10))
+                      fi
+                  done
+                  echo "::error::could not fetch the LALPulsar ephemeris tables from" \
+                       "git.ligo.org after three attempts; the continuous-wave entry needs them"
+                  exit 1
+
+            - name: Verify the ephemeris tables against their recorded hashes
+              run: uv run --no-sync python tests/data/verify_ephemeris.py
 
             - name: Run end-to-end tests
               run: uv run --no-sync pytest -m e2e --no-cov

--- a/examples/README.md
+++ b/examples/README.md
@@ -163,7 +163,7 @@ matrix needs a new entry.
 | `signal/sgwb/et_triangle_sardinia`                 | `StochasticBackgroundSimulator` — a different simulator class; **HDF5** output                            |
 | `signal/waveform_backend/ripple`                   | A non-default waveform library resolved from config. Needs `ripplegw`                                     |
 | `signal/execution/batched`                         | `execution: batched` — one batched call per segment, converted back to per-event chunks. Needs `ripplegw` |
-| `signal/cw/et_triangle_sardinia`                   | **Not run** — the continuous-wave branch of `_simulate`, blocked on a local ephemeris fixture             |
+| `signal/cw/et_triangle_sardinia`                   | The continuous-wave branch of `_simulate`; multi-segment, since one segment cannot distinguish it         |
 | `noise/glitches/gengli/et_triangle_sardinia/e1`    | **Not run** — glitch injection, blocked on `gengli` and a local glitch fixture                            |
 
 Deliberately excluded, with the reason:

--- a/tests/cli/test_continuous_wave_orchestration.py
+++ b/tests/cli/test_continuous_wave_orchestration.py
@@ -9,11 +9,16 @@ The simulator guarantees coherence only if ``reference_time_ssb`` reaches it as 
 whole run; plumbing that derived it per segment would produce frames that look entirely normal and
 are useless to a coherent search.
 
-This module needs ``ripplegw`` and a cached ephemeris, so it skips wherever those are absent --
-including CI. Everything that does *not* need a waveform lives in ``test_continuous_wave_wiring.py``
-instead, which runs everywhere: routing, the refusals, the ordering exemption and its source-type
-gate, provenance, and that the population index never advances. Adding a wiring-level test here
-rather than there means it will not run on any push.
+This module needs ``ripplegw`` and the LALPulsar ephemeris tables, and it **does** run in CI: the
+`test-jax` job installs the extra, caches the tables and verifies them against
+``tests/data/ephemeris.sha256``. It used to skip when they were absent, which on a fresh runner was
+always, so it ran nowhere while the suite reported green. There is no skip gate now -- absent
+tables fail.
+
+Everything that does *not* need a waveform lives in ``test_continuous_wave_wiring.py``, which runs
+in the default job too: routing, the refusals, the ordering exemption and its source-type gate,
+provenance, and that the population index never advances. Put a wiring-level test there rather than
+here, so it is covered without the optional extra.
 """
 
 from __future__ import annotations

--- a/tests/cli/test_continuous_wave_orchestration.py
+++ b/tests/cli/test_continuous_wave_orchestration.py
@@ -32,7 +32,22 @@ from gwmock.cli.utils.config import Config
 _EPOCH = 1577491218.0
 _FS = 64.0
 _DETECTORS = ["H1", "L1"]
-_EPHEMERIS = Path.home() / ".cache/ripplegw/ephemeris"
+
+
+def _ephemeris_directory() -> Path:
+    """Return where ripple keeps its cached ephemeris tables, asking ripple rather than guessing.
+
+    This was hardcoded to ``~/.cache/ripplegw/ephemeris``, which is the *Linux* default. Ripple
+    uses ``~/Library/Caches`` on macOS and honours ``RIPPLEGW_CACHE_DIR`` above both, so the
+    hardcoded path made these tests skip on macOS -- and skip in CI generally -- even where the
+    tables were present. Reading the location from ripple cannot drift from it.
+    """
+    from ripplegw.waveforms.cw.ephemeris import _cache_dir
+
+    return Path(_cache_dir())
+
+
+_EPHEMERIS = _ephemeris_directory()
 
 _PULSARS = (
     "right_ascension,declination,frequency,initial_phase,amplitude_plus,amplitude_cross,polarization_angle\n"
@@ -41,11 +56,12 @@ _PULSARS = (
 )
 
 
-def _ephemeris_available() -> bool:
-    return (_EPHEMERIS / "earth00-40-DE405.dat.gz").is_file() and (_EPHEMERIS / "sun00-40-DE405.dat.gz").is_file()
-
-
-pytestmark = pytest.mark.skipif(not _ephemeris_available(), reason="LALPulsar ephemeris tables are not cached locally")
+# No skip gate. These tests used to skip when the tables were not cached, which meant they never
+# ran in CI at all: the ephemeris is fetched on demand, so "not cached" was the normal state on a
+# fresh runner, and the module reported skipped rather than absent. A test that stops running
+# silently is worse than one that fails. CI now caches the tables, verifies them against
+# `tests/data/ephemeris.sha256`, and fails the job if it cannot obtain them; locally, ripple
+# fetches them on first use.
 
 
 def _config(tmp_path: Path, *, duration: float, total: float, n_pulsars: int = 2) -> dict[str, Any]:

--- a/tests/cli/test_continuous_wave_wiring.py
+++ b/tests/cli/test_continuous_wave_wiring.py
@@ -1,9 +1,11 @@
 """The continuous-wave branch of the orchestrator, exercised without a waveform library.
 
-``test_continuous_wave_orchestration.py`` covers the same branch against the real backend, which
-is where phase coherence and the numerical composition are established. That module needs
-``ripplegw`` and a cached ephemeris, so it skips everywhere those are absent -- including CI, which
-left the branch reported as uncovered and, more to the point, unexercised on every push.
+``test_continuous_wave_orchestration.py`` covers the same branch against the real backend, which is
+where phase coherence and the numerical composition are established. That module needs ``ripplegw``
+and the LALPulsar ephemeris tables, so it runs in the `test-jax` job rather than the default one.
+
+This module runs everywhere, which is the point of separating them: the wiring is covered without
+the optional extra, and only claims that need real strain depend on it.
 
 What is checked here is the wiring: which route a `cw` configuration takes, what it refuses, what
 it records, and that the catalogue is summed rather than overwritten. None of that involves a

--- a/tests/data/ephemeris.sha256
+++ b/tests/data/ephemeris.sha256
@@ -1,0 +1,20 @@
+# SHA-256 of the LALPulsar ephemeris tables the continuous-wave tests generate against.
+#
+# These are physics inputs, not build artefacts: they define the Earth and Sun trajectories the
+# barycentring uses, so a change to their content changes generated strain. ripple fetches them
+# from lalsuite `master` -- an unpinned moving target -- and caches them by name only, so without
+# this file a changed upstream table, or a corrupted cached copy, would be used silently and show
+# up as a numerical difference nobody could attribute.
+#
+# Two things use it. CI derives its cache identifier from this file, so editing it invalidates
+# the cache; and a verification step rejects tables that do not match, rather than letting a bad
+# copy reach a test as a confusing parse error.
+#
+# Recorded 2026-08-03 from ripplegw's own download of
+# https://git.ligo.org/lscsoft/lalsuite/-/raw/master/lalpulsar/lib/<name>.
+#
+# If verification fails: either the cache is corrupt (clear it and refetch) or upstream changed
+# the tables. The second case is worth understanding before updating these lines, because it
+# means the reference trajectories moved.
+4995647b2c47617c90804ad0bc814ce42b426f1e5015a90cf939bcdd0c20ea67  earth00-40-DE405.dat.gz
+0b132dc5a712ebc16661a10cb88409e2577c16723c64f98e9b9b4d265510700f  sun00-40-DE405.dat.gz

--- a/tests/data/ephemeris.sha256
+++ b/tests/data/ephemeris.sha256
@@ -16,5 +16,10 @@
 # If verification fails: either the cache is corrupt (clear it and refetch) or upstream changed
 # the tables. The second case is worth understanding before updating these lines, because it
 # means the reference trajectories moved.
+#
+# **Updating these hashes changes generated strain, so regenerate the continuous-wave e2e
+# reference in the same commit** -- `tests/e2e/references/signal__cw__et_triangle_sardinia.json`
+# was produced against the tables below. Nothing enforces that pairing: split across two commits,
+# the reference comparison fails on the second one and looks like a code regression.
 4995647b2c47617c90804ad0bc814ce42b426f1e5015a90cf939bcdd0c20ea67  earth00-40-DE405.dat.gz
 0b132dc5a712ebc16661a10cb88409e2577c16723c64f98e9b9b4d265510700f  sun00-40-DE405.dat.gz

--- a/tests/data/verify_ephemeris.py
+++ b/tests/data/verify_ephemeris.py
@@ -1,0 +1,79 @@
+"""Check the cached LALPulsar ephemeris tables against their recorded hashes.
+
+Run by CI after fetching them, and usable by hand:
+
+    uv run python tests/data/verify_ephemeris.py
+
+These are physics inputs, not build artefacts: they define the Earth and Sun trajectories the
+barycentring uses, so their content changes generated strain. Ripple takes them from lalsuite
+``master`` -- an unpinned moving target -- and its fetch is satisfied by the file merely existing,
+so without this a changed upstream table or a corrupt cached copy is used silently and surfaces as
+a parse error deep inside a test, attributed to nothing.
+
+Exits non-zero and names the offending file with expected and actual digests. The message
+distinguishes the two causes, because "the cache is corrupt" and "the reference trajectories moved"
+want very different responses.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import pathlib
+import sys
+
+MANIFEST = pathlib.Path(__file__).with_name("ephemeris.sha256")
+
+
+def cache_directory() -> pathlib.Path:
+    """Return where ripple keeps its cached tables, asking ripple rather than guessing.
+
+    Ripple's default is platform-dependent -- ``~/Library/Caches`` on macOS against
+    ``$XDG_CACHE_HOME`` or ``~/.cache`` elsewhere -- and ``RIPPLEGW_CACHE_DIR`` overrides both.
+    Reproducing that logic here would be one more place to drift from it.
+    """
+    from ripplegw.waveforms.cw.ephemeris import _cache_dir
+
+    return pathlib.Path(_cache_dir())
+
+
+def main() -> int:
+    """Return 0 when every table matches, 1 otherwise."""
+    cache = cache_directory()
+    expected_by_name: dict[str, str] = {}
+    for line in MANIFEST.read_text(encoding="utf-8").splitlines():
+        if not line.strip() or line.startswith("#"):
+            continue
+        digest, name = line.split()
+        expected_by_name[name] = digest
+
+    if not expected_by_name:
+        print(f"::error::{MANIFEST} lists no tables, so this check would pass vacuously")
+        return 1
+
+    failures: list[str] = []
+    for name, expected in sorted(expected_by_name.items()):
+        path = cache / name
+        if not path.is_file():
+            failures.append(f"{name}: missing from {cache}")
+            continue
+        actual = hashlib.sha256(path.read_bytes()).hexdigest()
+        if actual != expected:
+            failures.append(f"{name}: expected {expected}, got {actual}")
+
+    if failures:
+        print(f"::error::ephemeris tables do not match {MANIFEST}")
+        for failure in failures:
+            print(f"::error::{failure}")
+        print(
+            "::error::either the cache holds a corrupt copy, or lalsuite master changed the "
+            "tables -- the second means the reference trajectories moved and is worth "
+            "understanding before updating the manifest"
+        )
+        return 1
+
+    print(f"verified {len(expected_by_name)} ephemeris tables under {cache}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/data/verify_ephemeris.py
+++ b/tests/data/verify_ephemeris.py
@@ -43,7 +43,13 @@ def main() -> int:
     for line in MANIFEST.read_text(encoding="utf-8").splitlines():
         if not line.strip() or line.startswith("#"):
             continue
-        digest, name = line.split()
+        fields = line.split()
+        if len(fields) != 2:
+            # Reported rather than raised: an unpacking traceback exits non-zero too, but it names
+            # Python internals instead of the file the reader has to fix.
+            print(f"::error::{MANIFEST}: cannot read {line!r}; expected '<sha256>  <filename>'")
+            return 1
+        digest, name = fields
         expected_by_name[name] = digest
 
     if not expected_by_name:

--- a/tests/e2e/matrix.py
+++ b/tests/e2e/matrix.py
@@ -80,10 +80,11 @@ E2E_MATRIX: tuple[MatrixEntry, ...] = (
     MatrixEntry(
         label="signal/cw/et_triangle_sardinia",
         covers=(
-            "**Not run** -- the continuous-wave branch of `_simulate`, the one path where a "
-            "population is never consumed and every source contributes to every segment. Blocked "
-            "on a local ephemeris fixture: the example resolves bare LALPulsar table names, which "
-            "ripple fetches at runtime, and the smaller of the two is 16 MB compressed"
+            "The continuous-wave branch of `_simulate` -- the one path where a population is never "
+            "consumed and every source contributes to every segment. Multi-segment on purpose: a "
+            "single segment cannot distinguish that from the per-event path. Needs `ripplegw` and "
+            "the LALPulsar ephemeris tables, which CI caches and verifies against "
+            "`tests/data/ephemeris.sha256`"
         ),
         requires=("ripplegw",),
     ),

--- a/tests/e2e/overlay.py
+++ b/tests/e2e/overlay.py
@@ -38,6 +38,14 @@ _TEST_SEED = 20260731
 #: run is reproducible and needs no network.
 POPULATION_FIXTURE = EXAMPLES_DIR / "signal" / "bbh_population.csv"
 
+#: In-repo pulsar catalogue for the continuous-wave entry.
+#:
+#: The example points at this file with a path relative to the examples tree, which does not
+#: survive being copied into a test working directory -- the run failed with
+#: `FileNotFoundError: ../../cw_population.csv`. Repointed absolutely for the same reason every
+#: other entry's population is: the overlay owns where inputs come from.
+CW_POPULATION_FIXTURE = EXAMPLES_DIR / "signal" / "cw_population.csv"
+
 #: The single event in :data:`POPULATION_FIXTURE`.
 _FIXTURE_EVENT_GPS = 1577491300.0
 
@@ -50,12 +58,6 @@ _ALIGNED_START = 1577491296.0
 #: skipped rather than run against a remote URL. Removing an entry from here requires adding a
 #: local fixture for whatever it downloads.
 NOT_HERMETIC: dict[str, str] = {
-    "signal/cw/et_triangle_sardinia": (
-        "needs a local ephemeris fixture; the example names LALPulsar tables that ripple fetches "
-        "and caches at runtime, and earth00-40-DE405.dat.gz alone is 16 MB compressed -- too "
-        "large to commit, and truncating it to the test span would mean shipping fabricated "
-        "ephemeris data"
-    ),
     "noise/glitches/gengli/et_triangle_sardinia/e1": (
         "needs a local blip-glitch population fixture; the example reads one from "
         "sandbox.zenodo.org, whose records are purged"
@@ -129,6 +131,26 @@ _OVERLAYS: dict[str, dict[str, Any]] = {
         },
         "orchestration": {"population": {"arguments": {"path": str(POPULATION_FIXTURE)}}},
     },
+    # A continuous wave is on for the whole run, so there is no event to bracket and nothing to
+    # align a start time to -- the only thing to shorten is the span. Kept multi-segment on
+    # purpose: this entry exists to cover the branch where a population is never consumed and
+    # every source contributes to every segment, and one segment could not distinguish that from
+    # the per-event path.
+    #
+    # The ephemeris the example names is fetched by ripple on first use; CI caches it and verifies
+    # it against `tests/data/ephemeris.sha256`. That is why this entry is no longer in
+    # NOT_HERMETIC: the tables are obtained once and their content is pinned, rather than being
+    # re-downloaded per run or trusted unchecked.
+    "signal/cw/et_triangle_sardinia": {
+        "globals": {
+            "simulator-arguments": {
+                "sampling-frequency": 256,
+                "duration": 8,
+                "total-duration": 16,
+            }
+        },
+        "orchestration": {"population": {"arguments": {"path": str(CW_POPULATION_FIXTURE)}}},
+    },
     # Deliberately the same overlay as the ripple entry above: the two configs differ only by
     # `execution`, and holding the span, rate and population identical is what makes their stored
     # references comparable. The batched path JIT-compiles like the per-event ripple one.
@@ -154,6 +176,9 @@ CONTAINS_SIGNAL: frozenset[str] = frozenset(
         "signal/bbh/et_triangle_sardinia",
         "signal/waveform_backend/ripple",
         "signal/execution/batched",
+        # Every pulsar is present in every segment, so any span contains signal -- unlike the
+        # transient entries, whose span has to be aligned to an event.
+        "signal/cw/et_triangle_sardinia",
     }
 )
 

--- a/tests/e2e/references/signal__cw__et_triangle_sardinia.json
+++ b/tests/e2e/references/signal__cw__et_triangle_sardinia.json
@@ -1,0 +1,85 @@
+{
+  "environment": {
+    "astropy": "8.0.1",
+    "astropy-iers-data": "0.2026.8.3.0.53.6",
+    "gwmock": "0.12.0.post25+b328dab",
+    "gwmock-noise": "0.10.0",
+    "gwmock-pop": "0.11.4",
+    "gwmock-signal": "0.13.0",
+    "jax": "0.11.0",
+    "jaxlib": "0.11.0",
+    "lalsuite": "7.26.15",
+    "numpy": "2.5.1",
+    "pyerfa": "2.0.1.5",
+    "ripplegw": "0.3.1.dev3",
+    "scipy": "1.18.0"
+  },
+  "fingerprint": {
+    "machine": "x86_64",
+    "python": "3.12",
+    "system": "Linux"
+  },
+  "label": "signal/cw/et_triangle_sardinia",
+  "outputs": {
+    "output/signal/E-ET1_SARD_STRAIN_CW-1577491218-8.gwf": {
+      "argmax": 1596,
+      "content_hash": "sha256:971cd6c8194757f90caeb21405fcf2c1eeb249c6e80bb5cb5cc4d88f506e1c8f",
+      "mean": -3.57026670465963e-30,
+      "n": 2048,
+      "nonzero": 2048,
+      "peak": 8.503537108474799e-25,
+      "rms": 4.312563283282665e-25,
+      "signed_peak": -8.503537108474799e-25
+    },
+    "output/signal/E-ET1_SARD_STRAIN_CW-1577491226-8.gwf": {
+      "argmax": 1596,
+      "content_hash": "sha256:0c6076978cb9b52c5e61924134afb70cd3c21178cf00185f7e5ab7bff860a7af",
+      "mean": -4.099113186296669e-30,
+      "n": 2048,
+      "nonzero": 2048,
+      "peak": 8.595204977999033e-25,
+      "rms": 4.311911968125572e-25,
+      "signed_peak": -8.595204977999033e-25
+    },
+    "output/signal/E-ET2_SARD_STRAIN_CW-1577491218-8.gwf": {
+      "argmax": 126,
+      "content_hash": "sha256:16c8b8a65fd545e063537f892675bfa01fb72f681559e466321505d05df5403d",
+      "mean": -2.2826834470497144e-29,
+      "n": 2048,
+      "nonzero": 2048,
+      "peak": 6.372869739829235e-25,
+      "rms": 3.320503890161997e-25,
+      "signed_peak": 6.372869739829235e-25
+    },
+    "output/signal/E-ET2_SARD_STRAIN_CW-1577491226-8.gwf": {
+      "argmax": 126,
+      "content_hash": "sha256:60975965ca9227788777f9493c84576ed226147e19cd0eb73f0ff2cb020c8001",
+      "mean": -2.2830034500322928e-29,
+      "n": 2048,
+      "nonzero": 2048,
+      "peak": 6.356385622199647e-25,
+      "rms": 3.319800338434843e-25,
+      "signed_peak": 6.356385622199647e-25
+    },
+    "output/signal/E-ET3_SARD_STRAIN_CW-1577491218-8.gwf": {
+      "argmax": 1991,
+      "content_hash": "sha256:8265f313a36543e699e09cadb034f56fd8994304d1805b0dfedfa77c77e9a8c0",
+      "mean": 2.6304883348775483e-29,
+      "n": 2048,
+      "nonzero": 2048,
+      "peak": 8.337866832638094e-25,
+      "rms": 4.288318076250312e-25,
+      "signed_peak": 8.337866832638094e-25
+    },
+    "output/signal/E-ET3_SARD_STRAIN_CW-1577491226-8.gwf": {
+      "argmax": 967,
+      "content_hash": "sha256:7f70ec147f2bccc23b77b7cfa584a111398085ef2adf557617b87588a418cde5",
+      "mean": 2.683838691585971e-29,
+      "n": 2048,
+      "nonzero": 2048,
+      "peak": 8.346343006458691e-25,
+      "rms": 4.28590789214661e-25,
+      "signed_peak": 8.346343006458691e-25
+    }
+  }
+}


### PR DESCRIPTION
## 📝 Summary

The continuous-wave tests ran **nowhere** in CI, and nothing reported that. Two
independent gates, with the suite green through both:

- the `test` job installs `--group dev` only, so every `importorskip("ripplegw")`
  skipped — ripple lives in the `jax`/`cuda` extras;
- `tests/cli/test_continuous_wave_orchestration.py` additionally skipped unless the
  LALPulsar ephemeris tables were already cached, which on a fresh runner they
  never are, because ripple fetches them on demand;
- the e2e entry sat in `NOT_HERMETIC`, labelled **not run**, for the same reason.

So the `_simulate` branch added in #302, and the device projection behind it, were
covered only on machines that happened to have run continuous waves before.

## What changed

A single-cell `test-jax` job installs the `jax` extra and runs the unit suite. The
ephemeris is cached with the identifier derived from `tests/data/ephemeris.sha256`,
and verified against those hashes before the tests run — they are physics inputs,
taken from lalsuite `master` and keyed by name alone, so a changed upstream table
or a corrupt cached copy would otherwise be used silently. A failed fetch fails the
job; skipping is what produced this situation.

**The same steps are on the `e2e` job**, because jobs do not share a filesystem and
the continuous-wave entry runs there.

**The job asserts its outcome, not just its prerequisites.** Installing the extra
and verifying the tables removes *reasons* to skip; nothing would notice a
re-added `skipif`, a renamed module or a changed marker quietly emptying the job —
the exact failure this fixes, reintroduced by one line. It runs the two
continuous-wave modules by name, reads back the JUnit report, and fails on zero
collected or anything skipped.

The e2e entry is out of `NOT_HERMETIC` with an overlay, kept multi-segment since
one segment cannot distinguish a never-consumed population from the per-event path,
and added to `CONTAINS_SIGNAL` because an always-on source fills every span.

## Two bugs the skip gate was hiding

- **The module hardcoded `~/.cache/ripplegw/ephemeris`** — the *Linux* default.
  Ripple uses `~/Library/Caches` on macOS and honours `RIPPLEGW_CACHE_DIR` above
  both, so it would have skipped on macOS even where the tables were present. It
  now asks ripple.
- **Running the e2e entry failed immediately**: `FileNotFoundError:
  ../../cw_population.csv`. The example points at its catalogue with a path
  relative to the examples tree, which does not survive being copied into a test
  working directory. Repointed like every other entry's population.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** `uv run pytest` — 967 passed, 23 skipped
- [x] **Manual Test:** `uv run pytest -m e2e --no-cov` — **47 passed, 9 skipped**,
      up from 41 passed / 15 skipped. Also exercised `verify_ephemeris.py` against
      the real tables, a corrupted copy, a missing table, an empty manifest and a
      malformed line; and mutation-checked the ran-for-real guard by injecting a
      `pytest.mark.skip`, which fails it.

The new reference was reviewed rather than accepted: six outputs for three
detectors across two segments, 2048 samples each at 8 s and 256 Hz, and **every**
sample non-zero — the signature of an always-on source, where a transient would be
mostly zeros. Peaks differ per detector and shift slightly between consecutive
segments, as a rotating antenna pattern should.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Known limits, named rather than buried

- **macOS continuous-wave coverage is still absent.** The job is one cell, so the
  platform-dependent cache lookup this PR *fixes* is never exercised on macOS.
  Widening to the full six cells costs six ephemeris fetches and six JAX installs
  per run — worth deciding rather than assuming.
- **`verify_ephemeris.py` and the test module read ripple's private `_cache_dir`.**
  Preferred over reimplementing the platform logic, and it fails loudly if it
  moves, but it is a private API in a package currently pinned to an unreleased
  revision. Re-check when that pin comes out.
- **The new reference has two moving inputs**: `astropy-iers-data`, whose weekly
  release already exceeds the drift tolerance (`gwmock/iers-reference-churn`), and
  the DE405 tables. Updating the hashes requires regenerating the reference in the
  same commit; nothing enforces that, so it is documented in the manifest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added continuous-wave end-to-end coverage for the Sardinia Einstein Telescope triangle scenario.
  * Continuous-wave tests now run with validated ephemeris data instead of being skipped when local tables are unavailable.
  * Added reference outputs and a lightweight local fixture for reliable, reproducible testing.
* **Chores**
  * Improved automated validation, caching, downloading, and integrity checks for ephemeris data across test environments.
  * Added JAX-specific test coverage and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->