### PR TITLE
perf(population): transfer a population in one copy instead of per sample

### DIFF
--- a/src/gwmock/population/adapter.py
+++ b/src/gwmock/population/adapter.py
@@ -27,9 +27,10 @@ def _materialise_on_host(values: Sequence[Any]) -> tuple[Any, ...]:
     a tuple of floats, measured over eight parameters. So the bulk form is used for the transfer and
     discarded, which also keeps the stored type exactly what it was before.
 
-    Anything numpy cannot represent as a numeric array -- object columns, ragged input -- falls back
-    to the plain tuple. The per-element cost is real there, but such values were never
-    device-resident to begin with.
+    Ragged input, which ``np.asarray`` refuses, falls back to the plain tuple. Object columns do
+    *not* need a fallback: ``tolist`` on an object array hands the objects back unchanged, checked for
+    ``None``, dicts, ``Decimal``, ``datetime`` and nested lists, so a branch for them would be code
+    that cannot change an outcome.
 
     Args:
         values: One parameter's values, as the backend produced them.
@@ -40,8 +41,6 @@ def _materialise_on_host(values: Sequence[Any]) -> tuple[Any, ...]:
     try:
         materialised = np.asarray(values)
     except (TypeError, ValueError):
-        return tuple(values)
-    if materialised.dtype == object:
         return tuple(values)
     if materialised.ndim != 1:
         # Returned as the array, deliberately, so the shape check in `_validate_parameter_values`

--- a/src/gwmock/population/adapter.py
+++ b/src/gwmock/population/adapter.py
@@ -6,7 +6,40 @@ from collections.abc import Iterator, Mapping, Sequence
 from types import MappingProxyType
 from typing import Any
 
+import numpy as np
 from gwmock_pop import GWPopSimulator
+
+
+def _materialise_on_host(values: Sequence[Any]) -> tuple[Any, ...]:
+    """Return *values* as a tuple of plain Python scalars, transferred in one go.
+
+    ``gwmock-pop`` hands back **JAX device arrays**, and iterating one -- which a bare
+    ``tuple(values)`` does -- pulls each element back individually, dispatching a device operation
+    per sample. Measured on a 500-event catalogue: 2.18 s against 0.052 ms for a single bulk
+    transfer, a factor of 42,000. That was the entire cost of constructing this adapter.
+
+    ``tolist`` rather than keeping the array, because the values are read one at a time afterwards
+    and indexing an array builds a ``numpy`` scalar each time: 15.4 us per event against 1.4 us for
+    a tuple of floats, measured over eight parameters. So the bulk form is used for the transfer and
+    discarded, which also keeps the stored type exactly what it was before.
+
+    Anything numpy cannot represent as a numeric array -- object columns, ragged input -- falls back
+    to the plain tuple. The per-element cost is real there, but such values were never
+    device-resident to begin with.
+
+    Args:
+        values: One parameter's values, as the backend produced them.
+
+    Returns:
+        The values as a tuple.
+    """
+    try:
+        materialised = np.asarray(values)
+    except (TypeError, ValueError):
+        return tuple(values)
+    if materialised.dtype == object or materialised.ndim != 1:
+        return tuple(values)
+    return tuple(materialised.tolist())
 
 
 class PopulationAdapter:
@@ -27,7 +60,7 @@ class PopulationAdapter:
             source_type: Non-empty population routing key supplied by ``gwmock-pop``.
             parameter_names: Optional ordered parameter names. If omitted, the mapping order is used.
         """
-        self._population_mapping = {name: tuple(values) for name, values in population_mapping.items()}
+        self._population_mapping = {name: _materialise_on_host(values) for name, values in population_mapping.items()}
         self._source_type = self._validate_source_type(source_type)
         self._parameter_names = tuple(parameter_names or self._population_mapping.keys())
         self._metadata = dict(metadata or {})

--- a/src/gwmock/population/adapter.py
+++ b/src/gwmock/population/adapter.py
@@ -15,8 +15,12 @@ def _materialise_on_host(values: Sequence[Any]) -> tuple[Any, ...]:
 
     ``gwmock-pop`` hands back **JAX device arrays**, and iterating one -- which a bare
     ``tuple(values)`` does -- pulls each element back individually, dispatching a device operation
-    per sample. Measured on a 500-event catalogue: 2.18 s against 0.052 ms for a single bulk
-    transfer, a factor of 42,000. That was the entire cost of constructing this adapter.
+    per sample.
+
+    Steady state, both paths warmed, 500 events across 8 parameters: 24.2 ms against 0.135 ms, a
+    factor of 180. The first call is far worse -- seconds, because JAX initialises lazily -- but that
+    figure swings by one to two orders of magnitude between runs, so it is not the one to quote. 180x
+    is the number that reproduces.
 
     ``tolist`` rather than keeping the array, because the values are read one at a time afterwards
     and indexing an array builds a ``numpy`` scalar each time: 15.4 us per event against 1.4 us for
@@ -37,8 +41,14 @@ def _materialise_on_host(values: Sequence[Any]) -> tuple[Any, ...]:
         materialised = np.asarray(values)
     except (TypeError, ValueError):
         return tuple(values)
-    if materialised.dtype == object or materialised.ndim != 1:
+    if materialised.dtype == object:
         return tuple(values)
+    if materialised.ndim != 1:
+        # Returned as the array, deliberately, so the shape check in `_validate_parameter_values`
+        # sees a `.shape` and refuses it. Converting to a tuple here would yield one entry per row
+        # and slip past that check, which is what the previous `tuple(values)` did: a 2-D column was
+        # silently reinterpreted as a shorter catalogue of array-valued events.
+        return materialised
     return tuple(materialised.tolist())
 
 

--- a/tests/population/test_adapter.py
+++ b/tests/population/test_adapter.py
@@ -421,3 +421,67 @@ class TestBulkHostTransfer:
                 {"coa_time": np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])},
                 source_type="bbh",
             )
+
+    def test_input_numpy_cannot_convert_falls_back_without_crashing(self):
+        """Ragged input makes ``np.asarray`` raise, and the fallback must catch it.
+
+        numpy 2.x raises ``ValueError`` for a ragged nested sequence rather than building an object
+        array. The values then go through the plain tuple, which is the pre-change behaviour: a
+        two-event catalogue whose parameter values are lists. That is not obviously desirable, but it
+        is what this adapter has always done, and the bulk transfer is not the place to change it.
+        """
+        adapter = PopulationAdapter.from_mapping(
+            {"coa_time": [[1.0, 2.0], [3.0]]},
+            source_type="bbh",
+        )
+
+        assert len(adapter) == 2
+        assert adapter.get_event_parameters(0) == {"coa_time": [1.0, 2.0]}
+
+    def test_an_object_column_survives_the_bulk_path(self):
+        """No fallback for object columns, because none is needed, and that is worth pinning.
+
+        ``tolist`` on an object array returns the objects unchanged -- verified for ``None``, dicts,
+        ``Decimal``, ``datetime`` and nested lists -- so an earlier revision's ``dtype == object``
+        branch could not change an outcome. It was removed rather than kept with a test that passed
+        whether or not it existed. This asserts the values still come back intact without it.
+        """
+        adapter = PopulationAdapter.from_mapping({"value": [None, 1.0]}, source_type="bbh")
+
+        assert adapter.get_event_parameters(0) == {"value": None}
+        assert adapter.get_event_parameters(1) == {"value": 1.0}
+
+    def test_a_scalar_column_is_refused_for_its_shape(self):
+        """A 0-d array reaches the shape check, not the length check.
+
+        Worth pinning because it is the reason the validator's ``TypeError`` branch is now
+        unreachable through the public API: everything ``_materialise_on_host`` returns is a tuple or
+        an array, so the shape check fires first for anything not one-dimensional.
+        """
+        with pytest.raises(ValueError, match="one-dimensional"):
+            PopulationAdapter.from_mapping({"coa_time": 5.0}, source_type="bbh")
+
+    def test_the_validator_still_refuses_values_with_no_length(self):
+        """The validator's own contract, exercised directly because nothing public reaches it.
+
+        Tested at the private boundary on purpose. It is defensive code guarding a caller that does
+        not currently exist -- ``_materialise_on_host`` always yields something sized -- and a test
+        through the public API would be impossible rather than merely awkward. Pinned so the message
+        survives if a future conversion path does reach it.
+        """
+        with pytest.raises(TypeError, match="indexable sequences"):
+            PopulationAdapter._validate_parameter_values(
+                parameter_name="coa_time",
+                values=object(),
+                expected_length=None,
+            )
+
+    def test_from_backend_refuses_something_that_is_not_a_backend(self):
+        """The protocol check, which nothing exercised before.
+
+        Not part of the bulk-transfer work, but it is the last uncovered branch in this module and the
+        message is worth pinning: a caller passing the wrong object should be told the protocol is the
+        problem, not meet an ``AttributeError`` from inside ``simulate``.
+        """
+        with pytest.raises(TypeError, match="GWPopSimulator protocol"):
+            PopulationAdapter.from_backend(object(), n_samples=1)

--- a/tests/population/test_adapter.py
+++ b/tests/population/test_adapter.py
@@ -381,7 +381,16 @@ class TestBulkHostTransfer:
     def test_the_values_survive_the_bulk_conversion_unchanged(self):
         """Speed is worthless if the numbers move. Full float64 precision, not just close."""
         jax = pytest.importorskip("jax", reason="the [jax] extra is not installed")
-        jax.config.update("jax_enable_x64", True)
+
+        # Asserted, not set. An earlier version called `jax.config.update` here, which mutates JAX's
+        # global state and leaked x64 into every test that ran afterwards -- and it was redundant:
+        # importing this adapter imports `gwmock_pop`, whose `_precision` module enables x64 because
+        # float32 spacing at GPS scale is 128 s. So the invariant is checked rather than imposed,
+        # which also makes this a guard on `gwmock_pop` continuing to do it.
+        assert jax.config.jax_enable_x64, (
+            "float64 is unavailable, so this test cannot say anything about precision; gwmock_pop is "
+            "supposed to enable x64 on import"
+        )
 
         exact = [1577491296.123456789, -0.30000000000000004, 1e-21, 2.5e30]
         adapter = PopulationAdapter.from_mapping(

--- a/tests/population/test_adapter.py
+++ b/tests/population/test_adapter.py
@@ -298,3 +298,56 @@ class TestPopulationAdapter:
     def test_from_mapping_rejects_invalid_source_type(self):
         with pytest.raises(ValueError, match="non-empty string"):
             PopulationAdapter.from_mapping({"coa_time": np.array([1.0])}, source_type="")
+
+
+class TestBulkHostTransfer:
+    """``gwmock-pop`` returns JAX device arrays, and how they are read dominates this adapter."""
+
+    def test_device_arrays_are_transferred_in_bulk_not_element_by_element(self):
+        """Pinned by the *type* of the stored values, because timing tests are flaky.
+
+        A bare ``tuple(device_array)`` iterates the array, pulling each element back with its own
+        device operation, and leaves JAX scalars behind. Converting in bulk first leaves plain Python
+        floats. So the element type is a faithful witness for which path ran, and it fails
+        immediately if the bulk conversion is removed.
+
+        The cost this guards is not marginal: 0.994 ms per event against 0.0021 ms over a
+        1000-event, eight-parameter catalogue, a factor of 469, and it was the entire construction
+        cost of the adapter.
+        """
+        jax = pytest.importorskip("jax", reason="the [jax] extra is not installed")
+
+        adapter = PopulationAdapter.from_mapping(
+            {"coa_time": jax.numpy.asarray([1.0, 2.0, 3.0])},
+            source_type="bbh",
+        )
+
+        stored = adapter.population_mapping["coa_time"]
+        assert [type(value) for value in stored] == [float, float, float], (
+            f"stored {[type(v).__name__ for v in stored]}; JAX scalars here mean the device array was "
+            f"iterated element by element rather than transferred once"
+        )
+        assert stored == (1.0, 2.0, 3.0)
+
+    def test_the_values_survive_the_bulk_conversion_unchanged(self):
+        """Speed is worthless if the numbers move. Full float64 precision, not just close."""
+        jax = pytest.importorskip("jax", reason="the [jax] extra is not installed")
+        jax.config.update("jax_enable_x64", True)
+
+        exact = [1577491296.123456789, -0.30000000000000004, 1e-21, 2.5e30]
+        adapter = PopulationAdapter.from_mapping(
+            {"value": jax.numpy.asarray(exact, dtype=jax.numpy.float64)},
+            source_type="bbh",
+        )
+
+        stored = adapter.population_mapping["value"]
+        assert stored == tuple(exact), f"bulk transfer changed the values: {stored} against {tuple(exact)}"
+
+    def test_a_non_numeric_column_still_works(self):
+        """Object columns cannot go through the numeric path, and must not crash it."""
+        adapter = PopulationAdapter.from_mapping(
+            {"label": ["a", "b"], "value": np.array([1.0, 2.0])},
+            source_type="bbh",
+        )
+
+        assert adapter.get_event_parameters(1) == {"label": "b", "value": 2.0}

--- a/tests/population/test_adapter.py
+++ b/tests/population/test_adapter.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 import textwrap
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import numpy as np
 import pytest
@@ -300,8 +300,57 @@ class TestPopulationAdapter:
             PopulationAdapter.from_mapping({"coa_time": np.array([1.0])}, source_type="")
 
 
+class _ConversionSpy:
+    """Stands in for a device array and records how it was read.
+
+    The point is to distinguish *one bulk conversion* from *many element reads*, which is the whole
+    claim. Inferring that from the stored value type does not work: a per-element loop that calls
+    ``float()`` on each sample also leaves Python floats behind, so it passes a type check while
+    costing what the bulk transfer exists to avoid.
+    """
+
+    def __init__(self, values: np.ndarray) -> None:
+        self._values = values
+        self.bulk_conversions = 0
+        self.element_reads = 0
+
+    def __array__(self, dtype: Any = None, copy: Any = None) -> np.ndarray:
+        self.bulk_conversions += 1
+        return np.asarray(self._values, dtype=dtype)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __getitem__(self, index: Any) -> Any:
+        self.element_reads += 1
+        return self._values[index]
+
+    def __iter__(self):
+        for index in range(len(self._values)):
+            self.element_reads += 1
+            yield self._values[index]
+
+
 class TestBulkHostTransfer:
     """``gwmock-pop`` returns JAX device arrays, and how they are read dominates this adapter."""
+
+    def test_the_values_are_read_in_one_bulk_conversion(self):
+        """The faithful witness: count the conversions, do not infer them from the stored type.
+
+        A reviewer defeated the type-based check by writing a per-element implementation that calls
+        ``float()`` on each sample -- Python floats in the store, every test passing, and 1.4 s per
+        500 elements against 0.4 ms. Counting is what actually pins the behaviour.
+        """
+        spy = _ConversionSpy(np.arange(5.0))
+
+        adapter = PopulationAdapter.from_mapping({"coa_time": spy}, source_type="bbh")
+
+        assert spy.bulk_conversions == 1, f"converted {spy.bulk_conversions} times, expected exactly one"
+        assert spy.element_reads == 0, (
+            f"read {spy.element_reads} elements individually; on a device array each of those is its "
+            f"own transfer, which is the cost this exists to avoid"
+        )
+        assert adapter.population_mapping["coa_time"] == (0.0, 1.0, 2.0, 3.0, 4.0)
 
     def test_device_arrays_are_transferred_in_bulk_not_element_by_element(self):
         """Pinned by the *type* of the stored values, because timing tests are flaky.
