### PR TITLE
fix(orchestration): claim an event by where its waveform starts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,12 @@ classifiers = [
 requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = [
-  "gwmock-signal>=0.13.0", # 0.13.0 is the first release carrying the continuous-wave simulator
+  # 0.15.0 is the first release exposing `CBCSimulator.pre_coalescence_duration`, which segment
+  # placement asks before generating so an event is claimed by the segment its *waveform* starts in
+  # rather than the one holding its coalescence. Below this the query is absent, placement falls back
+  # to `coa_time`, and the start of any waveform landing near a boundary is cropped -- so this is a
+  # floor the behaviour depends on, not a convenience.
+  "gwmock-signal>=0.15.0",
   "gwmock-noise>=0.10.0",
   "gwmock-pop>=0.11.4",
   "typer>=0.19.0",         # Literal-type CLI options; the SPEC 0 floor (0.13) predates them

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -149,9 +149,16 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         # Recorded into per-batch metadata so a frame's sources are self-describing.
         self._batch_injections: list[dict[str, Any]] = []
         self._pending_noise_chunk: dict[str, Any] | None = None
-        # Warn once per run, not once per event: a catalogue the query cannot answer for cannot
-        # answer for any of its events, and the message would otherwise arrive thousands of times.
-        self._pre_coalescence_query_failed = False
+        # Warned at most once per distinct reason, not once per event: a catalogue whose parameters
+        # the query cannot read fails for every row alike, and the message would otherwise arrive
+        # thousands of times. Keyed by the failure text rather than a flag, because a single
+        # malformed row fails only its own query and its cause differs from a whole-catalogue one --
+        # collapsing both into one warning would name the wrong cause for everything after it.
+        self._pre_coalescence_query_failures: set[str] = set()
+        # Consumption order, as positions into `_population_events`. Established lazily by
+        # `_placement_order`, because it costs one query per event and the continuous-wave and
+        # stochastic paths never consume the catalogue this way.
+        self._placement_order_cache: tuple[int, ...] | None = None
 
         super().__init__(
             max_samples=max_samples,
@@ -535,8 +542,12 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
 
         chunks = TimeSeriesList()
         self._batch_injections = []
-        while self.population_index < len(self._population_events):
-            event_id = int(self.population_index)
+        order = self._placement_order()
+        while self.population_index < len(order):
+            # `population_index` counts events consumed, and `order` turns that into the catalogue
+            # position -- which is also the event id, so provenance keeps naming events by their
+            # place in the loaded catalogue rather than by the order generation happened to take.
+            event_id = int(order[int(self.population_index)])
             parameters = dict(self._population_events[event_id])
             if not self._event_starts_before_segment_end(parameters):
                 break
@@ -581,6 +592,59 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         # and restores `state`, which this flag is not part of -- so setting it first would let the
         # retry sail past a configuration the first attempt refused.
         self._configuration_checked = True
+
+    def _placement_order(self) -> tuple[int, ...]:
+        """Return catalogue positions ordered by when each event's waveform starts.
+
+        The loops consume the catalogue in order and stop at the first event that does not belong to
+        the current segment. That is only sound if "belongs" is a prefix property, and under the
+        waveform-start rule it is not for a ``coa_time``-sorted catalogue: the lead varies with the
+        source, roughly 3 s for a heavy binary black hole against ~100 s for a binary neutron star at
+        a low cutoff. So a long-lead event can sit *after* a short-lead one whose waveform start has
+        already crossed the boundary::
+
+            segment [100, 116):
+              coa=117 lead=10 -> start 107   belongs
+              coa=118 lead= 1 -> start 117   stops the walk
+              coa=119 lead=20 -> start  99   belongs, but is never reached
+
+        The third event would then be generated a segment late and cropped -- the very loss this rule
+        exists to prevent, reintroduced by catalogue ordering alone. Sorting by the placement key
+        makes the prefix property hold again, which keeps ``population_index`` meaning "every event
+        before this one is consumed" -- the invariant resume depends on.
+
+        Stable, so events sharing a start keep their catalogue order, and events with no ``coa_time``
+        sort first because they belong to every segment. The key is ``coa_time - lead``, with the lead
+        taken as zero when unknown, matching the fallback in
+        :meth:`_event_starts_before_segment_end`.
+
+        Computed once. It costs one query per event, which is arithmetic over the conditioning
+        settings rather than a generation -- orders of magnitude below the cost of generating the same
+        event, which the run is about to pay anyway.
+
+        Returns:
+            Catalogue positions in consumption order.
+        """
+        if self._placement_order_cache is None:
+            self._placement_order_cache = tuple(sorted(range(len(self._population_events)), key=self._placement_key))
+        return self._placement_order_cache
+
+    def _placement_key(self, position: int) -> float:
+        """Return the time the event at *position* starts, for ordering consumption.
+
+        Args:
+            position: Index into the catalogue as loaded.
+
+        Returns:
+            The waveform's start time, or ``-inf`` for an event with no coalescence time, which
+            belongs to every segment and so must never delay one.
+        """
+        parameters = self._population_events[position]
+        coa_time = parameters.get("coa_time")
+        if coa_time is None:
+            return float("-inf")
+        lead = self._pre_coalescence_duration(parameters)
+        return float(coa_time) if lead is None else float(coa_time) - float(lead)
 
     def _event_starts_before_segment_end(self, parameters: Mapping[str, Any]) -> bool:
         """Return whether this event's *waveform* begins before the current segment ends.
@@ -648,13 +712,19 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             #
             # The fallback is the previous behaviour, and its cost is reported rather than silent:
             # any inspiral cropped by it is named by `_report_content_before_segment`.
-            if not self._pre_coalescence_query_failed:
-                self._pre_coalescence_query_failed = True
+            #
+            # Deduplicated by reason rather than by a single flag. A whole catalogue the query cannot
+            # read fails identically for every row, and one message is right for it; but a single
+            # malformed row fails only its own query, and a flag would let every later row with a
+            # *different* problem fall back silently under a warning naming the first one.
+            reason = f"{type(exc).__name__}: {exc}"
+            if reason not in self._pre_coalescence_query_failures:
+                self._pre_coalescence_query_failures.add(reason)
                 logger.warning(
-                    "Cannot establish how long before coalescence a waveform starts (%s). Segments "
-                    "will claim events by coa_time alone, which crops the start of any waveform "
+                    "Cannot establish how long before coalescence a waveform starts (%s). Affected "
+                    "events are claimed by coa_time alone, which crops the start of any waveform "
                     "beginning before its segment; the amount lost is reported per signal.",
-                    exc,
+                    reason,
                 )
             return None
 
@@ -674,7 +744,8 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         remains the weaker of the two rules where they could differ.
 
         Returns:
-            The population indices and their parameter mappings, in catalogue order.
+            The population indices and their parameter mappings, in consumption order -- which is
+            :meth:`_placement_order`, so the indices need not be ascending.
         """
         event_ids: list[int] = []
         events: list[dict[str, Any]] = []
@@ -684,20 +755,29 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         # here would let a caller observe a consumed index after an exception, so the commit happens
         # in `_commit_consumed_events` once generation has succeeded. The CLI's retry wrapper
         # restores pre-batch state, so this is about direct library callers rather than the runner.
+        order = self._placement_order()
         position = int(self.population_index)
-        while position < len(self._population_events):
-            parameters = dict(self._population_events[position])
+        while position < len(order):
+            event_id = int(order[position])
+            parameters = dict(self._population_events[event_id])
             if not self._event_starts_before_segment_end(parameters):
                 break
-            event_ids.append(position)
+            event_ids.append(event_id)
             events.append(parameters)
             position += 1
         return event_ids, events
 
     def _commit_consumed_events(self, event_ids: list[int]) -> None:
-        """Advance the checkpointed index past events whose generation succeeded."""
+        """Advance the checkpointed index past events whose generation succeeded.
+
+        Advances by *count*, not to ``max(event_ids) + 1``: the ids are catalogue positions and
+        consumption follows :meth:`_placement_order`, so they need not be contiguous or ascending.
+
+        Args:
+            event_ids: Catalogue positions of the events this batch generated.
+        """
         if event_ids:
-            self.population_index = event_ids[-1] + 1
+            self.population_index = cast(int, self.population_index) + len(event_ids)
 
     def _batched_waveform_backend(self) -> Any:
         """Return the ripple backend the batched path should generate with.

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+import logging
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -31,6 +32,8 @@ from gwmock.simulator.state import StateAttribute
 #: backend. It must stay the same library ``WaveformFactory`` defaults to internally, or
 #: supplying arguments would quietly change which library generates the waveforms.
 _DEFAULT_WAVEFORM_BACKEND = "lal"
+
+logger = logging.getLogger("gwmock")
 
 
 @dataclass(slots=True)
@@ -139,12 +142,16 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         self._active_overwrite = False
         self._noise_stream: Iterator[dict[str, Any]] | None = None
         self._noise_stream_position = 0
-        # Source parameters of the signals that merge in the current batch, in
+        # Source parameters of the signals injected into the current batch, in
         # injection order: [{"event_id": <population index>, "parameters": {...}}].
-        # An event is attributed to the batch whose segment contains its coa_time.
+        # An event is attributed to the batch whose segment its *waveform starts* in,
+        # which for a compact binary is at or before the segment its coa_time falls in.
         # Recorded into per-batch metadata so a frame's sources are self-describing.
         self._batch_injections: list[dict[str, Any]] = []
         self._pending_noise_chunk: dict[str, Any] | None = None
+        # Warn once per run, not once per event: a catalogue the query cannot answer for cannot
+        # answer for any of its events, and the message would otherwise arrive thousands of times.
+        self._pre_coalescence_query_failed = False
 
         super().__init__(
             max_samples=max_samples,
@@ -531,9 +538,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         while self.population_index < len(self._population_events):
             event_id = int(self.population_index)
             parameters = dict(self._population_events[event_id])
-            coa_time = parameters.get("coa_time")
-            end_time_value = float(getattr(self.end_time, "value", self.end_time))
-            if coa_time is not None and float(coa_time) >= end_time_value:
+            if not self._event_starts_before_segment_end(parameters):
                 break
             strain = self.signal_adapter.simulate(
                 parameters,
@@ -577,26 +582,102 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         # retry sail past a configuration the first attempt refused.
         self._configuration_checked = True
 
+    def _event_starts_before_segment_end(self, parameters: Mapping[str, Any]) -> bool:
+        """Return whether this event's *waveform* begins before the current segment ends.
+
+        The segment boundary rule, in one place because two loops apply it -- the per-event loop and
+        :meth:`_events_for_this_segment` -- and a run that switches between execution modes mid-way
+        must not skip or repeat an event because the two disagreed.
+
+        The rule is the waveform's start, not ``coa_time``. A compact binary's buffer begins seconds
+        before coalescence, so an event whose ``coa_time`` lands just past a boundary has content
+        belonging to the segment before it. Claiming that event by ``coa_time`` puts its buffer start
+        outside the claiming segment, where injection crops it and it is gone: the earlier segments
+        are already written. Claiming it by its start instead places the whole waveform, and the
+        forward overflow already carried between segments delivers the rest.
+
+        ``None`` from the query means *unknown*, and unknown falls back to the ``coa_time`` rule --
+        the previous behaviour, whose loss is reported by
+        :meth:`~gwmock.data.time_series.time_series.TimeSeries._report_content_before_segment`.
+        Treating unknown as zero would be the same fallback while looking like an answer.
+
+        The query is arithmetic over the conditioning settings rather than a generation, so it is
+        cheap enough to ask per candidate event; it is not cached, and the cost is one query per
+        event plus one per segment for the event that ends it.
+
+        Args:
+            parameters: The candidate event's source parameters.
+
+        Returns:
+            Whether the event belongs to this segment. Events without a ``coa_time`` always do,
+            which is how non-coalescing sources reach the loop unchanged.
+        """
+        coa_time = parameters.get("coa_time")
+        if coa_time is None:
+            return True
+        end_time_value = float(getattr(self.end_time, "value", self.end_time))
+        lead = self._pre_coalescence_duration(parameters)
+        start_time_value = float(coa_time) if lead is None else float(coa_time) - float(lead)
+        return start_time_value < end_time_value
+
+    def _pre_coalescence_duration(self, parameters: Mapping[str, Any]) -> float | None:
+        """Return the event's waveform lead in seconds, or ``None`` when it cannot be established.
+
+        Args:
+            parameters: The candidate event's source parameters.
+
+        Returns:
+            Seconds before ``coa_time`` at which the waveform starts, or ``None`` for unknown.
+        """
+        if self.signal_adapter is None:
+            return None
+        try:
+            return self.signal_adapter.pre_coalescence_duration(
+                parameters,
+                sampling_frequency=float(self.sampling_frequency.value),
+                minimum_frequency=self.minimum_frequency,
+                waveform_arguments=self.waveform_arguments,
+                waveform_options=self.waveform_options,
+            )
+        except Exception as exc:
+            # Deliberately broad, and it does not hide the failure it swallows. This query decides
+            # *placement*; the same parameters are handed to generation immediately afterwards, which
+            # raises whatever this raised -- with the context of the event it was generating rather
+            # than of a boundary test. Letting placement be the thing that fails a run would turn an
+            # incomplete catalogue column into a crash in an unrelated part of the loop.
+            #
+            # The fallback is the previous behaviour, and its cost is reported rather than silent:
+            # any inspiral cropped by it is named by `_report_content_before_segment`.
+            if not self._pre_coalescence_query_failed:
+                self._pre_coalescence_query_failed = True
+                logger.warning(
+                    "Cannot establish how long before coalescence a waveform starts (%s). Segments "
+                    "will claim events by coa_time alone, which crops the start of any waveform "
+                    "beginning before its segment; the amount lost is reported per signal.",
+                    exc,
+                )
+            return None
+
     def _events_for_this_segment(self) -> tuple[list[int], list[dict[str, Any]]]:
         """Return the population events belonging to the current segment, without consuming them.
 
-        Stops on ``coa_time >= end_time``, which is the per-event loop's boundary. That matters for
-        resume: ``population_index`` is checkpointed state, so a run switched between modes must not
-        skip or repeat events. The index advances only in :meth:`_commit_consumed_events`, once
-        generation has succeeded.
+        Stops on :meth:`_event_starts_before_segment_end`, the same boundary the per-event loop
+        applies. That matters for resume: ``population_index`` is checkpointed state, so a run
+        switched between modes must not skip or repeat events. The index advances only in
+        :meth:`_commit_consumed_events`, once generation has succeeded.
 
         One difference, stated rather than glossed: the per-event loop also breaks when a *generated*
         strain starts at or after ``end_time``, a condition that cannot be evaluated before
-        generating. Reaching it requires a waveform whose buffer begins beyond the segment despite a
-        ``coa_time`` inside it, which the bundled waveforms do not produce. So the two agree on every
-        case exercised here, and this helper is the weaker of the two rules where they could differ.
+        generating. With the boundary now taken from the waveform's predicted start, reaching it
+        requires the prediction to disagree with the buffer generation actually produces -- the two
+        come from the same backend helpers, so the bundled waveforms do not reach it. This helper
+        remains the weaker of the two rules where they could differ.
 
         Returns:
             The population indices and their parameter mappings, in catalogue order.
         """
         event_ids: list[int] = []
         events: list[dict[str, Any]] = []
-        end_time_value = float(getattr(self.end_time, "value", self.end_time))
 
         # Read without advancing. `population_index` is checkpointed, and everything after this --
         # transposing to a struct-of-arrays, canonicalising, generating -- can still fail. Advancing
@@ -606,8 +687,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         position = int(self.population_index)
         while position < len(self._population_events):
             parameters = dict(self._population_events[position])
-            coa_time = parameters.get("coa_time")
-            if coa_time is not None and float(coa_time) >= end_time_value:
+            if not self._event_starts_before_segment_end(parameters):
                 break
             event_ids.append(position)
             events.append(parameters)

--- a/src/gwmock/cli/utils/metadata.py
+++ b/src/gwmock/cli/utils/metadata.py
@@ -41,10 +41,12 @@ class SignalSection(BaseModel):
     backend: str
     waveform_model: str | None = None
     detector_network: list[str] = Field(default_factory=list)
-    # Source parameters of the signals that merge in this batch's frame(s), in
+    # Source parameters of the signals injected into this batch's frame(s), in
     # injection order: [{"event_id": int, "parameters": {...}}]. An event is
-    # attributed to the frame its coa_time falls in; content extending into
-    # adjacent frames is not cross-listed. Empty for stationary/SGWB segments.
+    # attributed to the frame its waveform *starts* in -- for a compact binary that
+    # is at or before the frame containing its coalescence, because the buffer begins
+    # seconds earlier. Content extending forward into later frames is not
+    # cross-listed. Empty for stationary/SGWB segments.
     injections: list[dict[str, Any]] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
 

--- a/src/gwmock/cli/utils/metadata.py
+++ b/src/gwmock/cli/utils/metadata.py
@@ -11,7 +11,12 @@ import numpy as np
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-SCHEMA_VERSION = "1.3.0"
+#: 1.4.0 because ``signal.injections`` changed meaning: an event is now attributed to the frame its
+#: waveform *starts* in rather than the frame holding its coalescence. No field was added or removed,
+#: so a consumer reading the old version parses the new one without noticing -- which is exactly why
+#: the version has to move. A reader comparing records across a run boundary needs to be able to tell
+#: which convention produced each one.
+SCHEMA_VERSION = "1.4.0"
 _SCHEMA_VERSION_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
 

--- a/src/gwmock/data/time_series/inject.py
+++ b/src/gwmock/data/time_series/inject.py
@@ -113,9 +113,10 @@ def measure_content_before(
     overflow is different: it is returned as a tail and carried into the next segment. Backward
     overflow has nowhere to go, because the segments it belongs to have already been written.
 
-    That matters for compact-binary sources, whose inspiral *precedes* ``coa_time`` while the
-    segment claiming an event is the one ``coa_time`` falls in. A waveform buffer therefore starts
-    before its own segment whenever ``coa_time`` lands within one buffer length of the boundary.
+    That mattered for every compact binary landing near a boundary while segments claimed an event by
+    ``coa_time``, whose inspiral *precedes* it. Segments now claim by where the waveform starts, so
+    what this measures is the residue: a waveform beginning before the run itself, or a placement
+    that fell back to ``coa_time`` because the pre-coalescence duration could not be established.
 
     Args:
         segment_start_time: Start of the segment being injected into, in the chunk's time unit.

--- a/src/gwmock/data/time_series/time_series.py
+++ b/src/gwmock/data/time_series/time_series.py
@@ -353,9 +353,19 @@ class TimeSeries(JSONSerializable):
     def _report_content_before_segment(self, chunk: TimeSeries) -> None:
         """Warn that content starting before this segment is about to be dropped.
 
-        Reported rather than fixed. Placing it would mean writing into segments already on disk, so
-        the loss is real either way -- but it was silent, and a truncated inspiral looks like a
-        perfectly ordinary signal. Saying how much went, per signal, is what lets a run be judged.
+        Reaching this is now the exception rather than the rule. Segments claim an event by where its
+        waveform *starts*, so an ordinary compact binary is generated early enough for the whole
+        buffer to be placed. What still arrives here is the cases that rule cannot cover:
+
+        - a waveform beginning before the run's own start, which has no segment to go in;
+        - a backend that cannot say how long before coalescence its buffer starts, or an odd
+          catalogue the query cannot be answered for -- both fall back to claiming by ``coa_time``,
+          which is the behaviour that crops.
+
+        Still reported rather than fixed, for the same reason as before: placing it would mean
+        writing into segments already on disk. The loss is real either way, and a truncated inspiral
+        looks like a perfectly ordinary signal, so saying how much went -- per signal -- is what lets
+        a run be judged.
         """
         samples, seconds, energy_fraction = measure_content_before(
             float(self.start_time.to(chunk.start_time.unit).value),
@@ -370,9 +380,10 @@ class TimeSeries(JSONSerializable):
             "Discarding %.3f s (%d samples, %.2f%% of its unweighted strain-squared energy) of the "
             "signal with coa_time %s: it "
             "starts at %s, before this segment begins at %s. The earlier segments it belongs to are "
-            "already written, so this content cannot be placed. A compact-binary waveform starts "
-            "before its coa_time, so this happens whenever coa_time falls within one waveform buffer "
-            "of a segment boundary; a longer segment duration makes it rarer but not impossible.",
+            "already written, so this content cannot be placed. Segments normally claim an event by "
+            "where its waveform starts, which avoids this; reaching it means either the waveform "
+            "begins before the run itself, or the pre-coalescence duration could not be established "
+            "and placement fell back to coa_time -- look for a warning saying so.",
             seconds,
             samples,
             100.0 * energy_fraction,

--- a/src/gwmock/signal/adapter.py
+++ b/src/gwmock/signal/adapter.py
@@ -572,6 +572,134 @@ class SignalAdapter:
             )
         return name
 
+    def _backend_parameters(
+        self,
+        parameters: Mapping[str, Any],
+        waveform_arguments: Mapping[str, Any] | None,
+        waveform_options: Mapping[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Build the mapping a backend call takes, from per-event and fixed settings.
+
+        Shared by generation and by :meth:`pre_coalescence_duration`, because the buffer length the
+        query reports depends on settings that arrive this way -- ripple's ``ringdown_fraction`` and
+        ``segment_duration`` among them. Preparing the two mappings separately would let the query
+        describe a buffer other than the one generation goes on to produce, and the discrepancy
+        would appear as dropped signal rather than as an error.
+
+        Args:
+            parameters: Per-event source parameters.
+            waveform_arguments: Fixed waveform parameters merged flat; per-event values win.
+            waveform_options: Extra options passed through as the backend's ``waveform_arguments``.
+
+        Returns:
+            The merged mapping, less any parameters this backend has already rejected.
+
+        Raises:
+            ValueError: If *waveform_options* and a ``waveform_arguments`` parameter are both given.
+        """
+        backend_parameters = {**(waveform_arguments or {}), **dict(parameters)}
+        if waveform_options:
+            if "waveform_arguments" in backend_parameters:
+                raise ValueError(
+                    "Specify extra waveform options either via waveform_options or as a "
+                    "waveform_arguments parameter, not both"
+                )
+            backend_parameters["waveform_arguments"] = dict(waveform_options)
+        if self._unsupported_params:
+            backend_parameters = {k: v for k, v in backend_parameters.items() if k not in self._unsupported_params}
+        return backend_parameters
+
+    def _without_unsupported(self, exc: ValueError, backend_parameters: Mapping[str, Any]) -> dict[str, Any] | None:
+        """Return *backend_parameters* less what *exc* says the backend rejects, or ``None``.
+
+        ``None`` means *exc* is not an unsupported-parameter complaint and the caller should
+        re-raise it. Records the rejected names on the adapter, so the next call drops them up front
+        rather than paying a failed backend call per event.
+
+        Args:
+            exc: The ``ValueError`` a backend call raised.
+            backend_parameters: The mapping that call was given.
+
+        Returns:
+            The filtered mapping, or ``None`` when *exc* is some other failure.
+
+        Raises:
+            ValueError: If the rejected parameter is ``waveform_arguments`` itself, which no amount
+                of filtering fixes -- the installed gwmock-signal cannot carry the requested
+                waveform options at all, and dropping them would run the wrong waveform silently.
+        """
+        match = _UNSUPPORTED_PARAMS_RE.match(str(exc))
+        if match is None:
+            return None
+        extras = {token.strip() for token in match.group(1).split(",") if token.strip()}
+        if "waveform_arguments" in extras:
+            raise ValueError(
+                "The installed gwmock-signal does not support the waveform_arguments "
+                "parameter required by waveform_options; upgrade gwmock-signal"
+            ) from exc
+        new = extras - self._unsupported_params
+        if new:
+            logger.warning(
+                "Waveform backend does not accept the following population parameters "
+                "and they will be ignored: %s. "
+                "They are still recorded in injection_parameters metadata.",
+                ", ".join(sorted(new)),
+            )
+            self._unsupported_params |= new
+        return {k: v for k, v in backend_parameters.items() if k not in self._unsupported_params}
+
+    def pre_coalescence_duration(
+        self,
+        parameters: Mapping[str, Any],
+        *,
+        sampling_frequency: float,
+        minimum_frequency: float,
+        waveform_arguments: Mapping[str, Any] | None = None,
+        waveform_options: Mapping[str, Any] | None = None,
+    ) -> float | None:
+        """Return how long before ``coa_time`` this event's waveform starts, in seconds.
+
+        Asked before generating, so a segment can claim the event whose waveform *begins* inside it
+        rather than the one its ``coa_time`` falls in. A compact binary's buffer starts well before
+        coalescence, and a segment chosen from ``coa_time`` alone crops that lead away with nowhere
+        to put it -- the earlier segments are already written.
+
+        Args:
+            parameters: Per-event source parameters, as :meth:`simulate` takes them.
+            sampling_frequency: Sample rate in Hz.
+            minimum_frequency: Low-frequency cutoff in Hz.
+            waveform_arguments: Fixed waveform parameters, as :meth:`simulate` takes them.
+            waveform_options: Extra waveform options, as :meth:`simulate` takes them.
+
+        Returns:
+            Seconds between the first sample and coalescence, positive; or ``None`` when the answer
+            is *unknown* -- a backend that cannot say (PyCBC), a source type with no coalescence, or
+            an installed gwmock-signal predating the query. Never read ``None`` as zero: zero is a
+            claim that the waveform starts at coalescence, and acting on it drops the whole inspiral.
+        """
+        query = getattr(self._backend, "pre_coalescence_duration", None)
+        if query is None:
+            return None
+        backend_parameters = self._backend_parameters(parameters, waveform_arguments, waveform_options)
+        try:
+            return query(
+                backend_parameters,
+                sampling_frequency=sampling_frequency,
+                minimum_frequency=minimum_frequency,
+            )
+        except ValueError as exc:
+            # The same unsupported-parameter dance generation does, for the same reason: a
+            # population column the backend does not know must not be the thing that decides
+            # whether an inspiral is placed. Anything else propagates.
+            filtered = self._without_unsupported(exc, backend_parameters)
+            if filtered is None:
+                raise
+            return query(
+                filtered,
+                sampling_frequency=sampling_frequency,
+                minimum_frequency=minimum_frequency,
+            )
+
     def simulate_stack(
         self,
         parameters: Mapping[str, Any],
@@ -600,16 +728,7 @@ class SignalAdapter:
         Returns:
             A DetectorStrainStack instance.
         """
-        backend_parameters = {**(waveform_arguments or {}), **dict(parameters)}
-        if waveform_options:
-            if "waveform_arguments" in backend_parameters:
-                raise ValueError(
-                    "Specify extra waveform options either via waveform_options or as a "
-                    "waveform_arguments parameter, not both"
-                )
-            backend_parameters["waveform_arguments"] = dict(waveform_options)
-        if self._unsupported_params:
-            backend_parameters = {k: v for k, v in backend_parameters.items() if k not in self._unsupported_params}
+        backend_parameters = self._backend_parameters(parameters, waveform_arguments, waveform_options)
         try:
             return self._backend.simulate(
                 backend_parameters,
@@ -620,25 +739,9 @@ class SignalAdapter:
                 earth_rotation=earth_rotation,
             )
         except ValueError as exc:
-            match = _UNSUPPORTED_PARAMS_RE.match(str(exc))
-            if match is None:
+            filtered = self._without_unsupported(exc, backend_parameters)
+            if filtered is None:
                 raise
-            extras = {token.strip() for token in match.group(1).split(",") if token.strip()}
-            if "waveform_arguments" in extras:
-                raise ValueError(
-                    "The installed gwmock-signal does not support the waveform_arguments "
-                    "parameter required by waveform_options; upgrade gwmock-signal"
-                ) from exc
-            new = extras - self._unsupported_params
-            if new:
-                logger.warning(
-                    "Waveform backend does not accept the following population parameters "
-                    "and they will be ignored: %s. "
-                    "They are still recorded in injection_parameters metadata.",
-                    ", ".join(sorted(new)),
-                )
-                self._unsupported_params |= new
-            filtered = {k: v for k, v in backend_parameters.items() if k not in self._unsupported_params}
             return self._backend.simulate(
                 filtered,
                 self._network.detector_names,

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -313,7 +313,7 @@ def test_simulate_command_runs_adapter_orchestration(monkeypatch, tmp_path: Path
     assert (tmp_path / "output" / "signal" / "signal-1.gwf").exists()
     _assert_noise_outputs_exist(tmp_path / "output" / "noise")
     metadata = yaml.safe_load((tmp_path / "metadata" / "orchestration-0.metadata.json").read_text())
-    assert metadata["schema_version"] == "1.3.0"
+    assert metadata["schema_version"] == "1.4.0"
     assert metadata["config"]["orchestration"]["population"]["backend"] == FAKE_POPULATION_BACKEND
     assert metadata["config"]["orchestration"]["signal"]["backend"] == FAKE_SIGNAL_BACKEND
     assert metadata["config"]["orchestration"]["noise"]["backend"] == FAKE_NOISE_BACKEND

--- a/tests/cli/test_inspiral_segment_placement.py
+++ b/tests/cli/test_inspiral_segment_placement.py
@@ -1,0 +1,385 @@
+"""Which segment claims a compact binary, when its waveform starts before its coalescence.
+
+A compact binary's buffer begins seconds before ``coa_time``. A segment chosen from ``coa_time``
+alone therefore starts *after* the waveform does, and injection crops the difference away with
+nowhere to put it: the earlier segments are already written. The loss is not marginal -- for a 30+25
+solar-mass binary at 1024 Hz the lead is 3.6 s, so an event landing 1 s into a 16-second segment
+loses 2.6 s of inspiral.
+
+The rule these tests pin is that a segment claims the events whose *waveform* starts before it ends,
+taken from :meth:`SignalAdapter.pre_coalescence_duration`. Two loops apply it -- per-event and
+batched -- and both are checked, because ``population_index`` is checkpointed state and a run
+switched between modes must not skip or repeat an event because the two disagreed.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from gwmock.cli.utils.config import Config
+
+_POPULATION_CSV = Path(__file__).resolve().parents[2] / "examples" / "signal" / "bbh_population.csv"
+_START = 1577491296.0
+_SAMPLING_FREQUENCY = 1024.0
+_SEGMENT_DURATION = 16.0
+
+#: A complete BBH parameter set, so the query can actually answer. Underspecified events are the
+#: subject of their own test below rather than an accident of this one.
+_COMPLETE_EVENT: dict[str, Any] = {
+    "detector_frame_mass_1": 30.0,
+    "detector_frame_mass_2": 25.0,
+    "distance": 400.0,
+    "right_ascension": 1.0,
+    "declination": 0.5,
+    "polarization_angle": 0.2,
+    "inclination": 0.3,
+}
+
+
+def _config(working_directory: Path, execution: str, total_duration: float = _SEGMENT_DURATION) -> dict[str, Any]:
+    """Return a one-segment BBH config in the given execution mode.
+
+    No ``waveform-backend`` key, so the default LAL library is used: naming ripple would make
+    *constructing* the orchestrator instantiate ``RippleBackend``, which needs the ``[jax]`` extra
+    long before any generation happens, and these tests are about placement rather than a library.
+    """
+    return {
+        "globals": {
+            "simulator-arguments": {
+                "sampling-frequency": _SAMPLING_FREQUENCY,
+                "duration": _SEGMENT_DURATION,
+                "total-duration": total_duration,
+                "start-time": _START,
+                "seed": 20260804,
+            },
+            "working-directory": str(working_directory),
+            "output-directory": "output",
+            "metadata-directory": "metadata",
+        },
+        "orchestration": {
+            "population": {
+                "backend": "FilePopulationLoader",
+                "source-type": "bbh",
+                "n-samples": 1,
+                "arguments": {"path": str(_POPULATION_CSV)},
+            },
+            "signal": {
+                "source-type": "bbh",
+                "waveform-model": "IMRPhenomD",
+                "execution": execution,
+                "minimum-frequency": 30,
+                "detectors": ["ET-Triangle-Sardinia"],
+                "output": {
+                    "output_directory": "signal",
+                    "file_name": "sig-{{ detectors }}.gwf",
+                    "arguments": {"channel": "{{ detectors }}:STRAIN"},
+                },
+            },
+        },
+    }
+
+
+def _orchestrator(working_directory: Path, execution: str = "per-event", total_duration: float = _SEGMENT_DURATION):
+    from gwmock.cli.adapter_orchestration import AdapterOrchestrator
+
+    working_directory.mkdir(parents=True, exist_ok=True)
+    config = Config.model_validate(_config(working_directory, execution, total_duration))
+    return AdapterOrchestrator.from_config(
+        config.orchestration,
+        global_simulator_arguments=dict(config.globals.simulator_arguments),
+    )
+
+
+class _StubAdapter:
+    """A signal adapter that answers the placement query however the test needs.
+
+    Stands in for the real adapter so the boundary rule can be tested without generating a waveform
+    per case, and so *unknown* and *failing* answers can be produced at all -- neither is reachable
+    from the bundled backends with complete parameters.
+    """
+
+    def __init__(self, lead: float | None = None, error: Exception | None = None) -> None:
+        self._lead = lead
+        self._error = error
+        self.detector_names = ("E1",)
+
+    def pre_coalescence_duration(self, _parameters: Any, **_: Any) -> float | None:
+        if self._error is not None:
+            raise self._error
+        return self._lead
+
+
+def _end_time(orchestrator) -> float:
+    return float(getattr(orchestrator.end_time, "value", orchestrator.end_time))
+
+
+class TestTheBoundaryRule:
+    """The rule itself, with the lead supplied rather than generated."""
+
+    def test_an_event_coalescing_after_the_segment_is_claimed_when_its_waveform_starts_inside(self, tmp_path):
+        """This is the defect. Its ``coa_time`` is past the boundary; 3.6 s of its inspiral is not.
+
+        Under the previous ``coa_time`` rule this event was left to the next segment, whose start is
+        after the waveform's -- so the lead was cropped and could never be placed, because by then
+        this segment had been written.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(lead=3.6)
+        end_time = _end_time(orchestrator)
+
+        assert orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time + 1.0}), (
+            "an event whose waveform begins 2.6 s before the boundary belongs to this segment"
+        )
+
+    def test_an_event_whose_waveform_also_starts_later_is_left_for_the_next_segment(self, tmp_path):
+        """The rule must still end the segment, or every remaining event would be pulled forward."""
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(lead=3.6)
+        end_time = _end_time(orchestrator)
+
+        assert not orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time + 10.0})
+
+    def test_the_boundary_is_the_waveform_start_and_not_the_coalescence(self, tmp_path):
+        """Pins which quantity is compared, by making the two answers differ.
+
+        With a lead of 5 s an event coalescing 4 s past the boundary is claimed and one coalescing
+        6 s past it is not, so the comparison cannot be against ``coa_time``.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(lead=5.0)
+        end_time = _end_time(orchestrator)
+
+        assert orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time + 4.0})
+        assert not orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time + 6.0})
+
+    def test_an_event_without_a_coalescence_time_always_belongs(self, tmp_path):
+        """Non-coalescing sources reach the loop unchanged; there is nothing to place them by."""
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(lead=3.6)
+
+        assert orchestrator._event_starts_before_segment_end({"frequency": 100.0})
+
+
+class TestWhenTheLeadIsNotAvailable:
+    """Unknown must mean unknown. Reading it as zero would drop the whole inspiral silently."""
+
+    def test_an_unknown_lead_falls_back_to_the_coalescence_time(self, tmp_path):
+        """``None`` restores the previous behaviour rather than claiming the waveform starts at tc.
+
+        A backend that cannot say (PyCBC) and an installed gwmock-signal predating the query both
+        arrive here. Treating ``None`` as ``0.0`` would look like an answer and behave like the bug.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(lead=None)
+        end_time = _end_time(orchestrator)
+
+        assert orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time - 0.5})
+        assert not orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time + 0.5}), (
+            "without a lead the only rule available is coa_time, which is where this started"
+        )
+
+    def test_a_query_that_raises_does_not_fail_the_run(self, tmp_path, caplog):
+        """Placement must not be the thing that turns an odd catalogue into a crash.
+
+        The same parameters go to generation immediately afterwards, which raises whatever this
+        raised -- with the context of the event it was generating rather than of a boundary test.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(error=ValueError("Missing required parameter: 'distance'"))
+        end_time = _end_time(orchestrator)
+
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            claimed = orchestrator._event_starts_before_segment_end({"coa_time": end_time - 0.5})
+
+        assert claimed, "the fallback is the coa_time rule, not a refusal to place the event"
+        assert "Missing required parameter" in caplog.text, (
+            "the swallowed reason must appear, or a run silently reverts to the cropping behaviour"
+        )
+
+    def test_the_fallback_warns_once_rather_than_once_per_event(self, tmp_path, caplog):
+        """A catalogue the query cannot answer for cannot answer for any of its events."""
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(error=ValueError("nope"))
+        end_time = _end_time(orchestrator)
+
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            for offset in range(5):
+                orchestrator._event_starts_before_segment_end({"coa_time": end_time - offset - 1.0})
+
+        assert caplog.text.count("Cannot establish how long before coalescence") == 1
+
+    def test_a_run_without_a_signal_adapter_still_walks_the_catalogue(self, tmp_path):
+        """Noise-only orchestration reaches this helper through shared code paths."""
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = None
+        end_time = _end_time(orchestrator)
+
+        assert orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time - 0.5})
+        assert not orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time + 0.5})
+
+
+class TestBothLoopsAgree:
+    """``population_index`` is checkpointed, so the two execution modes must claim the same events."""
+
+    def test_the_batched_walk_claims_the_same_events_as_the_rule(self, tmp_path):
+        """``_events_for_this_segment`` must apply the boundary rule, not its own copy of one."""
+        orchestrator = _orchestrator(tmp_path, "batched")
+        orchestrator.signal_adapter = _StubAdapter(lead=3.6)
+        end_time = _end_time(orchestrator)
+        orchestrator._population_events = (
+            {**_COMPLETE_EVENT, "coa_time": end_time - 1.0},
+            {**_COMPLETE_EVENT, "coa_time": end_time + 1.0},  # coalesces later, starts inside
+            {**_COMPLETE_EVENT, "coa_time": end_time + 10.0},
+        )
+
+        event_ids, events = orchestrator._events_for_this_segment()
+
+        assert event_ids == [0, 1], "the event coalescing just past the boundary starts inside it"
+        assert len(events) == 2
+        assert int(orchestrator.population_index) == 0, "reading must not advance the checkpointed index"
+
+    def test_the_per_event_loop_claims_the_same_events(self, tmp_path):
+        """The same catalogue through the other loop, so a mode switch cannot skip or repeat."""
+        orchestrator = _orchestrator(tmp_path, "batched")
+        orchestrator.signal_adapter = _StubAdapter(lead=3.6)
+        end_time = _end_time(orchestrator)
+        events = (
+            {**_COMPLETE_EVENT, "coa_time": end_time - 1.0},
+            {**_COMPLETE_EVENT, "coa_time": end_time + 1.0},
+            {**_COMPLETE_EVENT, "coa_time": end_time + 10.0},
+        )
+        orchestrator._population_events = events
+        batched_ids, _ = orchestrator._events_for_this_segment()
+
+        per_event = _orchestrator(tmp_path / "per", "per-event")
+        per_event.signal_adapter = _StubAdapter(lead=3.6)
+        per_event._population_events = events
+        claimed = [
+            index for index, parameters in enumerate(events) if per_event._event_starts_before_segment_end(parameters)
+        ]
+
+        assert claimed == batched_ids, (
+            "the two modes must agree on the boundary; population_index is checkpointed across them"
+        )
+
+
+class TestNothingIsDiscarded:
+    """The point of the rule, measured on assembled segments rather than argued from the boundary."""
+
+    def _run_two_segments(self, orchestrator, coa_time: float):
+        """Assemble two consecutive segments containing one event, and return them."""
+        orchestrator._population_events = ({**_COMPLETE_EVENT, "coa_time": coa_time},)
+        first = orchestrator.simulate().signal_segment
+        orchestrator.update_state()
+        second = orchestrator.simulate().signal_segment
+        return first, second
+
+    def test_a_waveform_straddling_the_boundary_keeps_all_of_its_energy(self, tmp_path, caplog):
+        """No sample is dropped, and the check is the strain itself rather than the absence of a log.
+
+        The event coalesces 1 s into the *second* segment, so its buffer starts 2.6 s before that
+        segment begins. Claimed by ``coa_time`` it would be generated during the second segment, and
+        injection would crop those 2.6 s -- 65% of its samples -- because the first segment is
+        already written by then.
+
+        This offset is deliberately the *mild* case. Measured for this binary at 1024 Hz, the
+        unweighted strain-squared energy lost runs 0.34% at 1 s past the boundary, 11% at 0.25 s,
+        50% at 0.1 s and 99.8% at 1 ms, because a compact binary's energy is concentrated in the
+        last fraction of a second before merger. Testing the mild case makes the assertion depend on
+        placement rather than on that concentration: 0.34% is a loss no energy-fraction tolerance
+        would forgive, and a test pinned at the catastrophic end would still pass if placement were
+        only approximately right.
+
+        Summed squares across the two assembled segments are compared against the same waveform
+        generated on its own, which is the quantity that must survive placement.
+        """
+        orchestrator = _orchestrator(tmp_path, "per-event", total_duration=2 * _SEGMENT_DURATION)
+        adapter = orchestrator.signal_adapter
+        assert adapter is not None
+        coa_time = _START + _SEGMENT_DURATION + 1.0
+        standalone = adapter.simulate(
+            {**_COMPLETE_EVENT, "coa_time": coa_time},
+            sampling_frequency=_SAMPLING_FREQUENCY,
+            minimum_frequency=30.0,
+        )
+        expected_energy = float(np.sum(np.square(np.atleast_2d(np.asarray(standalone, dtype=float)))))
+
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            first, second = self._run_two_segments(orchestrator, coa_time)
+
+        placed_energy = sum(
+            float(np.sum(np.square(np.atleast_2d(np.asarray(segment, dtype=float))))) for segment in (first, second)
+        )
+
+        assert "Discarding" not in caplog.text, caplog.text
+        # atol=0.0 because strain-squared energies are ~1e-45: the default atol would make any two
+        # such numbers compare equal and the assertion could not fail.
+        assert placed_energy == pytest.approx(expected_energy, rel=1e-9, abs=0.0), (
+            f"placed {placed_energy} of {expected_energy}; the boundary lost "
+            f"{100.0 * (1.0 - placed_energy / expected_energy):.2f}% of the waveform"
+        )
+
+    def test_the_event_is_attributed_to_the_segment_its_waveform_starts_in(self, tmp_path):
+        """Provenance follows placement: the frame listing the event is the one its data begins in.
+
+        Stated rather than assumed, because it is a change -- an event used to be listed against the
+        frame containing its coalescence, and a reader of the metadata needs to know which.
+        """
+        orchestrator = _orchestrator(tmp_path, "per-event", total_duration=2 * _SEGMENT_DURATION)
+        coa_time = _START + _SEGMENT_DURATION + 1.0
+
+        orchestrator._population_events = ({**_COMPLETE_EVENT, "coa_time": coa_time},)
+        orchestrator.simulate()
+        first_segment_injections = list(orchestrator._batch_injections)
+        orchestrator.update_state()
+        orchestrator.simulate()
+        second_segment_injections = list(orchestrator._batch_injections)
+
+        assert [entry["event_id"] for entry in first_segment_injections] == [0], (
+            "the event belongs to the first segment, where its waveform starts"
+        )
+        assert second_segment_injections == [], "and it is not cross-listed against the frame its coalescence falls in"
+
+
+class TestAgainstRealGeneration:
+    """The predicted lead has to be the lead generation actually produces, or placement is wrong."""
+
+    def test_the_predicted_lead_matches_the_generated_buffer(self, tmp_path):
+        """Measured against the produced ``TimeSeries``, not against another prediction.
+
+        This is what makes the rule safe: if the query said less than generation produces, a segment
+        chosen from it would still crop the start.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        adapter = orchestrator.signal_adapter
+        assert adapter is not None
+        coa_time = _START + 8.0
+        parameters = {**_COMPLETE_EVENT, "coa_time": coa_time}
+
+        predicted = adapter.pre_coalescence_duration(
+            parameters,
+            sampling_frequency=_SAMPLING_FREQUENCY,
+            minimum_frequency=30.0,
+        )
+        strain = adapter.simulate(parameters, sampling_frequency=_SAMPLING_FREQUENCY, minimum_frequency=30.0)
+        measured = coa_time - float(strain.start_time.value)
+
+        assert predicted is not None, "LAL can answer this; a None here would disable the fix silently"
+        assert predicted == pytest.approx(measured, abs=0.5 / _SAMPLING_FREQUENCY), (
+            f"predicted lead {predicted} s but generation starts {measured} s before coalescence"
+        )
+
+    def test_an_event_just_past_the_boundary_is_claimed_using_the_real_query(self, tmp_path):
+        """End to end through the real adapter: no stub, no supplied lead."""
+        orchestrator = _orchestrator(tmp_path)
+        end_time = _end_time(orchestrator)
+
+        assert orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time + 1.0}), (
+            "a 30+25 binary at 1024 Hz leads coalescence by 3.6 s, so this event starts in this segment"
+        )
+        assert not orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time + 5.0})

--- a/tests/cli/test_inspiral_segment_placement.py
+++ b/tests/cli/test_inspiral_segment_placement.py
@@ -10,11 +10,17 @@ The rule these tests pin is that a segment claims the events whose *waveform* st
 taken from :meth:`SignalAdapter.pre_coalescence_duration`. Two loops apply it -- per-event and
 batched -- and both are checked, because ``population_index`` is checkpointed state and a run
 switched between modes must not skip or repeat an event because the two disagreed.
+
+The rule alone is not enough, which is what ``TestConsumptionOrderDoesNotStrandEvents`` covers: both
+loops stop at the first event that does not belong, so the catalogue has to be consumed in
+waveform-start order rather than in ``coa_time`` order, or a long-lead event sitting behind a
+short-lead one is never reached and is cropped exactly as before.
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -103,14 +109,30 @@ class _StubAdapter:
     from the bundled backends with complete parameters.
     """
 
