### PR TITLE
test(e2e): run the examples at an epoch inside the IERS table

### DIFF
--- a/tests/e2e/data/bbh_population.csv
+++ b/tests/e2e/data/bbh_population.csv
@@ -1,0 +1,2 @@
+detector_frame_mass_1,detector_frame_mass_2,coa_time,distance,declination,right_ascension,polarization_angle,inclination
+30.0,25.0,1419724820.0,400.0,0.3,1.1,0.2,0.5

--- a/tests/e2e/overlay.py
+++ b/tests/e2e/overlay.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_THIS_DIRECTORY = Path(__file__).resolve().parent
 EXAMPLES_DIR = _REPO_ROOT / "examples"
 
 #: Seed pinned for every run, so two runs of one entry are comparable.
@@ -36,7 +37,11 @@ _TEST_SEED = 20260731
 
 #: In-repo CBC population, used in place of every remote population file. Small and fixed, so a
 #: run is reproducible and needs no network.
-POPULATION_FIXTURE = EXAMPLES_DIR / "signal" / "bbh_population.csv"
+#:
+#: Test-owned rather than the example's copy, because its coalescence time has to sit at the epoch
+#: below and the examples deliberately use 2030. Identical to
+#: ``examples/signal/bbh_population.csv`` apart from that time.
+POPULATION_FIXTURE = _THIS_DIRECTORY / "data" / "bbh_population.csv"
 
 #: In-repo pulsar catalogue for the continuous-wave entry.
 #:
@@ -47,12 +52,28 @@ POPULATION_FIXTURE = EXAMPLES_DIR / "signal" / "bbh_population.csv"
 CW_POPULATION_FIXTURE = EXAMPLES_DIR / "signal" / "cw_population.csv"
 
 #: The single event in :data:`POPULATION_FIXTURE`.
-_FIXTURE_EVENT_GPS = 1577491300.0
+_FIXTURE_EVENT_GPS = 1419724820.0
 
 #: Start time placing that event inside a short segment. A run whose span misses the population
 #: still succeeds and writes only zeros, so this is not a cosmetic choice -- see the
 #: ``contains_signal`` assertions in the end-to-end tests.
-_ALIGNED_START = 1577491296.0
+#:
+#: 2025-01-01, and the choice of *year* is load-bearing. The shipped examples run in 2030 to match
+#: the Einstein Telescope era, which is roughly 885 days beyond the end of the IERS Earth-orientation
+#: table Astropy ships. Astropy clamps UT1-UTC to the table's final value there, so every weekly
+#: `astropy-iers-data` release moved that clamped value and with it the generated strain -- measured
+#: at 1.569e-06 of peak, above this suite's 1e-06 drift tolerance, so the reference comparison failed
+#: roughly weekly on something that was not a defect.
+#:
+#: Inside the *finalised* part of the table, nothing moves. Measured across the 0.2026.7.27 and
+#: 0.2026.8.3 releases: UT1-UTC at 2024-01-01, 2025-01-01 and 2026-01-01 is bit-identical, while
+#: 2030-01-01 stepped by 2.740 ms. Finalised data ended 2026-07-23 when this was chosen, so this
+#: epoch keeps about eighteen months of margin before the prediction boundary.
+#:
+#: The cost, stated because it is a real one: the suite no longer exercises the epoch the examples
+#: document. What that could hide is an error that depends on being far outside the IERS table --
+#: which is the situation this deliberately stops testing.
+_ALIGNED_START = 1419724816.0
 
 #: Entries that cannot be run without fetching from the network, with the reason. These are
 #: skipped rather than run against a remote URL. Removing an entry from here requires adding a
@@ -147,8 +168,14 @@ _OVERLAYS: dict[str, dict[str, Any]] = {
                 "sampling-frequency": 256,
                 "duration": 8,
                 "total-duration": 16,
+                "start-time": _ALIGNED_START,
             }
         },
+        # The SSB reference moves with the data. It could stay in 2030 -- it is only the epoch the
+        # spin parameters refer to -- but then the phase would be accumulated across five years for
+        # no reason, and the run would be describing a catalogue referenced to a time it never
+        # covers.
+        "signal": {"arguments": {"reference_time_ssb": _ALIGNED_START}},
         "orchestration": {"population": {"arguments": {"path": str(CW_POPULATION_FIXTURE)}}},
     },
     # Deliberately the same overlay as the ripple entry above: the two configs differ only by

--- a/tests/e2e/overlay.py
+++ b/tests/e2e/overlay.py
@@ -51,14 +51,29 @@ POPULATION_FIXTURE = _THIS_DIRECTORY / "data" / "bbh_population.csv"
 #: other entry's population is: the overlay owns where inputs come from.
 CW_POPULATION_FIXTURE = EXAMPLES_DIR / "signal" / "cw_population.csv"
 
-#: The single event in :data:`POPULATION_FIXTURE`.
-_FIXTURE_EVENT_GPS = 1419724820.0
+
+def _fixture_event_gps() -> float:
+    """Return the single event's coalescence time, read from the fixture rather than restated.
+
+    Duplicating it let the CSV and this constant drift: the bracket check below would keep passing
+    while the event sat outside every segment, and only the slower end-to-end nonzero assertion
+    would have caught it.
+    """
+    rows = POPULATION_FIXTURE.read_text(encoding="utf-8").strip().splitlines()
+    columns = rows[0].split(",")
+    return float(rows[1].split(",")[columns.index("coa_time")])
+
+
+#: The single event in :data:`POPULATION_FIXTURE`, read from the file itself.
+_FIXTURE_EVENT_GPS = _fixture_event_gps()
 
 #: Start time placing that event inside a short segment. A run whose span misses the population
 #: still succeeds and writes only zeros, so this is not a cosmetic choice -- see the
 #: ``contains_signal`` assertions in the end-to-end tests.
 #:
-#: 2025-01-01, and the choice of *year* is load-bearing. The shipped examples run in 2030 to match
+#: GPS 1419724816, which is 2024-12-31 23:59:58 UTC -- chosen for 16-second alignment, so the
+#: fixture event four seconds later falls at 2025-01-01 00:00:02. The choice of *year* is
+#: load-bearing; the seconds are only alignment. The shipped examples run in 2030 to match
 #: the Einstein Telescope era, which is roughly 885 days beyond the end of the IERS Earth-orientation
 #: table Astropy ships. Astropy clamps UT1-UTC to the table's final value there, so every weekly
 #: `astropy-iers-data` release moved that clamped value and with it the generated strain -- measured