@@ -344,10 +393,31 @@ class TestBulkHostTransfer:
         assert stored == tuple(exact), f"bulk transfer changed the values: {stored} against {tuple(exact)}"
 
     def test_a_non_numeric_column_still_works(self):
-        """Object columns cannot go through the numeric path, and must not crash it."""
+        """Object columns cannot go through the numeric path, and must not crash it.
+
+        This one checks behaviour, not the bulk path: it passes whichever conversion runs. Stated so
+        the module is not read as three guards on the transfer when only the type witness above is
+        one.
+        """
         adapter = PopulationAdapter.from_mapping(
             {"label": ["a", "b"], "value": np.array([1.0, 2.0])},
             source_type="bbh",
         )
 
         assert adapter.get_event_parameters(1) == {"label": "b", "value": 2.0}
+
+    def test_a_two_dimensional_column_is_refused_rather_than_reinterpreted(self):
+        """A 2-D column used to become one entry per row, silently shortening the catalogue.
+
+        ``tuple(values)`` on a 2-D array yields row arrays, and the shape check in
+        ``_validate_parameter_values`` looks for a ``.shape`` attribute -- which a tuple does not
+        have. So a (3, 2) column became a 3-event catalogue of array-valued parameters and no
+        validation noticed. Pre-existing rather than introduced by the bulk transfer, but the bulk
+        transfer is where the fix belongs: the array is passed through so the validator can see its
+        shape.
+        """
+        with pytest.raises(ValueError, match="one-dimensional"):
+            PopulationAdapter.from_mapping(
+                {"coa_time": np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])},
+                source_type="bbh",
+            )


