### PR TITLE
docs(tests): state the cutoff behind the placement loss figures

### DIFF
--- a/tests/cli/test_inspiral_segment_placement.py
+++ b/tests/cli/test_inspiral_segment_placement.py
@@ -451,7 +451,7 @@ class TestNothingIsDiscarded:
 
         This offset is deliberately the *mild* case. **At this module's 30 Hz cutoff, on the
         ET-Triangle-Sardinia network it configures**, the unweighted strain-squared energy lost runs
-        0.34% at 1 s past the boundary, 11% at 0.25 s, 50% at 0.1 s and 99.8% at 1 ms, because a
+        0.34% at 1 s past the boundary, 11.5% at 0.25 s, 50.3% at 0.1 s and 99.8% at 1 ms, because a
         compact binary's energy is concentrated in the last fraction of a second before merger. Testing the mild case makes the assertion depend on placement rather
         than on that concentration: 0.34% is a loss no energy-fraction tolerance would forgive, and a
         test pinned at the catastrophic end would still pass if placement were only approximately
@@ -461,8 +461,9 @@ class TestNothingIsDiscarded:
         magnitude while leaving the dropped *span* untouched. The same binary and network at a 20 Hz
         cutoff -- the one a real ET configuration uses -- loses 32.9% at 0.5 s past the boundary
         against 0.92% here at 30 Hz, since LAL's conditioning rounds both to the same 4.000 s buffer
-        but only the lower cutoff puts real signal in the early samples. That rounding coincidence is
-        specific to these masses on this backend, so it is not a rule to carry elsewhere. See
+        but only the lower cutoff puts real signal in the early samples. That rounding coincidence
+        holds for this chirp-time bin on this backend and not generally -- a 10+10 binary gets 16 s at
+        20 Hz against 8 s at 30 Hz -- so it is not a rule to carry elsewhere. See
         ``WaveformBackend.pre_coalescence_duration`` in gwmock-signal for the figures across cutoffs,
         offsets, masses and backends.
 

--- a/tests/cli/test_inspiral_segment_placement.py
+++ b/tests/cli/test_inspiral_segment_placement.py
@@ -449,13 +449,20 @@ class TestNothingIsDiscarded:
         injection would crop those 2.6 s -- 65% of its samples -- because the first segment is
         already written by then.
 
-        This offset is deliberately the *mild* case. Measured for this binary at 1024 Hz, the
-        unweighted strain-squared energy lost runs 0.34% at 1 s past the boundary, 11% at 0.25 s,
-        50% at 0.1 s and 99.8% at 1 ms, because a compact binary's energy is concentrated in the
-        last fraction of a second before merger. Testing the mild case makes the assertion depend on
-        placement rather than on that concentration: 0.34% is a loss no energy-fraction tolerance
-        would forgive, and a test pinned at the catastrophic end would still pass if placement were
-        only approximately right.
+        This offset is deliberately the *mild* case. **At this module's 30 Hz cutoff, on the
+        ET-Triangle-Sardinia network it configures**, the unweighted strain-squared energy lost runs
+        0.34% at 1 s past the boundary, 11% at 0.25 s, 50% at 0.1 s and 99.8% at 1 ms, because a
+        compact binary's energy is concentrated in the last fraction of a second before merger. Testing the mild case makes the assertion depend on placement rather
+        than on that concentration: 0.34% is a loss no energy-fraction tolerance would forgive, and a
+        test pinned at the catastrophic end would still pass if placement were only approximately
+        right.
+
+        The cutoff has to be stated, because it moves these numbers by more than an order of
+        magnitude while leaving the dropped *span* untouched. The same binary at a 20 Hz cutoff -- the
+        one a real ET configuration uses -- loses 32.3% at 0.5 s past the boundary against 0.91% here
+        at 30 Hz, since the conditioning rounds both to the same 4.000 s buffer but only the lower
+        cutoff puts real signal in the early samples. See
+        ``WaveformBackend.pre_coalescence_duration`` in gwmock-signal for both curves.
 
         Summed squares across the two assembled segments are compared against the same waveform
         generated on its own, which is the quantity that must survive placement.