@@ -68,11 +83,22 @@ _FIXTURE_EVENT_GPS = 1419724820.0
 #: Inside the *finalised* part of the table, nothing moves. Measured across the 0.2026.7.27 and
 #: 0.2026.8.3 releases: UT1-UTC at 2024-01-01, 2025-01-01 and 2026-01-01 is bit-identical, while
 #: 2030-01-01 stepped by 2.740 ms. Finalised data ended 2026-07-23 when this was chosen, so this
-#: epoch keeps about eighteen months of margin before the prediction boundary.
+#: epoch keeps about eighteen months of margin before the prediction boundary, and the margin only
+#: grows as the table extends.
 #:
-#: The cost, stated because it is a real one: the suite no longer exercises the epoch the examples
-#: document. What that could hide is an error that depends on being far outside the IERS table --
-#: which is the situation this deliberately stops testing.
+#: Not an indefinite bit-stability guarantee, though. IERS does occasionally reprocess historical
+#: spans when the C04 solution's reference frame changes -- 2021-2024 data has been revised that
+#: way -- so a future release could still move this epoch. What the move buys is removing a
+#: *weekly* certainty, not every possibility; a rare reprocessing is what
+#: `astropy-iers-data` staying in the recorded package list is for.
+#:
+#: The cost, stated because it is a real one, and narrower than it first looks: the *reference
+#: comparison* no longer runs at the epoch the examples document, so an error that depends on being
+#: far outside the IERS table would not show up in a reference diff. The far-future regime is still
+#: exercised by unit tests that stay at 2030 -- the continuous-wave orchestration, device-chunk and
+#: content-before-segment modules among them -- and those do not churn, because they assert
+#: properties rather than compare against stored numbers. So what is lost is reference-level
+#: coverage of the clamped regime, not all coverage of it.
 _ALIGNED_START = 1419724816.0
 
 #: Entries that cannot be run without fetching from the network, with the reason. These are
@@ -175,8 +201,17 @@ _OVERLAYS: dict[str, dict[str, Any]] = {
         # spin parameters refer to -- but then the phase would be accumulated across five years for
         # no reason, and the run would be describing a catalogue referenced to a time it never
         # covers.
-        "signal": {"arguments": {"reference_time_ssb": _ALIGNED_START}},
-        "orchestration": {"population": {"arguments": {"path": str(CW_POPULATION_FIXTURE)}}},
+        #
+        # Nested under `orchestration`, which is where the configuration reads it. The first
+        # version of this put `signal` at the root: the deep merge accepted the stray key without
+        # complaint, the effective value stayed at the example's 2030 epoch, and both the override
+        # and this comment were false while every test passed.
+        # One `orchestration` key, not two. Written as two at first, and Python keeps only the
+        # last -- so the reference-epoch override vanished silently and nothing failed.
+        "orchestration": {
+            "population": {"arguments": {"path": str(CW_POPULATION_FIXTURE)}},
+            "signal": {"arguments": {"reference_time_ssb": _ALIGNED_START}},
+        },
     },
     # Deliberately the same overlay as the ripple entry above: the two configs differ only by
     # `execution`, and holding the span, rate and population identical is what makes their stored