### PR DESCRIPTION
## 📝 Summary

`gwmock-pop` returns **JAX device arrays**. `PopulationAdapter.__init__` stored them with
`tuple(values)`, and iterating a device array pulls each element back individually — one device
dispatch per sample. Now `tuple(np.asarray(values).tolist())`: one bulk transfer, then plain Python
floats.

It made *iteration* slow too, less obviously: the resulting tuple held JAX scalars, so
`_coerce_event_value`'s `.item()` was another device call per parameter per event.

**Steady state, both paths warmed, 500 events × 8 parameters: 24.2 ms against 0.135 ms — a factor of
180.** An independent re-measurement got ~220×, and 37× per event.

An earlier revision of this PR quoted 42,000× and 469×. Those mixed a *cold* `tuple(jax)` against a
*warm* `tolist`. Per-element `.item()` swings 13–397 µs with JAX warm state, so the "before" side is
unstable by one to two orders of magnitude and does not belong in a headline. 180× is the figure that
reproduces.

`tolist` rather than keeping the array, because indexing an array builds a numpy scalar each time —
15.4 µs per event against 1.4 µs for a tuple of floats. The bulk form is used for the transfer and
discarded.

The container stays a tuple, but the **elements change** from JAX or numpy scalars to Python ones.
Event dictionaries are unaffected, since `_coerce_event_value` already called `.item()`, but
`population_mapping` exposes different element types. That is intended, and the tests assert it.

