### PR TITLE
chore(deps): drop the ripple pin, take the floor from gwmock-signal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,19 +45,17 @@ sgwb = ["gwmock-signal[sgwb]>=0.13.0"]
 # installed this way batches the work and runs it on the CPU. That is a supported configuration --
 # it is the one the test suite exercises -- but it is not device execution, and nothing at runtime
 # distinguishes the two beyond `jax.devices()`. Use the `cuda` extra below for a GPU.
-# `ripplegw` is named explicitly so the development pin at the bottom of this file applies
-# to it. uv honours a source only for a package the project *declares*, and ripple would
-# otherwise arrive transitively through `gwmock-signal[jax]`; a source alone left the lock
-# resolving ripplegw 0.3.0 from the registry. Declaring it here rather than in a dev group
-# keeps it on the extras that need it -- a dev group would put ripple and JAX into every
-# plain `uv sync`, which would un-skip the ripple-gated tests in the default CI job and make
-# that job quietly test something other than what it claims. The published wheel gains only
-# `ripplegw>=0.3` under these extras, a registry floor that was already transitive, and no
-# git URL: verified with a plain `uv build`, which is what the release workflow runs.
-jax = ["gwmock-signal[jax]>=0.13.0", "ripplegw>=0.3"]
+#
+# 0.15.0 rather than 0.13.0 because that release floors `ripplegw>=0.3.1`, the first ripple
+# carrying the geocentre fix (GW-JAX-Team/ripple#141). Without it the continuous-wave path gets a
+# ripple that returns NaN for every sample at the geocentre, where these simulators generate. The
+# floor is deliberately *not* restated here as a `ripplegw` declaration: it belongs beside the
+# guard that raises on those NaNs, which lives in gwmock-signal, and stating a version in two
+# repositories is how the two drift.
+jax = ["gwmock-signal[jax]>=0.15.0"]
 # The same path with an actual GPU backend. Linux x86_64 with a CUDA 12 driver only; there is no
 # macOS or Windows wheel, which is why this is separate from `jax` rather than folded into it.