-    def __init__(self, lead: float | None = None, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        lead: float | None = None,
+        error: Exception | None = None,
+        leads_by_coa_time: Mapping[float, float] | None = None,
+        errors_by_coa_time: Mapping[float, Exception] | None = None,
+    ) -> None:
         self._lead = lead
         self._error = error
+        # Per-event answers, so a catalogue can be given leads that vary the way real ones do -- a
+        # heavy binary black hole against a binary neutron star differ by an order of magnitude.
+        self._leads_by_coa_time = dict(leads_by_coa_time or {})
+        self._errors_by_coa_time = dict(errors_by_coa_time or {})
         self.detector_names = ("E1",)
 
-    def pre_coalescence_duration(self, _parameters: Any, **_: Any) -> float | None:
-        if self._error is not None:
+    def pre_coalescence_duration(self, parameters: Mapping[str, Any], **_: Any) -> float | None:
+        coa_time = parameters.get("coa_time")
+        per_event_error = self._errors_by_coa_time.get(coa_time)
+        if per_event_error is not None:
+            raise per_event_error
+        if self._error is not None and not self._errors_by_coa_time:
             raise self._error
+        if coa_time in self._leads_by_coa_time:
+            return self._leads_by_coa_time[coa_time]
         return self._lead
 
 
@@ -157,6 +179,19 @@ class TestTheBoundaryRule:
         assert orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time + 4.0})
         assert not orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time + 6.0})
 