--- a/tests/e2e/reference_values.py
+++ b/tests/e2e/reference_values.py
@@ -92,10 +92,10 @@ _RECORDED_PACKAGES = (
     # package version changed, so a dependency bump does not explain this" -- pointing the next
     # reader at a code regression that did not exist.
     #
-    # What actually moves, stated precisely because the obvious reading is wrong. The examples run
-    # at GPS 1577491296, which is 2030-01-01 -- about 885 days *beyond* the end of the packaged
-    # IERS table. Astropy clamps UT1-UTC to the table's final value there, so what changes each
-    # week is not a revised measurement for 2030 but the clamped edge following the table's new
+    # What used to move, and why it no longer does. The shipped examples run at GPS 1577491296 --
+    # 2030-01-01, about 885 days *beyond* the end of the packaged IERS table, where Astropy clamps
+    # UT1-UTC to the final tabulated value. What changed each week was not a revised measurement
+    # for 2030 but the clamped edge following the table's new
     # end date: -0.044955 s to -0.047695 s, a step of 2.740 ms. That rotates GMST by 1.9976e-07
     # rad, matching 2.740e-3 s x 7.2921e-5 rad/s to 0.02%.
     #
@@ -132,16 +132,21 @@ _RECORDED_PACKAGES_ARE_CURATED = True
 #: Nobody has measured how far apart two platforms actually land, so treat it as a bound on what
 #: this check can detect rather than as a statement about numerical agreement.
 #:
-#: **One legitimate drift now exceeds it**, which the paragraph above no longer describes
-#: correctly. A weekly `astropy-iers-data` release moves the clamped Earth-orientation value at
-#: these examples' 2030 epoch, and that reached 1.569e-06 on one detector -- above this bound. So
-#: the comparison fails roughly weekly on a change that is not a defect.
+#: A weekly `astropy-iers-data` release used to exceed this bound, reaching 1.569e-06 on one
+#: detector, because the examples ran at a 2030 epoch beyond the end of the Earth-orientation
+#: table where Astropy clamps UT1-UTC to the final tabulated value -- so every release moved that
+#: clamp and the generated strain with it. That is fixed at the cause: the suite now runs inside
+#: the finalised part of the table (see ``_ALIGNED_START`` in ``overlay.py``), where the value is
+#: bit-identical across releases.
 #:
-#: Left at 1e-06 deliberately. Raising it to sit above routine Earth-orientation movement would
-#: also stop it detecting a projection regression of the same size, and projection errors are
-#: exactly what it exists to catch. The alternative -- running the examples at an epoch inside the
-#: IERS table, where only a revised finalised value moves anything -- fixes the cause instead of
-#: hiding it, and is the open question rather than this number.
+#: Left at 1e-06 rather than widened, and the distinction matters. Raising it to sit above routine
+#: Earth-orientation movement would also have stopped it detecting a projection regression of the
+#: same size, which is what it exists to catch.
+#:
+#: What can still move output through this route is a *revised finalised* value, which IERS does
+#: occasionally publish. That is rare and small rather than weekly, and it is why
+#: `astropy-iers-data` stays in :data:`_RECORDED_PACKAGES`: the churn is gone, the dependency is
+#: not.
 STATISTIC_TOLERANCE = 1e-6
 
 

--- a/tests/e2e/references/default_config.json
+++ b/tests/e2e/references/default_config.json
@@ -2,7 +2,7 @@
   "environment": {
     "astropy": "8.0.1",
     "astropy-iers-data": "0.2026.8.3.0.53.6",
-    "gwmock": "0.12.0.post25+b328dab",
+    "gwmock": "0.12.0.post28+148c143",
     "gwmock-noise": "0.10.0",
     "gwmock-pop": "0.11.4",
     "gwmock-signal": "0.13.0",

--- a/tests/e2e/references/noise__uncorrelated_gaussian__et_triangle_sardinia.json
+++ b/tests/e2e/references/noise__uncorrelated_gaussian__et_triangle_sardinia.json
@@ -2,7 +2,7 @@
   "environment": {
     "astropy": "8.0.1",
     "astropy-iers-data": "0.2026.8.3.0.53.6",
-    "gwmock": "0.12.0.post25+b328dab",
+    "gwmock": "0.12.0.post28+148c143",
     "gwmock-noise": "0.10.0",
     "gwmock-pop": "0.11.4",
     "gwmock-signal": "0.13.0",

--- a/tests/e2e/references/noise__uncorrelated_gaussian__quick_start.json
+++ b/tests/e2e/references/noise__uncorrelated_gaussian__quick_start.json
@@ -2,7 +2,7 @@
   "environment": {
     "astropy": "8.0.1",
     "astropy-iers-data": "0.2026.8.3.0.53.6",
-    "gwmock": "0.12.0.post25+b328dab",
+    "gwmock": "0.12.0.post28+148c143",
     "gwmock-noise": "0.10.0",
     "gwmock-pop": "0.11.4",
     "gwmock-signal": "0.13.0",
@@ -21,9 +21,9 @@
   },
   "label": "noise/uncorrelated_gaussian/quick_start",
   "outputs": {
-    "output/noise/E-ET1_SARD_STRAIN_NOISE-1577491296-16.gwf": {
+    "output/noise/E-ET1_SARD_STRAIN_NOISE-1419724816-16.gwf": {
       "argmax": 16381,
-      "content_hash": "sha256:9720b5c8e102fd0a8e8f0d553662fa558fd960d19de4889b4f93c2792549a6b1",
+      "content_hash": "sha256:a49a4a3c03bc55292e6716cd84f0a04ab3124b5c1bd0393761ce52838a49f5bc",
       "mean": 4.9510246572524466e-26,
       "n": 16384,
       "nonzero": 16384,
@@ -31,9 +31,9 @@
       "rms": 4.237765002169535e-23,
       "signed_peak": -1.626182300858675e-22
     },
-    "output/noise/E-ET2_SARD_STRAIN_NOISE-1577491296-16.gwf": {
+    "output/noise/E-ET2_SARD_STRAIN_NOISE-1419724816-16.gwf": {
       "argmax": 1850,
-      "content_hash": "sha256:661268ba948d009057fb0c1ba88fb8c3c668e15a5fbc648a3313c87d95d7464f",
+      "content_hash": "sha256:c545f9aa7dad39d93729f8789d5138ccff4eeee83cc88570c21eb705032579b3",
       "mean": -8.353027018740866e-26,
       "n": 16384,
       "nonzero": 16384,
@@ -41,9 +41,9 @@
       "rms": 4.288438072677149e-23,
       "signed_peak": 1.7077067895293085e-22
     },
-    "output/noise/E-ET3_SARD_STRAIN_NOISE-1577491296-16.gwf": {
+    "output/noise/E-ET3_SARD_STRAIN_NOISE-1419724816-16.gwf": {
       "argmax": 8533,
-      "content_hash": "sha256:d87b5db9c91144fd90667436c60c757143a348e1488324e27b9fcfd4dd8bab09",
+      "content_hash": "sha256:fc0d8b5681218f036340f909df703350b8d8ca3170c76626bed3b01ff142012f",
       "mean": 5.120818541779048e-27,
       "n": 16384,
       "nonzero": 16384,
@@ -51,35 +51,35 @@
       "rms": 5.481805055732837e-23,
       "signed_peak": -1.9929523480377454e-22
     },
-    "output/signal/E-ET1_SARD_STRAIN_BBH-1577491296-16.gwf": {
+    "output/signal/E-ET1_SARD_STRAIN_BBH-1419724816-16.gwf": {
       "argmax": 4079,
-      "content_hash": "sha256:8b2fb296535f1a18505345eaf9a4a4c8daac457b312f2cde0dc5e5d908b58597",
-      "mean": -1.173071888195575e-27,
+      "content_hash": "sha256:b5e1c2a1a15c9f7f2e58ddac2c572dc34d5fc0039b0a6db8ba5e566a87a78960",
+      "mean": -1.1816462862718835e-27,
       "n": 16384,
       "nonzero": 4096,
-      "peak": 8.452943015158544e-22,
-      "rms": 5.446048949803173e-23,
-      "signed_peak": 8.452943015158544e-22
+      "peak": 8.396916948925513e-22,
+      "rms": 5.454434411024383e-23,
+      "signed_peak": 8.396916948925513e-22
     },
-    "output/signal/E-ET2_SARD_STRAIN_BBH-1577491296-16.gwf": {
+    "output/signal/E-ET2_SARD_STRAIN_BBH-1419724816-16.gwf": {
       "argmax": 4082,
-      "content_hash": "sha256:f705aa91865069b1d65b8ba081d0360a669dd5d71944a5a0b246151fc328c780",
-      "mean": 9.089474289874154e-27,
+      "content_hash": "sha256:9af739bddf96c75c60d61bb01062edf3d43ef947815c7c900bd37b9798412dfd",
+      "mean": 9.113982210136405e-27,
       "n": 16384,
       "nonzero": 4096,
-      "peak": 9.222137785018572e-22,
-      "rms": 5.512287322735116e-23,
-      "signed_peak": 9.222137785018572e-22
+      "peak": 9.267975864821214e-22,
+      "rms": 5.517820988449424e-23,
+      "signed_peak": 9.267975864821214e-22
     },
-    "output/signal/E-ET3_SARD_STRAIN_BBH-1577491296-16.gwf": {
+    "output/signal/E-ET3_SARD_STRAIN_BBH-1419724816-16.gwf": {
       "argmax": 4083,
-      "content_hash": "sha256:9735e8a2538627799441b4cb762d7fa2e493ef4488807f353292d55e1bc05694",
-      "mean": -7.936226852108053e-27,
+      "content_hash": "sha256:a475617de581cfa3076ebdd51719d149a7a3a388b35cd6c50499efa6af10eb52",
+      "mean": -7.952108992471122e-27,
       "n": 16384,
       "nonzero": 4096,
-      "peak": 7.612419388814761e-22,
-      "rms": 5.232304819245205e-23,
-      "signed_peak": -7.612419388814761e-22
+      "peak": 7.475129026517652e-22,
+      "rms": 5.2408965716174654e-23,
+      "signed_peak": -7.475129026517652e-22
     }
   }
 }

--- a/tests/e2e/references/signal__bbh__et_triangle_sardinia.json
+++ b/tests/e2e/references/signal__bbh__et_triangle_sardinia.json
@@ -2,7 +2,7 @@
   "environment": {
     "astropy": "8.0.1",
     "astropy-iers-data": "0.2026.8.3.0.53.6",
-    "gwmock": "0.12.0.post25+b328dab",
+    "gwmock": "0.12.0.post28+148c143",
     "gwmock-noise": "0.10.0",
     "gwmock-pop": "0.11.4",
     "gwmock-signal": "0.13.0",
@@ -21,35 +21,35 @@
   },
   "label": "signal/bbh/et_triangle_sardinia",
   "outputs": {
-    "output/signal/E-ET1_SARD_STRAIN_BBH-1577491296-16.gwf": {
+    "output/signal/E-ET1_SARD_STRAIN_BBH-1419724816-16.gwf": {
       "argmax": 4080,
-      "content_hash": "sha256:f7d5453a2b42f954af4093a4734f7b41b2712ecdf95991d6feeed3505c5e0aa5",
-      "mean": 3.530805972389288e-26,
+      "content_hash": "sha256:d8eb57220b2e8a38097a78284dea7f18107e4187cea363037e9bf9f8a576bae5",
+      "mean": 3.536902191228812e-26,
       "n": 16384,
       "nonzero": 5734,
-      "peak": 8.97489943162297e-22,
-      "rms": 7.831724680915335e-23,
-      "signed_peak": 8.97489943162297e-22
+      "peak": 8.942912893531663e-22,
+      "rms": 7.843767013252251e-23,
+      "signed_peak": 8.942912893531663e-22
     },
-    "output/signal/E-ET2_SARD_STRAIN_BBH-1577491296-16.gwf": {
+    "output/signal/E-ET2_SARD_STRAIN_BBH-1419724816-16.gwf": {
       "argmax": 4083,
-      "content_hash": "sha256:808ee81f1b7e47fd2eb203b8cd6720c4c7b39bf5e3a71c5c498a288be2022d23",
-      "mean": -1.1654495466478243e-25,
+      "content_hash": "sha256:08d8186354490c41b62fca1cb3ca2f56e81e878ee0675691e69ddf5aea1b31f2",
+      "mean": -1.1667909992070215e-25,
       "n": 16384,
       "nonzero": 5734,
-      "peak": 8.697599348955181e-22,
-      "rms": 7.926107523860575e-23,
-      "signed_peak": 8.697599348955181e-22
+      "peak": 8.628683230152873e-22,
+      "rms": 7.934049945434054e-23,
+      "signed_peak": 8.628683230152873e-22
     },
-    "output/signal/E-ET3_SARD_STRAIN_BBH-1577491296-16.gwf": {
+    "output/signal/E-ET3_SARD_STRAIN_BBH-1419724816-16.gwf": {
       "argmax": 4079,
-      "content_hash": "sha256:041eb57dfbf5c733e74ea764c36f831feb18001f58abd40fe676d3505fd69706",
-      "mean": 8.12797392841756e-26,
+      "content_hash": "sha256:4ea263dd2c7daf369472d59c234a4e1567380a79b969a7f541d623989bbfcb47",
+      "mean": 8.135247733784193e-26,
       "n": 16384,
       "nonzero": 5734,
-      "peak": 8.368663761797118e-22,
-      "rms": 7.520224300863269e-23,
-      "signed_peak": -8.368663761797118e-22
+      "peak": 8.353640727666681e-22,
+      "rms": 7.532562266117961e-23,
+      "signed_peak": -8.353640727666681e-22
     }
   }
 }

--- a/tests/e2e/references/signal__cw__et_triangle_sardinia.json
+++ b/tests/e2e/references/signal__cw__et_triangle_sardinia.json
@@ -23,63 +23,63 @@
   "outputs": {
     "output/signal/E-ET1_SARD_STRAIN_CW-1419724816-8.gwf": {
       "argmax": 653,
-      "content_hash": "sha256:1d0132f226da67e36f149e202908aee620cde4e79fddf6bce713e01da3f5fcf9",
-      "mean": -4.0785087551809195e-29,
+      "content_hash": "sha256:ea1b528f43831819c90890bcde0b18ab8498a70e2bc005e3019c217b20bdae49",
+      "mean": -4.0779608509577994e-29,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 8.669711332741158e-25,
-      "rms": 4.308881348968329e-25,
-      "signed_peak": 8.669711332741158e-25
+      "peak": 8.669719437127463e-25,
+      "rms": 4.308881299526465e-25,
+      "signed_peak": 8.669719437127463e-25
     },
     "output/signal/E-ET1_SARD_STRAIN_CW-1419724824-8.gwf": {
       "argmax": 141,
-      "content_hash": "sha256:dca45a4d356e8792041b14028e63273b177be03ef0196a2b5172713c04607a41",
-      "mean": -3.806612393719352e-29,
+      "content_hash": "sha256:8f2fccccec0f645ddd81bbc1c8ce57092d3029601811698b0923c35f3c133e26",
+      "mean": -3.806399163955231e-29,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 8.65365562023137e-25,
-      "rms": 4.308332017973152e-25,
-      "signed_peak": 8.65365562023137e-25
+      "peak": 8.653649255856141e-25,
+      "rms": 4.308331956972266e-25,
+      "signed_peak": 8.653649255856141e-25
     },
     "output/signal/E-ET2_SARD_STRAIN_CW-1419724816-8.gwf": {
       "argmax": 1827,
-      "content_hash": "sha256:232a789b7c117c6e4cec9c65fb22e54916f8aa26c8c807500c092f3eaa2fbc73",
-      "mean": 6.386526373851543e-30,
+      "content_hash": "sha256:4b305a855242b7aa97238344cfd48b4facd5b67189da6d1cb7b20091499d6325",
+      "mean": 6.386176818971265e-30,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 6.40240210447646e-25,
-      "rms": 3.31667932433335e-25,
-      "signed_peak": 6.40240210447646e-25
+      "peak": 6.402404321983363e-25,
+      "rms": 3.3166792911182656e-25,
+      "signed_peak": 6.402404321983363e-25
     },
     "output/signal/E-ET2_SARD_STRAIN_CW-1419724824-8.gwf": {
       "argmax": 1827,
-      "content_hash": "sha256:e95eef0625c1973af0fad754a7086e2308c76c1116fd4c82186909b48c0f0a35",
-      "mean": 3.8033646432315444e-30,
+      "content_hash": "sha256:bbf453b1f63cd26437a9676cc9c4b51adbcf5e3471af2c6ec92877a12074a939",
+      "mean": 3.799044455510672e-30,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 6.435754335923702e-25,
-      "rms": 3.315999775754061e-25,
-      "signed_peak": 6.435754335923702e-25
+      "peak": 6.435753627922695e-25,
+      "rms": 3.3159998152712577e-25,
+      "signed_peak": 6.435753627922695e-25
     },
     "output/signal/E-ET3_SARD_STRAIN_CW-1419724816-8.gwf": {
       "argmax": 94,
-      "content_hash": "sha256:de01665fbdb46e2c51715085aaf6d0ff80220bd67de07d06dd60d0001c0aaed7",
-      "mean": 3.464445384610895e-29,
+      "content_hash": "sha256:7c26177f46c63344d876507705ce17299e58543272d091ef24345179d59188bf",
+      "mean": 3.4639300076440884e-29,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 7.982566408071731e-25,
-      "rms": 4.274023452599483e-25,
-      "signed_peak": 7.982566408071731e-25
+      "peak": 7.982557734013806e-25,
+      "rms": 4.2740235644150125e-25,
+      "signed_peak": 7.982557734013806e-25
     },
     "output/signal/E-ET3_SARD_STRAIN_CW-1419724824-8.gwf": {
       "argmax": 1644,
-      "content_hash": "sha256:99e81c8028890fe47451b675242db312b85f4c0868904d7e1a1612282118965c",
-      "mean": 3.4511264692912955e-29,
+      "content_hash": "sha256:c4f2334699de3a9f9bc130e41f727ffa98d3253e7cc36210e06aa56a3d88db8e",
+      "mean": 3.4513462422540224e-29,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 8.061700383330487e-25,
-      "rms": 4.271662891343619e-25,
-      "signed_peak": 8.061700383330487e-25
+      "peak": 8.061702410942921e-25,
+      "rms": 4.2716628140774055e-25,
+      "signed_peak": 8.061702410942921e-25
     }
   }
 }

--- a/tests/e2e/references/signal__cw__et_triangle_sardinia.json
+++ b/tests/e2e/references/signal__cw__et_triangle_sardinia.json
@@ -2,7 +2,7 @@
   "environment": {
     "astropy": "8.0.1",
     "astropy-iers-data": "0.2026.8.3.0.53.6",
-    "gwmock": "0.12.0.post25+b328dab",
+    "gwmock": "0.12.0.post28+148c143",
     "gwmock-noise": "0.10.0",
     "gwmock-pop": "0.11.4",
     "gwmock-signal": "0.13.0",
@@ -21,65 +21,65 @@
   },
   "label": "signal/cw/et_triangle_sardinia",
   "outputs": {
-    "output/signal/E-ET1_SARD_STRAIN_CW-1577491218-8.gwf": {
-      "argmax": 1596,
-      "content_hash": "sha256:971cd6c8194757f90caeb21405fcf2c1eeb249c6e80bb5cb5cc4d88f506e1c8f",
-      "mean": -3.57026670465963e-30,
+    "output/signal/E-ET1_SARD_STRAIN_CW-1419724816-8.gwf": {
+      "argmax": 653,
+      "content_hash": "sha256:1d0132f226da67e36f149e202908aee620cde4e79fddf6bce713e01da3f5fcf9",
+      "mean": -4.0785087551809195e-29,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 8.503537108474799e-25,
-      "rms": 4.312563283282665e-25,
-      "signed_peak": -8.503537108474799e-25
+      "peak": 8.669711332741158e-25,
+      "rms": 4.308881348968329e-25,
+      "signed_peak": 8.669711332741158e-25
     },
-    "output/signal/E-ET1_SARD_STRAIN_CW-1577491226-8.gwf": {
-      "argmax": 1596,
-      "content_hash": "sha256:0c6076978cb9b52c5e61924134afb70cd3c21178cf00185f7e5ab7bff860a7af",
-      "mean": -4.099113186296669e-30,
+    "output/signal/E-ET1_SARD_STRAIN_CW-1419724824-8.gwf": {
+      "argmax": 141,
+      "content_hash": "sha256:dca45a4d356e8792041b14028e63273b177be03ef0196a2b5172713c04607a41",
+      "mean": -3.806612393719352e-29,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 8.595204977999033e-25,
-      "rms": 4.311911968125572e-25,
-      "signed_peak": -8.595204977999033e-25
+      "peak": 8.65365562023137e-25,
+      "rms": 4.308332017973152e-25,
+      "signed_peak": 8.65365562023137e-25
     },
-    "output/signal/E-ET2_SARD_STRAIN_CW-1577491218-8.gwf": {
-      "argmax": 126,
-      "content_hash": "sha256:16c8b8a65fd545e063537f892675bfa01fb72f681559e466321505d05df5403d",
-      "mean": -2.2826834470497144e-29,
+    "output/signal/E-ET2_SARD_STRAIN_CW-1419724816-8.gwf": {
+      "argmax": 1827,
+      "content_hash": "sha256:232a789b7c117c6e4cec9c65fb22e54916f8aa26c8c807500c092f3eaa2fbc73",
+      "mean": 6.386526373851543e-30,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 6.372869739829235e-25,
-      "rms": 3.320503890161997e-25,
-      "signed_peak": 6.372869739829235e-25
+      "peak": 6.40240210447646e-25,
+      "rms": 3.31667932433335e-25,
+      "signed_peak": 6.40240210447646e-25
     },
-    "output/signal/E-ET2_SARD_STRAIN_CW-1577491226-8.gwf": {
-      "argmax": 126,
-      "content_hash": "sha256:60975965ca9227788777f9493c84576ed226147e19cd0eb73f0ff2cb020c8001",
-      "mean": -2.2830034500322928e-29,
+    "output/signal/E-ET2_SARD_STRAIN_CW-1419724824-8.gwf": {
+      "argmax": 1827,
+      "content_hash": "sha256:e95eef0625c1973af0fad754a7086e2308c76c1116fd4c82186909b48c0f0a35",
+      "mean": 3.8033646432315444e-30,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 6.356385622199647e-25,
-      "rms": 3.319800338434843e-25,
-      "signed_peak": 6.356385622199647e-25
+      "peak": 6.435754335923702e-25,
+      "rms": 3.315999775754061e-25,
+      "signed_peak": 6.435754335923702e-25
     },
-    "output/signal/E-ET3_SARD_STRAIN_CW-1577491218-8.gwf": {
-      "argmax": 1991,
-      "content_hash": "sha256:8265f313a36543e699e09cadb034f56fd8994304d1805b0dfedfa77c77e9a8c0",
-      "mean": 2.6304883348775483e-29,
+    "output/signal/E-ET3_SARD_STRAIN_CW-1419724816-8.gwf": {
+      "argmax": 94,
+      "content_hash": "sha256:de01665fbdb46e2c51715085aaf6d0ff80220bd67de07d06dd60d0001c0aaed7",
+      "mean": 3.464445384610895e-29,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 8.337866832638094e-25,
-      "rms": 4.288318076250312e-25,
-      "signed_peak": 8.337866832638094e-25
+      "peak": 7.982566408071731e-25,
+      "rms": 4.274023452599483e-25,
+      "signed_peak": 7.982566408071731e-25
     },
-    "output/signal/E-ET3_SARD_STRAIN_CW-1577491226-8.gwf": {
-      "argmax": 967,
-      "content_hash": "sha256:7f70ec147f2bccc23b77b7cfa584a111398085ef2adf557617b87588a418cde5",
-      "mean": 2.683838691585971e-29,
+    "output/signal/E-ET3_SARD_STRAIN_CW-1419724824-8.gwf": {
+      "argmax": 1644,
+      "content_hash": "sha256:99e81c8028890fe47451b675242db312b85f4c0868904d7e1a1612282118965c",
+      "mean": 3.4511264692912955e-29,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 8.346343006458691e-25,
-      "rms": 4.28590789214661e-25,
-      "signed_peak": 8.346343006458691e-25
+      "peak": 8.061700383330487e-25,
+      "rms": 4.271662891343619e-25,
+      "signed_peak": 8.061700383330487e-25
     }
   }
 }

--- a/tests/e2e/references/signal__execution__batched.json
+++ b/tests/e2e/references/signal__execution__batched.json
@@ -2,7 +2,7 @@
   "environment": {
     "astropy": "8.0.1",
     "astropy-iers-data": "0.2026.8.3.0.53.6",
-    "gwmock": "0.12.0.post25+b328dab",
+    "gwmock": "0.12.0.post28+148c143",
     "gwmock-noise": "0.10.0",
     "gwmock-pop": "0.11.4",
     "gwmock-signal": "0.13.0",
@@ -21,35 +21,35 @@
   },
   "label": "signal/execution/batched",
   "outputs": {
-    "output/signal/E-ET1_SARD_STRAIN_BBH-1577491296-16.gwf": {
+    "output/signal/E-ET1_SARD_STRAIN_BBH-1419724816-16.gwf": {
       "argmax": 4076,
-      "content_hash": "sha256:26ef46ad0b8d099fd8d84ff7e052b1bd017352d70de85999d614f86ceb815906",
-      "mean": 6.162627147715549e-29,
+      "content_hash": "sha256:b40694b5baac42a0d4cf00b13ef609be9dcf50494888fe1dbfdb24a6305dd640",
+      "mean": 6.173696180791245e-29,
       "n": 16384,
       "nonzero": 4557,
-      "peak": 8.371565670421422e-22,
-      "rms": 5.450588945669413e-23,
-      "signed_peak": -8.371565670421422e-22
+      "peak": 8.431968264816197e-22,
+      "rms": 5.458974796912211e-23,
+      "signed_peak": -8.431968264816197e-22
     },
-    "output/signal/E-ET2_SARD_STRAIN_BBH-1577491296-16.gwf": {
+    "output/signal/E-ET2_SARD_STRAIN_BBH-1419724816-16.gwf": {
       "argmax": 4077,
-      "content_hash": "sha256:d7b060c69e624b9bce556a6132227f7dbd27f445b22bd43da95fe01b41eea44a",
-      "mean": 3.899885264320979e-29,
+      "content_hash": "sha256:721778280c018f312d4a192817957da12d10d415d03d2c8728dba5478178e155",
+      "mean": 3.903047642409647e-29,
       "n": 16384,
       "nonzero": 4557,
-      "peak": 8.889966192414945e-22,
-      "rms": 5.515358700573951e-23,
-      "signed_peak": 8.889966192414945e-22
+      "peak": 8.907997490923896e-22,
+      "rms": 5.520897306305166e-23,
+      "signed_peak": 8.907997490923896e-22
     },
-    "output/signal/E-ET3_SARD_STRAIN_BBH-1577491296-16.gwf": {
+    "output/signal/E-ET3_SARD_STRAIN_BBH-1419724816-16.gwf": {
       "argmax": 4078,
-      "content_hash": "sha256:fc5e58f2f237dc845db59d33f19a4ba550a57575a2a92eca3a369c82f9bd3e1e",
-      "mean": -1.0088625145610389e-28,
+      "content_hash": "sha256:e5d5be46e50c8b0c52c5aa0f2eb0a3b43f4b9e32f8011330e1b5ee764484b169",
+      "mean": -1.0102809248976426e-28,
       "n": 16384,
       "nonzero": 4557,
-      "peak": 8.291564320518887e-22,
-      "rms": 5.2376575527026696e-23,
-      "signed_peak": -8.291564320518887e-22
+      "peak": 8.2331497179279805e-22,
+      "rms": 5.2462627198733615e-23,
+      "signed_peak": -8.2331497179279805e-22
     }
   }
 }

--- a/tests/e2e/references/signal__sgwb__et_triangle_sardinia.json
+++ b/tests/e2e/references/signal__sgwb__et_triangle_sardinia.json
@@ -2,7 +2,7 @@
   "environment": {
     "astropy": "8.0.1",
     "astropy-iers-data": "0.2026.8.3.0.53.6",
-    "gwmock": "0.12.0.post25+b328dab",
+    "gwmock": "0.12.0.post28+148c143",
     "gwmock-noise": "0.10.0",
     "gwmock-pop": "0.11.4",
     "gwmock-signal": "0.13.0",

--- a/tests/e2e/references/signal__waveform_backend__ripple.json
+++ b/tests/e2e/references/signal__waveform_backend__ripple.json
@@ -2,7 +2,7 @@
   "environment": {
     "astropy": "8.0.1",
     "astropy-iers-data": "0.2026.8.3.0.53.6",
-    "gwmock": "0.12.0.post25+b328dab",
+    "gwmock": "0.12.0.post28+148c143",
     "gwmock-noise": "0.10.0",
     "gwmock-pop": "0.11.4",
     "gwmock-signal": "0.13.0",
@@ -21,35 +21,35 @@
   },
   "label": "signal/waveform_backend/ripple",
   "outputs": {
-    "output/signal/E-ET1_SARD_STRAIN_BBH-1577491296-16.gwf": {
+    "output/signal/E-ET1_SARD_STRAIN_BBH-1419724816-16.gwf": {
       "argmax": 4076,
-      "content_hash": "sha256:6c8c477afc768a65a76b61996689915c6e5802055625d54743890142e57f4d77",
-      "mean": 6.162627145403949e-29,
+      "content_hash": "sha256:c181037d511929a4e1a35a6ec15c2e418d7aa9eaeb5119449b121da9d5b292e1",
+      "mean": 6.173696167832431e-29,
       "n": 16384,
       "nonzero": 4557,
-      "peak": 8.371565670419655e-22,
-      "rms": 5.450588945669484e-23,
-      "signed_peak": -8.371565670419655e-22
+      "peak": 8.43196826480844e-22,
+      "rms": 5.45897479691129e-23,
+      "signed_peak": -8.43196826480844e-22
     },
-    "output/signal/E-ET2_SARD_STRAIN_BBH-1577491296-16.gwf": {
+    "output/signal/E-ET2_SARD_STRAIN_BBH-1419724816-16.gwf": {
       "argmax": 4077,
-      "content_hash": "sha256:0c3465a635c33982d22fe910282ad92a8f9677d2fcd1e4231ded80ad05dfdb41",
-      "mean": 3.8998852589388807e-29,
+      "content_hash": "sha256:78210729923406b21060f34da2750227007ea2af4387beff3d96daf433f4852b",
+      "mean": 3.903047656861146e-29,
       "n": 16384,
       "nonzero": 4557,
-      "peak": 8.889966192414501e-22,
-      "rms": 5.515358700574e-23,
-      "signed_peak": 8.889966192414501e-22
+      "peak": 8.907997490922055e-22,
+      "rms": 5.520897306304593e-23,
+      "signed_peak": 8.907997490922055e-22
     },
-    "output/signal/E-ET3_SARD_STRAIN_BBH-1577491296-16.gwf": {
+    "output/signal/E-ET3_SARD_STRAIN_BBH-1419724816-16.gwf": {
       "argmax": 4078,
-      "content_hash": "sha256:dabd53dfca02f0696cb8b9b886c6ef2b69405f41bf3ecef9f61a3e506e50bafa",
-      "mean": -1.0088625152108486e-28,
+      "content_hash": "sha256:a99d0a3fb6f286263a69f493bb0d762a66e4d0c8c19e9a24471290e9da55389a",
+      "mean": -1.0102809259169924e-28,
       "n": 16384,
       "nonzero": 4557,
-      "peak": 8.29156432052176e-22,
-      "rms": 5.2376575527027025e-23,
-      "signed_peak": -8.29156432052176e-22
+      "peak": 8.233149717937569e-22,
+      "rms": 5.2462627198724217e-23,
+      "signed_peak": -8.233149717937569e-22
     }
   }
 }

--- a/tests/e2e/test_overlay.py
+++ b/tests/e2e/test_overlay.py
@@ -209,3 +209,94 @@ def test_the_runner_pins_the_earth_orientation_table():
     assert completed.stdout.strip() == "False", (
         f"the runner's environment left IERS auto-download enabled: {completed.stdout.strip()!r}"
     )
+
+
+def test_the_population_fixture_matches_the_example_it_copies():
+    """The test-owned catalogue must differ from the example's only in ``coa_time``.
+
+    It exists because the e2e epoch has to sit inside the IERS table while the examples stay in
+    2030, so the coalescence time cannot be shared. Everything else -- masses, distance, sky
+    position, inclination -- must track the example, or the suite quietly stops testing the
+    configuration it claims to and the stored references stop describing the documented example.
+
+    Nothing else enforces that: the neighbouring guard checks the event falls inside the span, not
+    that the two files agree. Duplication without a guard is how the copy goes stale.
+    """
+    example = EXAMPLES_DIR / "signal" / "bbh_population.csv"
+    fixture = POPULATION_FIXTURE
+
+    example_rows = example.read_text(encoding="utf-8").strip().splitlines()
+    fixture_rows = fixture.read_text(encoding="utf-8").strip().splitlines()
+
+    assert fixture_rows[0] == example_rows[0], (
+        f"{fixture.name} and {example.name} disagree on their columns; the fixture is a copy of "
+        f"the example and must follow it"
+    )
+    assert len(fixture_rows) == len(example_rows), (
+        f"{example.name} has {len(example_rows) - 1} event(s) and {fixture.name} has "
+        f"{len(fixture_rows) - 1}; the e2e suite would test a different population than the example"
+    )
+
+    columns = example_rows[0].split(",")
+    time_column = columns.index("coa_time")
+    paired = zip(fixture_rows[1:], example_rows[1:], strict=True)
+    for line_number, (mine, theirs) in enumerate(paired, start=2):
+        mine_fields, theirs_fields = mine.split(","), theirs.split(",")
+        fields = zip(mine_fields, theirs_fields, strict=True)
+        differing = [columns[i] for i, (a, b) in enumerate(fields) if a != b]
+        assert differing == ["coa_time"], (
+            f"line {line_number} differs in {differing} as well as coa_time; only the coalescence "
+            f"time may differ between the fixture and the example"
+        )
+    # And the coalescence time must actually differ, or the fixture has no reason to exist.
+    assert fixture_rows[1].split(",")[time_column] != example_rows[1].split(",")[time_column]
+
+
+def test_every_overlay_override_survives_the_merge(tmp_path: Path):
+    """An override that lands nowhere is worse than no override: it reads as done and is not.
+
+    This catches one of the two ways that happened while writing this module: a `signal` key at the
+        overlay's root, which the deep merge accepted while the configuration read
+        `orchestration.signal`. Silent -- the config parsed, the run succeeded, the value stayed the
+        example's.
+
+        The other way, two `orchestration` keys in one dict literal where Python keeps only the last,
+        is *not* covered here and cannot be: the duplicate is discarded at parse time, so the overlay
+        this test inspects never contains the lost override. Ruff's `F601` catches that one, and the
+        pre-commit hook enforces it -- worth knowing so nobody adds a test here expecting to.
+    """
+
+    def leaves(mapping, prefix=()):
+        for key, value in mapping.items():
+            if isinstance(value, dict):
+                yield from leaves(value, (*prefix, key))
+            else:
+                yield (*prefix, key), value
+
+    for label, overlay in _OVERLAYS.items():
+        if label in NOT_HERMETIC:
+            continue
+        example = _example(label)
+        merged = apply_overlay(example, label, tmp_path / label.replace("/", "_"))
+        for path, expected in leaves(overlay):
+            # The override must attach to a branch the configuration already has. This is the check
+            # that catches the real bug: a `signal` key at the overlay root produced
+            # `signal.arguments.reference_time_ssb` in the merged mapping -- present, equal to what
+            # the overlay asked for, and read by nobody, because the configuration reads
+            # `orchestration.signal`. Comparing the overlay against the merged result cannot see
+            # that; comparing against the *example* can.
+            assert path[0] in example, (
+                f"'{label}' overlay sets {'.'.join(path)}, but the example has no {path[0]!r} "
+                f"section -- the override creates a branch nothing reads"
+            )
+            node = merged
+            for step in path:
+                assert isinstance(node, dict), f"'{label}' overlay sets {'.'.join(path)}, but {step!r} is not a section"
+                assert step in node, (
+                    f"'{label}' overlay sets {'.'.join(path)}, which does not exist in the merged "
+                    f"configuration -- the key is at the wrong level and the override does nothing"
+                )
+                node = node[step]
+            assert node == expected, (
+                f"'{label}' overlay sets {'.'.join(path)} to {expected!r} but the merged configuration has {node!r}"
+            )


### PR DESCRIPTION
## 📝 Summary

The e2e reference comparison failed roughly **weekly**, on something that was not a
defect. This removes the cause.

The shipped examples run in 2030 to match the Einstein Telescope era, which is about
**885 days beyond the end** of the Earth-orientation table Astropy ships. There is no
data there, so Astropy **clamps** UT1−UTC to the table's final value — and every
weekly `astropy-iers-data` release extends that end date and moves the clamped value
with it. Measured: a 2.740 ms step, 1.9976e-07 rad of GMST, **1.569e-06 of peak** on
one detector, above this suite's 1e-06 drift tolerance.

Because the epoch rode the table edge, the churn was **structural**, not incidental.

## The evidence

Measured across the 0.2026.7.27 and 0.2026.8.3 releases, on GMST — the quantity the
projection actually consumes:

| epoch | 0.2026.7.27 | 0.2026.8.3 |
|---|---|---|
| 2030 (old) | 1.763085399538589 | 1.763085**199778395** |
| 2025 (new) | 1.760886943642783 | 1.760886943642783 |

Bit-identical at the new epoch.

## Why this option and not the others

Three alternatives were considered and are worse:

1. **Regenerate on each bump** — honest, but a recurring review where a real
   regression hides in the noise.
2. **Pin `astropy-iers-data` for the suite** — stable references, at the cost of
   testing against ageing Earth-orientation data.
3. **Widen the tolerance past ~2e-06** — would stop the check catching a projection
   regression of the same size, which is exactly what it exists for.

Closes the standing decision tracked as `gwmock/iers-reference-churn`.

## Why 2025-01-01 specifically

Finalised IERS data ended 2026-07-23 when this was chosen, so the epoch keeps about
**eighteen months of margin** before the prediction boundary — predictions get
revised, finalised values effectively do not. Verified at 2024-01-01, 2025-01-01 and
2026-01-01: all bit-identical across the two releases, while 2030 moved.

## What moved with it

- **The population fixture is now test-owned.** Its coalescence time has to sit at
  this epoch and the examples deliberately stay in 2030. Identical to the example's
  copy apart from that time.
- **The continuous-wave entry's `reference_time_ssb`.** It could have stayed in 2030,
  since it is only the epoch the spin parameters refer to, but the run would then
  describe a catalogue referenced to a time it never covers.
- **All eight references**, regenerated.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** `uv run pytest` — 967 passed, 23 skipped
- [x] **Manual Test:** `uv run pytest -m e2e --no-cov` — 47 passed, 9 skipped. The
      GMST table above comes from installing both `astropy-iers-data` versions in
      scratch environments and comparing directly.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.

## The cost, stated rather than left implicit

**The suite no longer exercises the epoch the examples document.** It cannot catch an
error that depends on being far outside the IERS table — which is the situation this
deliberately stops testing. That trade-off is written into the `_ALIGNED_START`
docstring so the next reader meets it there rather than deducing it.

## A note on the recorded environment

The references record gwmock-signal 0.13.0, which is what this branch resolves. An
earlier pass generated them under 0.14.0 while I was testing the unreleased
`pre_coalescence_duration` API on the same branch. Every comparison still passed —
confirming that addition changed no generated data — but the recorded environment
would have named a version never installed here, so they were regenerated. The
inspiral-cropping fix that needs 0.14.0 is a separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability of simulated signal overlays by aligning event and reference times with a more reliable time period.
  - Updated test data locations for more consistent end-to-end validation.

- **Tests**
  - Refreshed expected noise, signal, waveform, and batched execution results.
  - Updated verification data to reflect the latest simulation environment and regenerated outputs.
  - Preserved validation of noise and signal statistics across supported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->