-cuda = ["gwmock-signal[jax]>=0.13.0", "ripplegw>=0.3", "jax[cuda12]>=0.11.0"]
+cuda = ["gwmock-signal[jax]>=0.15.0", "jax[cuda12]>=0.11.0"]
 
 [dependency-groups]
 dev = [
@@ -189,37 +187,6 @@ docstring-code-format = true # Format code in docstrings
 # ARG001: allow unused function arguments (common in fixtures)
 # PLC0415: allow import statements not at the top level
 # PLR2004: allow magic values in the unit tests
-
-# TEMPORARY development pin. When a ripplegw release carries the geocentre fix
-# (GW-JAX-Team/ripple#141), do all of this together, or the paths below silently fall back to a
-# ripple without the fix:
-#
-#   1. delete this table;
-#   2. raise the `ripplegw>=0.3` floor in the `jax` and `cuda` extras above to that release;
-#   3. do the same in gwmock-signal, which carries its own copy of this pin;
-#   4. re-lock.
-#
-# Leaving the declarations without the table, or the table without the declarations, resolves
-# ripplegw 0.3.0 again -- and that is the version that returns NaN at the geocentre.
-#
-# Development-only: `[tool.uv.sources]` is not carried into the published wheel, so nobody
-# installing gwmock from PyPI inherits a git dependency. Build with `uv build --no-sources` while
-# this is present.
-#
-# Why it moved here. Until gwmock-signal 0.13.0 this file pinned *gwmock-signal* to a git
-# revision, and that was enough on its own: gwmock-signal carries its own sources pin of ripplegw,
-# and uv honours a git dependency's sources. Consuming the release instead breaks that inheritance
-# -- a wheel does not carry `[tool.uv.sources]` -- so resolving `gwmock-signal[jax]>=0.13.0` from
-# PyPI produces ripplegw 0.3.0, the version without the fix. Measured, not assumed: a scratch
-# project depending only on `gwmock-signal[jax]>=0.13.0` locks `ripplegw 0.3.0` from the registry.
-#
-# What that costs without this pin. The continuous-wave simulator generates polarizations at the
-# geocentre so one projection route serves every source type; released ripplegw evaluates the
-# detector latitude as `arccos(lz / rd)`, which is 0/0 there, and returns NaN for every sample.
-# gwmock-signal 0.13.0 refuses that rather than writing it, so the failure is loud -- but
-# continuous waves would simply not work in this repository's own development and CI.
-[tool.uv.sources]
-ripplegw = { git = "https://github.com/GW-JAX-Team/ripple.git", rev = "400afb4" }
 
 [[tool.uv.index]]
 name = "testpypi"

--- a/uv.lock
+++ b/uv.lock
@@ -667,11 +667,9 @@ dependencies = [
 cuda = [
     { name = "gwmock-signal", extra = ["jax"] },
     { name = "jax", extra = ["cuda12"] },
-    { name = "ripplegw" },
 ]
 jax = [
     { name = "gwmock-signal", extra = ["jax"] },
-    { name = "ripplegw" },
 ]
 sgwb = [
     { name = "gwmock-signal", extra = ["sgwb"] },
@@ -703,16 +701,14 @@ requires-dist = [
     { name = "gwmock-noise", specifier = ">=0.10.0" },
     { name = "gwmock-pop", specifier = ">=0.11.4" },
     { name = "gwmock-signal", specifier = ">=0.13.0" },
-    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'cuda'", specifier = ">=0.13.0" },
-    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'jax'", specifier = ">=0.13.0" },
+    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'cuda'", specifier = ">=0.15.0" },
+    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'jax'", specifier = ">=0.15.0" },
     { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", specifier = ">=0.13.0" },
     { name = "h5py", specifier = ">=3.12.1" },
     { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda'", specifier = ">=0.11.0" },
     { name = "psutil", specifier = ">=6.1.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
     { name = "pymap3d", specifier = ">=3.2.0" },
-    { name = "ripplegw", marker = "extra == 'cuda'", git = "https://github.com/GW-JAX-Team/ripple.git?rev=400afb4" },
-    { name = "ripplegw", marker = "extra == 'jax'", git = "https://github.com/GW-JAX-Team/ripple.git?rev=400afb4" },
     { name = "textual", specifier = ">=2.0.0" },
     { name = "tqdm", specifier = ">=4.67.0" },
     { name = "typer", specifier = ">=0.19.0" },
@@ -772,7 +768,7 @@ wheels = [
 
 [[package]]
 name = "gwmock-signal"
-version = "0.13.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gwpy" },
@@ -780,9 +776,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/ac/ef9fd787daae0b03c5d6b0ed5d09c973484e6cba6f57cddddac1fe50e8c0/gwmock_signal-0.13.0.tar.gz", hash = "sha256:72838b14ca0545ff25dcf36c61e42a6e1e46319677eecacfc0a756ec9fc40513", size = 437126, upload-time = "2026-08-03T11:39:51.144Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/8e/4d8161a3d06de6a972f3507be3ae35a25aa1335d517df363f49498c013a0/gwmock_signal-0.15.0.tar.gz", hash = "sha256:9e90af755e80f1555a6bb8e6a66602cff34c77f9dfbdf5894b58a053c3d5c8f1", size = 445527, upload-time = "2026-08-04T09:40:44.488Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/6e/2eaa611c36e9c695678cf373f4e1d77d897b9bf2c55b82ed4940565aff99/gwmock_signal-0.13.0-py3-none-any.whl", hash = "sha256:31feb76bd44a1835a8dbe1f218a7e3ada81d9541b183fc813c0d6afdc5ab6f0c", size = 162065, upload-time = "2026-08-03T11:39:49.839Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2b/1a42e19fc7f8c458e2c5a8e889559499111d0dfd5d963c34f816cc2828da/gwmock_signal-0.15.0-py3-none-any.whl", hash = "sha256:7d39b5c576c1d5ae2b63cb631f97cb209f024edde71fa45fcd1fa46e2c91be73", size = 165891, upload-time = "2026-08-04T09:40:43.308Z" },
 ]
 
 [package.optional-dependencies]
@@ -2534,11 +2530,15 @@ wheels = [
 
 [[package]]
 name = "ripplegw"
-version = "0.3.1.dev3"
-source = { git = "https://github.com/GW-JAX-Team/ripple.git?rev=400afb4#400afb4d41d2fbc6a85f3aac7ad8c07eb64fa641" }
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jax" },
     { name = "jaxtyping" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/d6da3e3adcd03d5490638a1f73c743e22b9d002ea06c8ebf8c2725905727/ripplegw-0.3.1.tar.gz", hash = "sha256:c9435c9266125b645d38636a42947acad93cf841ce635e55a1a3a5d765990f2e", size = 481899, upload-time = "2026-08-03T20:28:19.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/33/fc079529e3a796da9f4bb1b2cd17a77ba70ff3ae9e821380bdcf46714134/ripplegw-0.3.1-py3-none-any.whl", hash = "sha256:0bd8f1bb8235ae59d9bfa3938ca1ee49bf91f4b38bd313a25620f087539cfeaf", size = 225512, upload-time = "2026-08-03T20:28:17.909Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
ripplegw 0.3.1 carries the geocentre fix (GW-JAX-Team/ripple#141), and gwmock-signal
0.15.0 floors `ripplegw>=0.3.1` itself. Both change how this repository should express the
constraint, so the development pin can go.

## The problem the pin solved

The continuous-wave simulator generates polarizations at the geocentre so one projection
route serves every source type. Released ripplegw 0.3.0 evaluates the detector latitude as
`arccos(lz / rd)`, which is 0/0 there, and returns NaN for every sample. gwmock-signal
refuses that rather than writing it, so continuous waves simply did not work in this
repository's development or CI without a pinned ripple.

## What changed

Three things together, because any one alone resolves ripplegw 0.3.0 again:

- the `[tool.uv.sources]` table and its rationale are deleted;
- the `jax` and `cuda` extras move to `gwmock-signal[jax]>=0.15.0`;
- the explicit `ripplegw>=0.3` declaration in those extras is **removed** rather than raised
  to 0.3.1.

That last one is the substantive choice. The declaration existed only so the source table
would apply -- uv honours a source only for a package the project declares -- and with the
table gone its only remaining effect would be to restate a version gwmock-signal already
states. The floor belongs beside the guard that raises on the NaNs; two repositories naming
the same version is how the two drift apart.

## Verification

The floor still binds, rather than 0.3.1 merely being latest. A scratch project on
`gwmock-signal[jax]>=0.15.0` plus `ripplegw==0.3.0` is unsatisfiable:

> Because gwmock-signal[jax]==0.15.0 depends on ripplegw>=0.3.1 [...] your project's
> requirements are unsatisfiable.

So the constraint is carried in released metadata, not inferred from resolution order. The
relocked file takes ripplegw 0.3.1 and gwmock-signal 0.15.0 from the registry and no longer
contains any git URL.

Runtime rather than resolution alone: the continuous-wave e2e example runs against registry
ripple, so the NaN is gone in fact and not only by version number. All six
`signal/cw/et_triangle_sardinia` e2e tests pass, including the stored-reference and
reproducibility comparisons.

e2e: 46 passed, 9 skipped. Unit and integration: 971 passed, 23 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining the minimum supported version and geocentre-related fix.

* **Chores**
  * Updated optional JAX and CUDA setup requirements.
  * Removed temporary development configuration and outdated package declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->