+    def test_a_waveform_starting_exactly_on_the_boundary_goes_to_the_next_segment(self, tmp_path):
+        """The comparison is strict, and which way it resolves matters rather than being arbitrary.
+
+        A waveform starting exactly where the next segment starts loses nothing by being claimed
+        there: that segment's start *is* the waveform's start, so injection crops zero samples.
+        Claiming it here would generate it a segment early for no gain.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(lead=4.0)
+        end_time = _end_time(orchestrator)
+
+        assert not orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time + 4.0})
+
     def test_an_event_without_a_coalescence_time_always_belongs(self, tmp_path):
         """Non-coalescing sources reach the loop unchanged; there is nothing to place them by."""
         orchestrator = _orchestrator(tmp_path)
@@ -201,8 +236,8 @@ class TestWhenTheLeadIsNotAvailable:
             "the swallowed reason must appear, or a run silently reverts to the cropping behaviour"
         )
 
-    def test_the_fallback_warns_once_rather_than_once_per_event(self, tmp_path, caplog):
-        """A catalogue the query cannot answer for cannot answer for any of its events."""
+    def test_the_fallback_warns_once_for_a_repeated_reason(self, tmp_path, caplog):
+        """A catalogue the query cannot read fails identically for every row; say so once."""
         orchestrator = _orchestrator(tmp_path)
         orchestrator.signal_adapter = _StubAdapter(error=ValueError("nope"))
         end_time = _end_time(orchestrator)
@@ -213,6 +248,31 @@ class TestWhenTheLeadIsNotAvailable:
 
         assert caplog.text.count("Cannot establish how long before coalescence") == 1
 
+    def test_a_second_distinct_reason_is_also_reported(self, tmp_path, caplog):
+        """Deduplicating by a flag rather than by reason would name the wrong cause.
+
+        One malformed row fails only its own query. Under a single flag, every later event failing for
+        a *different* reason falls back silently beneath a warning describing the first one -- so the
+        operator reads one cause and has no way to see the others.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        end_time = _end_time(orchestrator)
+        first, second = end_time - 1.0, end_time - 2.0
+        orchestrator.signal_adapter = _StubAdapter(
+            errors_by_coa_time={
+                first: ValueError("Missing required parameter: 'distance'"),
+                second: TypeError("unsupported operand type(s)"),
+            }
+        )
+
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": first})
+            orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": second})
+
+        assert caplog.text.count("Cannot establish how long before coalescence") == 2
+        assert "Missing required parameter" in caplog.text
+        assert "unsupported operand" in caplog.text
+
     def test_a_run_without_a_signal_adapter_still_walks_the_catalogue(self, tmp_path):
         """Noise-only orchestration reaches this helper through shared code paths."""
         orchestrator = _orchestrator(tmp_path)