## A pre-existing bug, fixed here

`tuple(values)` on a 2-D array yields row arrays, and the one-dimensional check in
`_validate_parameter_values` looks for a `.shape` that a tuple does not have. So a (3, 2) column
silently became a 3-event catalogue of array-valued parameters and nothing refused it. The array is
now passed through so the validator sees its shape. Both reviewers found this independently;
mutation-testing the old behaviour gives `DID NOT RAISE ValueError`.

## Coverage

Codecov flagged 66.66% patch coverage. Now **100% statement and branch** for this module (89
statements, 22 branches).

Reaching that removed code rather than adding it. The `dtype == object` fallback I had written **did
nothing**: its test passed with the branch deleted, so the test could not fail, and `tolist` on an
object array returns the objects unchanged — checked for `None`, dicts, `Decimal`, `datetime` and
nested lists. Deleted, so the diff is now smaller than before.

The validator's `TypeError` branch turns out to be unreachable through the public API: everything
`_materialise_on_host` returns is a tuple or an array, so anything not one-dimensional meets the shape
check first. It is tested at the private boundary with that stated, rather than presented as a
reachable path.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue) — the 2-D column silently reinterpreted
- [x] 🎨 Refactoring (no functional changes, no API changes) — the performance change itself

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** `uv run --extra jax pytest tests/population/` — 25 passed, and 6 consecutive
      clean runs after a reviewer saw one transient failure while the tree was mid-edit
- [x] **Full suite:** 1008 passed, 23 skipped
- [x] **Values, across both reviewers:** old and new produce bit-identical results for float16/32/64,
      bfloat16, complex, int, uint, bool, weak types, NaN, inf, signed zero, subnormals and extremes.
      Production is float64 (`gwmock_pop` enables x64 on import), so `coa_time` round-trips exactly at
      GPS scale; under `JAX_ENABLE_X64=0` it would be float32 and lossy, which is pre-existing.
- [x] **The guard counts conversions rather than inferring them.** The first version asserted the
      stored elements are Python floats; a reviewer defeated it with a per-element implementation that
      also leaves Python floats, passes every test, and costs 1.4 s per 500 elements. A spy now counts
      bulk conversions and element reads, and fails that counterexample with
      `read 5 elements individually`.
- [x] **Which tests guard what is stated in the file.** The value-preservation and object-column tests
      check behaviour and pass under a revert; the conversion spy, the ragged fallback and the 2-D
      refusal are the discriminating ones.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation — not applicable; internal storage change
      with no API or configuration surface.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective.

## 📷 Screenshots (if applicable)

Not a UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved population data handling for bulk conversion between backend and host environments.
  * Preserved numeric values and scalar types, including ragged or object-based inputs.
  * Added validation for invalid data dimensions and unsupported inputs.
  * Maintained existing validation behavior while avoiding unnecessary element-level reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->