--- a/tests/cli/test_inspiral_segment_placement.py
+++ b/tests/cli/test_inspiral_segment_placement.py
@@ -458,11 +458,13 @@ class TestNothingIsDiscarded:
         right.
 
         The cutoff has to be stated, because it moves these numbers by more than an order of
-        magnitude while leaving the dropped *span* untouched. The same binary at a 20 Hz cutoff -- the
-        one a real ET configuration uses -- loses 32.3% at 0.5 s past the boundary against 0.91% here
-        at 30 Hz, since the conditioning rounds both to the same 4.000 s buffer but only the lower
-        cutoff puts real signal in the early samples. See
-        ``WaveformBackend.pre_coalescence_duration`` in gwmock-signal for both curves.
+        magnitude while leaving the dropped *span* untouched. The same binary and network at a 20 Hz
+        cutoff -- the one a real ET configuration uses -- loses 32.9% at 0.5 s past the boundary
+        against 0.92% here at 30 Hz, since LAL's conditioning rounds both to the same 4.000 s buffer
+        but only the lower cutoff puts real signal in the early samples. That rounding coincidence is
+        specific to these masses on this backend, so it is not a rule to carry elsewhere. See
+        ``WaveformBackend.pre_coalescence_duration`` in gwmock-signal for the figures across cutoffs,
+        offsets, masses and backends.
 
         Summed squares across the two assembled segments are compared against the same waveform
         generated on its own, which is the quantity that must survive placement.


### PR DESCRIPTION
## 📝 Summary

The energy-loss curve in the placement test's docstring — 0.34% at 1 s past a boundary rising
to 99.8% at 1 ms — was measured at this module's 30 Hz cutoff and did not say so. Same omission
as the one fixed in Leuven-Gravity-Institute/gwmock-signal#369, made one commit later in this
repository's own work.

It matters because 30 Hz is the mild end. The same binary and network at a 20 Hz cutoff, which
is what a real ET configuration uses, loses 32.9% at 0.5 s past the boundary against 0.92% at
30 Hz. LAL's conditioning rounds both cutoffs to the same 4.000 s buffer, so the dropped *span*
is identical at 3.100 s and only its content differs. Quoted without its cutoff the curve
understates the defect the test exists for by a factor of 35.

Two corrections from review:

- The cross-reference quoted 32.3% and 0.91%, which are **single-detector** values, inside a
  module that configures the ET-Triangle-Sardinia network. Now 32.9% and 0.92%, measured on the
  network the module actually uses.
- The rounding coincidence is a property of the **chirp-time bin**, not of "these masses": it
  holds for a range of heavier pairs and breaks for lighter ones, so the 10+10 counterexample
  (16 s at 20 Hz against 8 s at 30 Hz) is now given inline.

Also stopped rounding 11.47% to 11% and 50.30% to 50%, which cost precision for nothing and
made the figures harder to reconcile with the same numbers elsewhere.

The full tables live in gwmock-signal's user guide at
`user_guide/segment-placement-losses.md`; this docstring points there rather than duplicating
them.

## ✨ Type of Change

- [x] 📝 Documentation update

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** `uv run --extra jax pytest tests/cli/test_inspiral_segment_placement.py` — 24 passed
- [x] **Every figure re-measured** rather than copied: 0.338% at 1 s, 11.469% at 0.25 s, 50.302%
      at 0.1 s, 99.778% at 1 ms on ET at 30 Hz; 32.93% and 0.9191% at 0.5 s for the 20/30 Hz
      comparison.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works — not
      applicable: a test docstring only, no behaviour change.

## 📷 Screenshots (if applicable)

Not a UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded test documentation with details on 30 Hz and 20 Hz configurations.
  * Added explanations of energy loss across offsets, buffer rounding, and backend or mass variability.
  * Documented the ET-Triangle-Sardinia network used in the tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->