@@ -221,6 +281,108 @@ class TestWhenTheLeadIsNotAvailable:
 
         assert orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time - 0.5})
         assert not orchestrator._event_starts_before_segment_end({**_COMPLETE_EVENT, "coa_time": end_time + 0.5})
+
+
+class TestConsumptionOrderDoesNotStrandEvents:
+    """A long-lead event behind a short-lead one must still be claimed by the segment it starts in.
+
+    Both loops walk the catalogue and stop at the first event that does not belong, which is sound
+    only if "belongs" is a prefix property. It was, under the ``coa_time`` rule. Under the
+    waveform-start rule it is not for a ``coa_time``-sorted catalogue, because the lead varies with
+    the source -- roughly 3 s for a heavy binary black hole against ~100 s for a binary neutron star.
+    Consumption is therefore ordered by the placement key instead.
+
+    Without that ordering the third event below is never reached, is generated a segment late, and is
+    cropped -- the exact loss this rule exists to prevent, reintroduced by catalogue order alone.
+    """
+
+    def _catalogue(self, end_time: float):
+        """Return a catalogue whose waveform-start order differs from its coa_time order."""
+        return (
+            {**_COMPLETE_EVENT, "coa_time": end_time + 1.0},  # start end-9   belongs
+            {**_COMPLETE_EVENT, "coa_time": end_time + 2.0},  # start end+1   does not
+            {**_COMPLETE_EVENT, "coa_time": end_time + 3.0},  # start end-17  belongs, sorts last
+        )
+
+    def _leads(self, end_time: float) -> dict[float, float]:
+        return {end_time + 1.0: 10.0, end_time + 2.0: 1.0, end_time + 3.0: 20.0}
+
+    def test_the_batched_walk_reaches_the_long_lead_event_behind_a_short_lead_one(self, tmp_path):
+        orchestrator = _orchestrator(tmp_path, "batched")
+        end_time = _end_time(orchestrator)
+        orchestrator.signal_adapter = _StubAdapter(leads_by_coa_time=self._leads(end_time))
+        orchestrator._population_events = self._catalogue(end_time)
+
+        event_ids, events = orchestrator._events_for_this_segment()
+
+        assert sorted(event_ids) == [0, 2], (
+            "event 2 starts 17 s before the boundary; stopping at event 1 would strand it and crop it"
+        )
+        assert len(events) == 2
+        assert 1 not in event_ids, "event 1's waveform starts after this segment ends"
+
+    def test_the_per_event_loop_reaches_it_too(self, tmp_path):
+        """The two loops must agree, or a mode switch mid-run changes which events exist where."""
+        orchestrator = _orchestrator(tmp_path, "per-event")
+        end_time = _end_time(orchestrator)
+        orchestrator.signal_adapter = _StubAdapter(leads_by_coa_time=self._leads(end_time))
+        orchestrator._population_events = self._catalogue(end_time)
+
+        order = orchestrator._placement_order()
+        claimed = []
+        for position in order:
+            if not orchestrator._event_starts_before_segment_end(orchestrator._population_events[position]):
+                break
+            claimed.append(position)
+
+        assert sorted(claimed) == [0, 2]
+
+    def test_the_deferred_event_is_picked_up_by_the_next_segment(self, tmp_path):
+        """Consuming out of catalogue order must not skip or repeat the event left behind.
+
+        ``population_index`` counts events consumed rather than naming a catalogue position, so this
+        is the assertion that the count and the order stay consistent with each other.
+        """
+        orchestrator = _orchestrator(tmp_path, "batched")
+        end_time = _end_time(orchestrator)
+        orchestrator.signal_adapter = _StubAdapter(leads_by_coa_time=self._leads(end_time))
+        orchestrator._population_events = self._catalogue(end_time)
+
+        first_ids, _ = orchestrator._events_for_this_segment()
+        orchestrator._commit_consumed_events(first_ids)
+
+        assert int(orchestrator.population_index) == 2, "two events consumed, whatever their positions"
+
+        orchestrator.update_state()
+        second_ids, _ = orchestrator._events_for_this_segment()
+
+        assert second_ids == [1], "the deferred event, exactly once"
+        orchestrator._commit_consumed_events(second_ids)
+        assert int(orchestrator.population_index) == 3
+        assert sorted(first_ids + second_ids) == [0, 1, 2], "every event claimed exactly once"
+
+    def test_events_without_a_coalescence_time_are_never_left_behind(self, tmp_path):
+        """They belong to every segment, so they must not sit behind an event that ends the walk."""
+        orchestrator = _orchestrator(tmp_path, "batched")
+        end_time = _end_time(orchestrator)
+        orchestrator.signal_adapter = _StubAdapter(lead=1.0)
+        orchestrator._population_events = (
+            {**_COMPLETE_EVENT, "coa_time": end_time + 100.0},
+            {"frequency": 100.0},
+        )
+
+        event_ids, _ = orchestrator._events_for_this_segment()
+
+        assert event_ids == [1]
+
+    def test_the_order_is_stable_for_events_sharing_a_start(self, tmp_path):
+        """Equal keys keep catalogue order, so provenance and injection order stay reproducible."""
+        orchestrator = _orchestrator(tmp_path, "batched")
+        end_time = _end_time(orchestrator)
+        orchestrator.signal_adapter = _StubAdapter(lead=2.0)
+        orchestrator._population_events = tuple({**_COMPLETE_EVENT, "coa_time": end_time - 5.0} for _ in range(4))
+
+        assert orchestrator._placement_order() == (0, 1, 2, 3)
 
 
 class TestBothLoopsAgree:
@@ -344,6 +506,74 @@ class TestNothingIsDiscarded:
             "the event belongs to the first segment, where its waveform starts"
         )
         assert second_segment_injections == [], "and it is not cross-listed against the frame its coalescence falls in"
+
+
+class TestWhatAConsumerSees:
+    """The attribution change reaches serialized metadata and the lookup, so it is checked there."""
+
+    def test_the_schema_version_records_that_the_attribution_changed(self):
+        """No field was added or removed, so nothing but the version tells the two conventions apart.
+
+        A consumer reading a 1.3.0 record and a new one sees the same shape while ``injections`` means
+        something different in each. The version is the only signal available, so it has to move.
+        """
+        from gwmock.cli.utils.metadata import SCHEMA_VERSION
+
+        assert SCHEMA_VERSION == "1.4.0"
+
+    def test_an_older_record_still_loads(self):
+        """Bumping the minor must not orphan archived runs: the major is what gates parsing."""
+        from gwmock.cli.utils.metadata import MetadataRecord
+
+        record = MetadataRecord.model_validate(
+            {
+                "schema_version": "1.3.0",
+                "subpackage_versions": {},
+                "config": {},
+                "config_sha256": "0" * 64,
+                "host": {"platform": "linux", "python": "3.12", "cpu": "x86_64"},
+            }
+        )
+
+        assert record.schema_version == "1.3.0"
+
+    def test_the_lookup_reports_the_frame_the_injection_was_recorded_against(self, tmp_path):
+        """``find_signal`` reads ``signal.injections`` generically, so it follows placement.
+
+        Pinned because it is the user-visible consequence: an event is reported against the frame its
+        waveform starts in, which for a large lead can be a frame holding mostly quiet lead-in rather
+        than the merger. The lookup itself needs no change; this is here so that stays true.
+        """
+        import json
+
+        from gwmock.cli.utils.signal_lookup import find_signals
+
+        metadata_directory = tmp_path / "metadata"
+        metadata_directory.mkdir()
+        (metadata_directory / "orchestration-0.metadata.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "1.4.0",
+                    "subpackage_versions": {},
+                    "config": {},
+                    "config_sha256": "0" * 64,
+                    "host": {"platform": "linux", "python": "3.12", "cpu": "x86_64"},
+                    "signal": {
+                        "backend": "stub",
+                        "injections": [{"event_id": 7, "parameters": {"coa_time": 1000.0}}],
+                    },
+                    "outputs": [{"kind": "signal", "path": "signal/sig-0.gwf"}],
+                }
+            )
+        )
+
+        results = find_signals(metadata_directory, param_filters=[("coa_time", "==", 1000.0)])
+
+        assert [entry["event_id"] for entry in results] == [7]
+        assert results[0]["frames"] == ["signal/sig-0.gwf"], (
+            "the frame listed is the one the injection was recorded against, which is now the frame "
+            "the waveform starts in"
+        )
 
 
 class TestAgainstRealGeneration:

