### PR TITLE
docs(readme): show plain pip install as an alternative to uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ generation.
 ## Installation
 
 We recommend using `uv` to manage virtual environments for installing gwmock.
+The commands below use `uv`, but gwmock is a regular PyPI package that also
+installs fine with plain `pip` in any environment.
 
 If you don't have `uv` installed, you can install it with pip. See the project
 pages for more details:
@@ -39,6 +41,25 @@ pages for more details:
 - Project pages: [uv on PyPI](https://pypi.org/project/uv/) |
   [uv on GitHub](https://github.com/astral-sh/uv)
 - Full documentation and usage guide: [uv docs](https://docs.astral.sh/uv/)
+
+### Without uv (venv or Conda)
+
+If you prefer not to use uv, install with plain `pip` in a standard virtual
+environment:
+
+```bash
+# venv
+python -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+pip install gwmock
+```
+
+```bash
+# Conda
+conda create -n gwmock python=3.13
+conda activate gwmock
+pip install gwmock
+```
 
 **Note:** The package requires Python 3.12 or later and is built and tested
 against Python 3.12–3.14. When creating a virtual environment with `uv`, specify


### PR DESCRIPTION
## 📝 Summary

Clarifies the README installation section so readers who have never used `uv`
don't assume `pip install` won't work. Adds a short note that gwmock is a
regular PyPI package installable with plain `pip`, plus a "Without uv (venv or
Conda)" subsection with venv and Conda examples.

## ✨ Type of Change

- [x] 📝 Documentation update

## 🧪 How Has This Been Tested?

- [x] **Manual Test:** Reviewed rendered markdown; pre-commit (markdownlint)
      passed locally.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