--- a/tests/cli/utils/test_metadata.py
+++ b/tests/cli/utils/test_metadata.py
@@ -59,7 +59,7 @@ def test_metadata_record_uses_versioned_json_schema(tmp_path: Path) -> None:
     metadata_path = tmp_path / "metadata" / "mock-0.metadata.json"
     record = load_metadata_record(metadata_path)
 
-    assert record.schema_version == "1.3.0"
+    assert record.schema_version == "1.4.0"
     assert record.config_sha256 == compute_file_hash(config_file)
     assert record.seed == 42
     assert record.outputs[0].path == "output/data.json"

--- a/tests/data/time_series/test_content_before_segment.py
+++ b/tests/data/time_series/test_content_before_segment.py
@@ -184,12 +184,19 @@ class TestTheWarning:
         assert "Discarding" in caplog.text
         assert "unknown" in caplog.text
 
-    def test_a_real_run_warns_when_coa_time_lands_near_a_boundary(self, tmp_path, caplog):
-        """Synthetic arrays cannot show that ordinary configurations reach this.
+    def test_a_real_run_warns_when_the_pre_coalescence_duration_is_unavailable(self, tmp_path, caplog):
+        """Synthetic arrays cannot show that a real configuration reaches this.
 
         A 30+25 Msun binary at 20 Hz is conditioned into a 4 s buffer with the merger 0.4 s from its
-        end, so a ``coa_time`` 0.5 s past a segment boundary puts 3.1 s of inspiral in the previous
+        end, so a ``coa_time`` 0.5 s past a segment boundary has 3.1 s of inspiral in the previous
         segment -- which is already written.
+
+        Segments now claim an event by where its waveform starts, so this configuration keeps that
+        inspiral -- ``tests/cli/test_inspiral_segment_placement.py`` measures that it survives, by
+        energy rather than by the absence of this warning. What is exercised here is the fallback:
+        with the pre-coalescence duration unavailable -- an older gwmock-signal, a backend that
+        cannot say -- placement reverts to ``coa_time`` and the loss returns. That is the path this
+        reporting exists for, and the one that must keep saying how much went.
         """
         from gwmock.cli.adapter_orchestration import AdapterOrchestrator
         from gwmock.cli.utils.config import Config
@@ -240,12 +247,16 @@ class TestTheWarning:
             config.orchestration, global_simulator_arguments=dict(config.globals.simulator_arguments)
         )
 
+        # Force the fallback rather than simulate an old install: the query is made through the
+        # adapter, so replacing its answer with "unknown" is the whole difference.
+        orchestrator.signal_adapter.pre_coalescence_duration = lambda *_args, **_kwargs: None
+
         with caplog.at_level(logging.WARNING, logger="gwmock"):
             orchestrator.simulate()  # first segment: nothing to claim yet
             orchestrator.update_state()
             orchestrator.simulate()  # the segment holding coa_time
 
-        assert "Discarding" in caplog.text, "an ordinary BBH config lost part of its inspiral without saying so"
+        assert "Discarding" in caplog.text, "the fallback lost part of an inspiral without saying so"
         # A bounded range, not the exact 3.100 s this currently prints. The value comes from LAL's
         # conditioning, so pinning it would turn a waveform-library bump into a failure here while
         # saying nothing about whether the reporting works. Still tight enough to fail if the

--- a/uv.lock
+++ b/uv.lock
@@ -700,7 +700,7 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.16.0" },
     { name = "gwmock-noise", specifier = ">=0.10.0" },
     { name = "gwmock-pop", specifier = ">=0.11.4" },
-    { name = "gwmock-signal", specifier = ">=0.13.0" },
+    { name = "gwmock-signal", specifier = ">=0.15.0" },
     { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'cuda'", specifier = ">=0.15.0" },
     { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'jax'", specifier = ">=0.15.0" },
     { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", specifier = ">=0.13.0" },


### PR DESCRIPTION
A compact binary's buffer begins seconds before its coalescence. Segments claimed an event
by `coa_time`, so an event landing just past a boundary was generated during the *next*
segment -- whose start is after the waveform's. Injection cropped the difference and it
could never be placed, because the earlier segments were already written.

Segments now claim the events whose waveform starts before the segment ends, taken from
`CBCSimulator.pre_coalescence_duration` (gwmock-signal 0.15.0). The existing
forward-overflow carry delivers the remainder, so only the claiming rule changes.

## How much was being lost

Measured for a 30+25 solar-mass binary at 1024 Hz with 16-second segments, against where
`coa_time` lands past the boundary. The lead is 3.5996 s, so 22.5% of uniformly distributed
events lose something:

| coa_time - boundary | dropped | samples | energy |
|---|---|---|---|
| +0.001 s | 3.599 s | 90.0% | 99.78% |
| +0.1 s | 3.500 s | 87.5% | 50.30% |
| +0.25 s | 3.350 s | 83.7% | 11.47% |
| +1.0 s | 2.600 s | 65.0% | 0.34% |
| +3.5 s | 0.100 s | 2.5% | 0.02% |

The energy column collapses because a compact binary's energy sits in the last fraction of a
second before merger, so the damage depends steeply on the offset -- an event 1 ms past a
boundary loses essentially all of its signal.

## Verification

The predicted lead is checked against the buffer generation actually produces, read from the
resulting `TimeSeries.start_time` rather than from another prediction: 3.599609375 s both,
difference exactly 0.0. If the query understated the lead, a segment chosen from it would
still crop.

The payoff is measured as strain energy, not as the absence of a log line. Summed squares
across two assembled segments equal the standalone waveform to rel 1e-9. On the unfixed rule
the same run reports `Discarding 2.600 s (2662 samples)` -- the predicted 2.6 s.

Mutation-tested: reverting to the `coa_time` rule fails 4 tests, removing the warn-once
dedupe fails 1, letting the query failure propagate fails 2.

## Two decisions worth stating

**A failing query does not fail the run.** The boundary test now needs a full parameter set
where before it needed only `coa_time`, so an incomplete catalogue column would crash in
placement. It falls back to the `coa_time` rule and warns once instead. The failure is not
hidden: the same parameters reach generation immediately afterwards, which raises whatever
the query raised, with the context of the event rather than of a boundary test.

**Attribution follows placement.** An event is now listed in the metadata against the frame
its waveform *starts* in, not the frame holding its coalescence, so `find_signal` reports
that earlier frame. Keeping the old key would mean deferring the injection record across a
frame, which leaves no provenance at all for data already written if a run stops between the
two. Both convention comments are updated and a test pins it.

`_report_content_before_segment` stays: a waveform beginning before the run itself has no
segment to go in, and the fallback above still crops. Its docstring and message no longer
claim this is what ordinarily happens.

## Stacking

Targets #310 out of necessity rather than tidiness. With that pin present ripplegw resolves
to `0.3.1.dev3`, below the `>=0.3.1` gwmock-signal 0.15.0 requires, so 0.15.0 -- and this
query -- cannot be installed at all. Merge #310 first; this then retargets to main.

983 passed, 23 skipped. e2e unchanged at 46 passed, 9 skipped: its fixture event sits 4 s
into a single-segment run, so no placement moves and the stored references still match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Waveform segments are now placed and consumed according to waveform start time, improving event ordering and resume behavior.
  * Added fallback handling and warnings when waveform lead-time information is unavailable.
  * Batched and per-event processing now apply consistent placement rules.

* **Metadata**
  * Updated the metadata schema to version 1.4.0 to reflect revised signal-injection attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->