### PR TITLE
fix(provenance): record a signal against every frame it reaches

### DIFF
--- a/docs/user-guide/reproducibility.md
+++ b/docs/user-guide/reproducibility.md
@@ -5,12 +5,12 @@
 
 ## Schema
 
-Each record is validated at write time and uses schema version `1.3.0`.
+Each record is validated at write time and uses schema version `1.5.0`.
 Consumers must reject unknown major versions.
 
 ```json
 {
-    "schema_version": "1.3.0",
+    "schema_version": "1.5.0",
     "gwmock_version": "x.y.z",
     "subpackage_versions": {
         "gwmock_signal": "x.y.z",

--- a/docs/user-guide/reproducibility.md
+++ b/docs/user-guide/reproducibility.md
@@ -95,9 +95,13 @@ gwmock rewriting their internal structure.
 `signal.injections` records the source parameters of the signals attributed to
 that batch's frame(s), in injection order. Each entry is
 `{"event_id": <index in the population>, "parameters": {...}}`. A signal is
-attributed to the frame in which it **merges** (its `coa_time` falls inside that
-frame's time segment); a long waveform whose inspiral or ringdown extends into
-adjacent frames is listed only under its merger frame. `event_id` is the event's
+listed against **every frame its samples reach**, so a long inspiral crossing a
+segment boundary appears in each frame it spans, and a continuous wave appears
+in all of them. This changed in schema 1.5.0: a signal used to be listed only
+under the frame it was generated for, which for a 48 s inspiral across 32 s
+segments meant one frame out of three -- and not the one holding the merger. The
+frame a signal is _generated_ for is the one its waveform **starts** in (schema
+1.4.0; before that, the one its `coa_time` fell in). `event_id` is the event's
 index in the population as ordered for the run (by `coa_time` under the default
 ordering), so it is stable for a fixed configuration. Stationary/SGWB segments
 have no discrete events and record an empty list.
@@ -154,8 +158,12 @@ Requirements and limits:
 ## Finding which frame contains a signal
 
 Alongside the per-file `index.yaml`, a run writes `signal_index.yaml` mapping
-each signal's `event_id` to the frame file(s) that contain it. Use
-`gwmock find-signal` to resolve a signal to its frame:
+each signal's `event_id` to the frame file(s) that contain it. The entry records
+one contribution per batch, because a signal reaching several segments is
+written by several batches; `find-signal` flattens them, and reports `metadata`
+as a **list** of batch metadata files on both lookup paths. An index written
+before schema 1.5.0 is still read. Use `gwmock find-signal` to resolve a signal
+to its frame:
 
 ```bash
 # By id (fast path via signal_index.yaml)

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -444,7 +444,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                     "detectors": self.detectors,
                     "network_resolution": self._detector_resolution,
                     "segment_seed": signal_segment_seed,
-                    "injections": list(self._batch_injections),
+                    "injections": self._segment_injections(),
                 },
                 "noise": {
                     "arguments": self.noise_arguments,
@@ -559,7 +559,9 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                 waveform_options=self.waveform_options,
                 earth_rotation=self.earth_rotation,
             )
-            strain.metadata.update({"injection_parameters": dict(parameters)})
+            # `event_id` alongside the parameters, and both survive onto a tail, so a chunk that
+            # crosses a segment boundary can still be attributed to its event in the next segment.
+            strain.metadata.update({"injection_parameters": dict(parameters), "event_id": event_id})
             self._batch_injections.append({"event_id": event_id, "parameters": dict(parameters)})
             chunks.append(strain)
             self.population_index = cast(int, self.population_index) + 1
@@ -779,6 +781,27 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         if event_ids:
             self.population_index = cast(int, self.population_index) + len(event_ids)
 
+    def _segment_injections(self) -> list[dict[str, Any]]:
+        """Return one record per signal present in the segment just built.
+
+        Not the same list as ``_batch_injections``, and the difference is the whole point of
+        `gwmock/per-event-provenance-on-segments`: that list holds what this batch *generated*, while
+        a segment also contains the continuing part of any signal generated earlier. A 1.6+1.4
+        binary from 30 Hz runs about 48 s, so across 32 s segments it appears in three frames and
+        only one of them generated it -- and the frame holding the merger, the loudest part, was not
+        that one.
+
+        Ordered generated-first so the common case reads as it did before, then the carried ones.
+        Deduplicated on ``event_id``, because a multi-detector batch emits one chunk per detector
+        carrying the same record.
+
+        Returns:
+            Injection records for this segment, generated and carried alike.
+        """
+        from gwmock.mixin.time_series import _merge_injection_records  # noqa: PLC0415
+
+        return _merge_injection_records(self._batch_injections, getattr(self, "carried_injections", []))
+
     def _batched_waveform_backend(self) -> Any:
         """Return the ripple backend the batched path should generate with.
 
@@ -901,7 +924,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             for event_id, event in zip(event_ids, events, strict=True)
         ]
         for chunk, record in zip(chunks, self._batch_injections, strict=True):
-            chunk.metadata.update({"injection_parameters": dict(record["parameters"])})
+            chunk.metadata.update({"injection_parameters": dict(record["parameters"]), "event_id": record["event_id"]})
         return chunks
 
     def _simulate_continuous_wave_segment(self) -> TimeSeriesList:

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -979,14 +979,10 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             # Recorded for every segment, not once: a continuous wave is present in all of them, so
             # attributing it to one frame the way a transient is attributed would be wrong.
             #
-            # Known limitation, tracked as `gwmock/per-event-provenance-on-segments`. The per-batch
-            # metadata written from this list is correct and is the documented source of truth, so
-            # parameter-based lookup finds every frame. But `update_signal_index` assigns
-            # `index[event_id] = ...` rather than merging, so the id fast path keeps only the last
-            # frame written for each pulsar -- `gwmock find-signal --id N` returns one frame where
-            # a continuous wave is in all of them. Fixing it means letting an index entry hold
-            # several frames and metadata files, which is a schema change and belongs with that
-            # item rather than here. A continuous wave makes it universal rather than occasional.
+            # This used to be undone downstream: `update_signal_index` assigned rather than
+            # merged, so the id fast path kept only the last frame written for each pulsar and
+            # `gwmock find-signal --id N` named one frame where a continuous wave is in all of
+            # them. The index now accumulates per batch, so appending here is what it looks like.
             self._batch_injections.append({"event_id": source_id, "parameters": dict(source)})
 
         if strain is None:  # pragma: no cover - guarded by the empty-catalogue check above

--- a/src/gwmock/cli/find_signal.py
+++ b/src/gwmock/cli/find_signal.py
@@ -30,6 +30,9 @@ def find_signal_command(
     Look up by ``--id`` (fast, via ``signal_index.yaml``) and/or by one or more
     ``--param`` predicates matched against the source parameters recorded in the
     batch metadata (e.g. ``--param mass_1>=30 --param network_snr>8``).
+
+    Reports every frame the signal reaches, which for a waveform crossing a segment
+    boundary -- or for a continuous wave, which is in all of them -- is more than one.
     """
     from gwmock.cli.utils.signal_lookup import find_signals, parse_param_filter
 

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -601,7 +601,15 @@ def update_signal_index(
 
     The index (``signal_index.yaml``) maps a signal's ``event_id`` to the signal
     frame file(s) that contain it plus the batch metadata file, enabling O(1)
-    signal->frame lookup by id. Parameter-based lookup reads the injections
+    signal->frame lookup by id.
+
+    **Not safe against concurrent writers.** This is an unlocked read-modify-write, so two
+    processes updating the index at once can lose one side's contribution -- reproduced
+    deterministically with a barrier. It predates the per-batch accumulation below and is not
+    made worse by it, but the accumulation does change what is lost: a dropped update used to
+    cost one assignment, and now costs one batch's frames for every event in it. gwmock writes
+    batches sequentially within a run, so this bites only when two runs share a metadata
+    directory. Tracked as ``gwmock/signal-index-concurrent-writers``. Parameter-based lookup reads the injections
     recorded in the batch metadata files (their source of truth); this index is
     only the id shortcut. A batch with no injected signals writes nothing.
 

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -569,6 +569,28 @@ def update_metadata_index(
         raise
 
 
+def _withdraw_batch(index: dict[str, Any], metadata_file_name: str) -> dict[str, Any]:
+    """Return *index* with every contribution from *metadata_file_name* removed.
+
+    Entries left with no contributions are dropped, so a re-run that injects nothing no longer
+    leaves an id pointing at frames it did not write.
+
+    Pre-1.5.0 entries carried a single ``metadata`` string and a flat ``frames`` list. They are
+    migrated in passing rather than rejected: an index is a rebuildable cache, and refusing to read
+    one written by an older gwmock would make an upgrade look like data loss.
+    """
+    migrated: dict[str, Any] = {}
+    for event_id, entry in index.items():
+        batches = entry.get("batches")
+        if batches is None:
+            batches = [{"metadata": entry.get("metadata"), "frames": entry.get("frames") or []}]
+        kept = [batch for batch in batches if batch.get("metadata") != metadata_file_name]
+        if not kept:
+            continue
+        migrated[event_id] = {"batches": kept, "coa_time": entry.get("coa_time")}
+    return migrated
+
+
 def update_signal_index(
     metadata_directory: Path,
     metadata: dict[str, Any],
@@ -604,10 +626,11 @@ def update_signal_index(
     else:
         index = {}
 
-    # Drop any entries this batch wrote previously so a re-run or overwrite (which
-    # may now inject different or no events) cannot leave stale id -> frame rows
-    # that the id fast-path would trust.
-    index = {event_id: entry for event_id, entry in index.items() if entry.get("metadata") != metadata_file_name}
+    # Withdraw this batch's previous contribution, per event, so a re-run or overwrite (which may
+    # now inject different or no events) cannot leave stale id -> frame rows the fast path would
+    # trust. This used to drop whole entries whose `metadata` matched, which was equivalent only
+    # while an entry belonged to exactly one batch -- and that is the assumption being removed here.
+    index = _withdraw_batch(index, metadata_file_name)
 
     signal_frames = [
         output["path"] for output in metadata.get("outputs", []) if output.get("kind") == "signal" and "path" in output
@@ -616,11 +639,16 @@ def update_signal_index(
         event_id = injection.get("event_id")
         if event_id is None:
             continue
-        index[str(event_id)] = {
-            "frames": signal_frames,
-            "metadata": metadata_file_name,
-            "coa_time": (injection.get("parameters") or {}).get("coa_time"),
-        }
+        # Appended, not assigned. A signal reaches every frame its samples land in, and each of those
+        # frames belongs to a different batch writing this index in turn, so the previous
+        # `index[event_id] = ...` kept whichever batch happened to write last. For a continuous wave
+        # that is one frame out of every frame in the run; for a 48 s inspiral across 32 s segments it
+        # was one of three, and not the one holding the merger.
+        entry = index.setdefault(
+            str(event_id),
+            {"batches": [], "coa_time": (injection.get("parameters") or {}).get("coa_time")},
+        )
+        entry["batches"].append({"metadata": metadata_file_name, "frames": signal_frames})
 
     try:
         with index_file.open("w") as f:

--- a/src/gwmock/cli/utils/metadata.py
+++ b/src/gwmock/cli/utils/metadata.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 #: so a consumer reading the old version parses the new one without noticing -- which is exactly why
 #: the version has to move. A reader comparing records across a run boundary needs to be able to tell
 #: which convention produced each one.
-SCHEMA_VERSION = "1.4.0"
+SCHEMA_VERSION = "1.5.0"
 _SCHEMA_VERSION_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
 

--- a/src/gwmock/cli/utils/metadata.py
+++ b/src/gwmock/cli/utils/metadata.py
@@ -11,11 +11,18 @@ import numpy as np
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-#: 1.4.0 because ``signal.injections`` changed meaning: an event is now attributed to the frame its
-#: waveform *starts* in rather than the frame holding its coalescence. No field was added or removed,
-#: so a consumer reading the old version parses the new one without noticing -- which is exactly why
-#: the version has to move. A reader comparing records across a run boundary needs to be able to tell
-#: which convention produced each one.
+#: Two changes to the meaning of ``signal.injections`` ride on this constant, and neither altered the
+#: shape of a record -- so a consumer reading an old version parses a new one without noticing, which
+#: is exactly why the version has to move.
+#:
+#: 1.4.0: an event is attributed to the frame its waveform *starts* in rather than the frame holding
+#: its coalescence.
+#:
+#: 1.5.0: ``injections`` lists every event **present** in the frame, including one generated for an
+#: earlier segment, so a signal crossing a boundary now appears in each frame it reaches. The list
+#: was already a list, so its *cardinality* changed without its type: a consumer that sums
+#: ``injections`` across a run to count events will now overcount, and only ``schema_version`` says
+#: so. ``signal_index.yaml`` changed shape in the same release.
 SCHEMA_VERSION = "1.5.0"
 _SCHEMA_VERSION_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
@@ -46,12 +53,18 @@ class SignalSection(BaseModel):
     backend: str
     waveform_model: str | None = None
     detector_network: list[str] = Field(default_factory=list)
-    # Source parameters of the signals injected into this batch's frame(s), in
-    # injection order: [{"event_id": int, "parameters": {...}}]. An event is
-    # attributed to the frame its waveform *starts* in -- for a compact binary that
+    # Source parameters of every signal **present in** this batch's frame(s), in
+    # injection order: [{"event_id": int, "parameters": {...}}]. That includes a signal
+    # generated for an earlier segment whose content extends into this one, so one event
+    # appears in the record of every frame it reaches. An event is *generated* for the
+    # frame its waveform *starts* in -- for a compact binary that
     # is at or before the frame containing its coalescence, because the buffer begins
-    # seconds earlier. Content extending forward into later frames is not
-    # cross-listed. Empty for stationary/SGWB segments.
+    # seconds earlier. Empty for stationary/SGWB segments.
+    #
+    # One gap, and it is a pre-existing data bug rather than a provenance one: spillover
+    # chunks are not part of simulator state, so a run resumed from a checkpoint loses the
+    # tail itself -- both the samples and the record. See
+    # `gwmock/spillover-lost-on-checkpoint-resume`.
     injections: list[dict[str, Any]] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
 

--- a/src/gwmock/cli/utils/signal_lookup.py
+++ b/src/gwmock/cli/utils/signal_lookup.py
@@ -77,6 +77,38 @@ def _iter_metadata_files(metadata_directory: Path) -> Iterator[Path]:
     yield from sorted(metadata_directory.glob("*.metadata.json"))
 
 
+def _flatten_batches(entry: dict[str, Any]) -> tuple[list[str], list[str]]:
+    """Return ``(frames, metadata_files)`` for one index entry, in the order written.
+
+    The index stores contributions per batch rather than a flattened list of frames, because a
+    re-run has to be able to withdraw one batch's contribution and a flattened copy alongside it
+    would be a second place for the same fact to live. Flattening happens here, once, on read.
+
+    Frames are deduplicated: two batches can legitimately name the same frame when a segment is
+    written once and contributed to twice.
+
+    Pre-1.5.0 entries carried ``metadata`` as a string and ``frames`` flat; they are read as a single
+    batch rather than rejected, so an index written by an older gwmock still answers.
+    """
+    batches = entry.get("batches")
+    if batches is None:
+        metadata = entry.get("metadata")
+        return list(entry.get("frames") or []), ([] if metadata is None else [metadata])
+
+    frames: list[str] = []
+    seen: set[str] = set()
+    metadata_files: list[str] = []
+    for batch in batches:
+        for frame in batch.get("frames") or []:
+            if frame not in seen:
+                seen.add(frame)
+                frames.append(frame)
+        name = batch.get("metadata")
+        if name is not None and name not in metadata_files:
+            metadata_files.append(name)
+    return frames, metadata_files
+
+
 def find_signals(
     metadata_directory: Path | str,
     *,
@@ -88,9 +120,10 @@ def find_signals(
     With only ``event_id`` set, the fast ``signal_index.yaml`` path is used. When
     parameter filters are supplied, the batch metadata files are scanned (their
     ``signal.injections`` are the source of truth). Each result is a mapping with
-    ``event_id``, ``frames`` (signal frame paths), ``metadata`` (batch metadata
-    file name), and ``coa_time``; parameter-filtered results also carry
-    ``parameters``.
+    ``event_id``, ``frames`` (signal frame paths), ``metadata`` (a *list* of batch
+    metadata file names, since a signal long enough to cross a segment boundary is
+    recorded by every batch whose frames it reaches), and ``coa_time``;
+    parameter-filtered results also carry ``parameters``.
     """
     metadata_directory = Path(metadata_directory)
     param_filters = param_filters or []
@@ -104,11 +137,14 @@ def find_signals(
             index = yaml.safe_load(f) or {}
         entry = index.get(str(event_id))
         if entry:
+            frames, metadata_files = _flatten_batches(entry)
             results.append(
                 {
                     "event_id": event_id,
-                    "frames": entry.get("frames", []),
-                    "metadata": entry.get("metadata"),
+                    "frames": frames,
+                    # A list now, because one signal spans the frames of several batches. Kept as a
+                    # list even when there is one, so a consumer never has to branch on the type.
+                    "metadata": metadata_files,
                     "coa_time": entry.get("coa_time"),
                 }
             )
@@ -138,7 +174,10 @@ def find_signals(
                 {
                     "event_id": injection.get("event_id"),
                     "frames": frames,
-                    "metadata": meta_path.name,
+                    # A one-element list, matching the id path's shape. This path yields one result
+                    # per batch, so each result genuinely has one metadata file -- but a consumer
+                    # reading both paths should not have to know which one it asked.
+                    "metadata": [meta_path.name],
                     "parameters": parameters,
                     "coa_time": parameters.get("coa_time"),
                 }

--- a/src/gwmock/data/time_series/time_series.py
+++ b/src/gwmock/data/time_series/time_series.py
@@ -392,6 +392,35 @@ class TimeSeries(JSONSerializable):
             self.start_time,
         )
 
+    def contributes_samples(self, other: TimeSeries) -> bool:
+        """Whether injecting *other* into this segment would place at least one sample.
+
+        Provenance needs this, and it cannot be recovered after the fact: injection sums chunks into
+        shared channels, so once a segment is built there is no way to ask which signal put samples
+        where. It has to be asked before.
+
+        Deliberately a *time* predicate rather than a look at the data. A chunk of genuine zeros --
+        a signal whose amplitude is below the sample quantum, or a segment covering only its tapered
+        edge -- still means the signal is present in that frame, which is what a provenance record
+        is claiming. Reading the samples would call that absent.
+
+        The two endpoints are exclusive because a chunk ending exactly at ``self.start_time`` has no
+        sample inside this segment: the segment's first sample is *at* that time and the chunk's last
+        sample is one interval before it. This is tested across the boundary rather than argued, in
+        ``test_provenance_across_segments.py``, because an off-by-one here silently over- or
+        under-reports one frame per signal.
+
+        Args:
+            other: The chunk that would be injected.
+
+        Returns:
+            ``True`` if the chunk overlaps this segment's sampled span.
+        """
+        unit = self.start_time.unit
+        chunk_start = float(other.start_time.to(unit).value)
+        chunk_end = float(other.end_time.to(unit).value)
+        return chunk_start < float(self.end_time.to(unit).value) and chunk_end > float(self.start_time.value)
+
     def inject_from_list(self, ts_iterable: Iterable[TimeSeries]) -> TimeSeriesList:
         """Inject multiple TimeSeries from an iterable into the current TimeSeries.
 

--- a/src/gwmock/mixin/time_series.py
+++ b/src/gwmock/mixin/time_series.py
@@ -84,6 +84,14 @@ class TimeSeriesMixin:  # pylint: disable=too-few-public-methods,too-many-instan
     #: signals generated for an *earlier* segment whose content extends into this one. Rebuilt per
     #: segment by :meth:`simulate`; a subclass writing provenance should union this with whatever it
     #: generated itself. Empty for simulators that do not inject.
+    #:
+    #: **Lost across a checkpoint resume**, along with the samples themselves: ``cached_data_chunks``
+    #: is not a :class:`~gwmock.simulator.state.StateAttribute`, so a resumed run regenerates neither
+    #: the spillover nor its record, and the segment after the resume point silently loses the rest of
+    #: any signal crossing it. That is a data bug older than this attribute -- the samples go missing
+    #: whether or not anything records them -- so it is tracked separately as
+    #: ``gwmock/spillover-lost-on-checkpoint-resume`` rather than papered over here. What it means for
+    #: provenance is that "recorded against every frame it reaches" is false at exactly that boundary.
     carried_injections: list[dict[str, Any]]
 
     def __init__(

--- a/src/gwmock/mixin/time_series.py
+++ b/src/gwmock/mixin/time_series.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, cast
 
@@ -20,6 +21,56 @@ from gwmock.utils.datetime_parser import parse_duration_to_seconds
 logger = logging.getLogger("gwmock")
 
 
+def _injection_record(chunk: TimeSeries) -> dict[str, Any] | None:
+    """Return the injection record a chunk carries, or ``None`` if it carries none.
+
+    Both are stamped at generation and copied onto a tail when a chunk crosses a segment boundary,
+    which is what lets a carried-forward chunk still say what it is. A chunk with parameters but no
+    ``event_id`` is recorded with ``event_id`` ``None`` rather than dropped: the parameters are still
+    the provenance, and dropping it would silently lose a signal from the record.
+    """
+    parameters = chunk.metadata.get("injection_parameters")
+    if parameters is None:
+        return None
+    event_id = chunk.metadata.get("event_id")
+    return {"event_id": event_id, "parameters": dict(parameters)}
+
+
+def _contributing_injections(segment: TimeSeries, chunks: Iterable[TimeSeries]) -> list[dict[str, Any]]:
+    """Return injection records for the chunks that place at least one sample in *segment*."""
+    records: list[dict[str, Any]] = []
+    for chunk in chunks:
+        if not segment.contributes_samples(chunk):
+            continue
+        record = _injection_record(chunk)
+        if record is not None:
+            records.append(record)
+    return records
+
+
+def _merge_injection_records(*groups: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Concatenate injection records, keeping the first of each ``event_id`` and order stable.
+
+    Deduplicated because one signal can reach a segment through several chunks -- a multi-detector
+    generation emits one chunk per detector, all carrying the same record -- and a provenance list
+    naming the same event three times would read as three injections.
+
+    Records whose ``event_id`` is ``None`` are never merged together: without an id there is nothing
+    to say two chunks are the same signal, so collapsing them would drop real injections.
+    """
+    merged: list[dict[str, Any]] = []
+    seen: set[Any] = set()
+    for group in groups:
+        for record in group:
+            event_id = record.get("event_id")
+            if event_id is not None:
+                if event_id in seen:
+                    continue
+                seen.add(event_id)
+            merged.append(record)
+    return merged
+
+
 class TimeSeriesMixin:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
     """Mixin providing timing and duration management.
 
@@ -29,6 +80,11 @@ class TimeSeriesMixin:  # pylint: disable=too-few-public-methods,too-many-instan
 
     start_time = StateAttribute(Quantity(0, unit="s"))
     cached_data_chunks = TimeSeriesList()
+    #: Injection records for every signal that reaches the segment currently being built, including
+    #: signals generated for an *earlier* segment whose content extends into this one. Rebuilt per
+    #: segment by :meth:`simulate`; a subclass writing provenance should union this with whatever it
+    #: generated itself. Empty for simulators that do not inject.
+    carried_injections: list[dict[str, Any]]
 
     def __init__(
         self,
@@ -53,6 +109,9 @@ class TimeSeriesMixin:  # pylint: disable=too-few-public-methods,too-many-instan
         super().__init__(**kwargs)
         # TimeSeriesMixin is the last mixin in the hierarchy, so no super().__init__() call needed
         self.start_time = Quantity(start_time, unit="s")
+        # Per instance, not a class attribute: two simulators in one process must not share the
+        # list of signals reaching the segment each is building.
+        self.carried_injections = []
         self.duration = duration
         self.total_duration = total_duration
         self.sampling_frequency = sampling_frequency
@@ -211,11 +270,23 @@ class TimeSeriesMixin:  # pylint: disable=too-few-public-methods,too-many-instan
             sampling_frequency=self.sampling_frequency,
         )
 
+        # Which carried-forward chunks reach this segment, recorded *before* injecting them.
+        # Injection sums into shared channels, so after this line there is no way to ask which
+        # signal contributed to the segment -- and a signal long enough to cross a boundary is
+        # exactly the case where the answer is not the segment it was generated in.
+        self.carried_injections = _contributing_injections(segment, self.cached_data_chunks)
+
         # Inject cached data chunks into the segment
         self.cached_data_chunks = segment.inject_from_list(self.cached_data_chunks)
 
         # Generate new chunks of data
         new_chunks = self._simulate(*args, **kwargs)
+
+        # Chunks generated for this segment that do not actually reach it are excluded for the same
+        # reason the carried ones are included: the record names the frames a signal is *in*.
+        self.carried_injections = _merge_injection_records(
+            self.carried_injections, _contributing_injections(segment, new_chunks)
+        )
 
         # Add the new chunks to the segment
         remaining_chunks = segment.inject_from_list(new_chunks)

--- a/tests/cli/test_cli_orchestration.py
+++ b/tests/cli/test_cli_orchestration.py
@@ -313,7 +313,7 @@ def test_simulate_command_runs_adapter_orchestration(monkeypatch, tmp_path: Path
     assert (tmp_path / "output" / "signal" / "signal-1.gwf").exists()
     _assert_noise_outputs_exist(tmp_path / "output" / "noise")
     metadata = yaml.safe_load((tmp_path / "metadata" / "orchestration-0.metadata.json").read_text())
-    assert metadata["schema_version"] == "1.4.0"
+    assert metadata["schema_version"] == "1.5.0"
     assert metadata["config"]["orchestration"]["population"]["backend"] == FAKE_POPULATION_BACKEND
     assert metadata["config"]["orchestration"]["signal"]["backend"] == FAKE_SIGNAL_BACKEND
     assert metadata["config"]["orchestration"]["noise"]["backend"] == FAKE_NOISE_BACKEND
@@ -372,7 +372,7 @@ def test_orchestration_records_injections_and_signal_lookup(monkeypatch, tmp_pat
     # Part B: signal_index.yaml maps each event id to its containing frame(s).
     index = yaml.safe_load((metadata_dir / "signal_index.yaml").read_text())
     assert set(index) == {"0", "1"}
-    assert any("signal-0.gwf" in frame for frame in index["0"]["frames"])
+    assert any("signal-0.gwf" in frame for batch in index["0"]["batches"] for frame in batch["frames"])
 
     # Lookup by id (fast path) resolves to the right frame.
     by_id = find_signals(metadata_dir, event_id=1)

--- a/tests/cli/test_inspiral_segment_placement.py
+++ b/tests/cli/test_inspiral_segment_placement.py
@@ -501,6 +501,12 @@ class TestNothingIsDiscarded:
 
         Stated rather than assumed, because it is a change -- an event used to be listed against the
         frame containing its coalescence, and a reader of the metadata needs to know which.
+
+        About ``_batch_injections``, which is what each batch *generated*. That is deliberately not
+        what reaches the metadata: a signal crossing a boundary is present in both frames, so
+        ``_segment_injections`` cross-lists it, and
+        ``test_provenance_across_segments.py`` pins that. The two used to be the same list, and
+        conflating them is what made `gwmock find-signal` name one frame out of three.
         """
         orchestrator = _orchestrator(tmp_path, "per-event", total_duration=2 * _SEGMENT_DURATION)
         coa_time = _START + _SEGMENT_DURATION + 1.0
@@ -515,21 +521,55 @@ class TestNothingIsDiscarded:
         assert [entry["event_id"] for entry in first_segment_injections] == [0], (
             "the event belongs to the first segment, where its waveform starts"
         )
-        assert second_segment_injections == [], "and it is not cross-listed against the frame its coalescence falls in"
+        assert second_segment_injections == [], (
+            "and the second segment generated nothing -- `_batch_injections` is what this batch "
+            "produced, which is the attribution #311 changed"
+        )
 
 
 class TestWhatAConsumerSees:
     """The attribution change reaches serialized metadata and the lookup, so it is checked there."""
 
-    def test_the_schema_version_records_that_the_attribution_changed(self):
-        """No field was added or removed, so nothing but the version tells the two conventions apart.
+    def test_a_signal_crossing_a_boundary_is_recorded_against_both_segments(self, tmp_path):
+        """The metadata a consumer reads must name every frame the signal is in, not only the first.
 
-        A consumer reading a 1.3.0 record and a new one sees the same shape while ``injections`` means
+        Goes through the orchestrator rather than the helpers because the defect was in the *wiring*:
+        `_contributing_injections` can be perfectly correct while nothing calls it before the chunks
+        are injected, and after injection the attribution is gone -- chunks are summed into shared
+        channels. Reproduced end to end before the fix, this second segment recorded ``injections:
+        []`` while holding the merger.
+        """
+        orchestrator = _orchestrator(tmp_path, "per-event", total_duration=2 * _SEGMENT_DURATION)
+        coa_time = _START + _SEGMENT_DURATION + 1.0
+
+        orchestrator._population_events = ({**_COMPLETE_EVENT, "coa_time": coa_time},)
+        orchestrator.simulate()
+        first = [entry["event_id"] for entry in orchestrator._segment_injections()]
+        orchestrator.update_state()
+        orchestrator.simulate()
+        second = [entry["event_id"] for entry in orchestrator._segment_injections()]
+
+        assert first == [0], "the segment its waveform starts in must record it"
+        assert second == [0], (
+            "the segment holding the rest of the signal -- including the coalescence -- recorded "
+            "nothing, so `find-signal` names one frame out of two"
+        )
+
+    def test_the_schema_version_records_that_the_attribution_changed(self):
+        """No field was added or removed, so nothing but the version tells the conventions apart.
+
+        Two changes now ride on this version, and both are invisible in the shape of a record.
+        1.4.0: ``injections`` lists an event against the frame its waveform *starts* in rather than
+        the frame holding its coalescence. 1.5.0: ``injections`` lists every event *present* in the
+        frame, including one generated for an earlier segment, and ``signal_index.yaml`` stores
+        contributions per batch so one event can name the frames of several.
+
+        A consumer reading an old record and a new one sees the same shape while ``injections`` means
         something different in each. The version is the only signal available, so it has to move.
         """
         from gwmock.cli.utils.metadata import SCHEMA_VERSION
 
-        assert SCHEMA_VERSION == "1.4.0"
+        assert SCHEMA_VERSION == "1.5.0"
 
     def test_an_older_record_still_loads(self):
         """Bumping the minor must not orphan archived runs: the major is what gates parsing."""
@@ -563,7 +603,7 @@ class TestWhatAConsumerSees:
         (metadata_directory / "orchestration-0.metadata.json").write_text(
             json.dumps(
                 {
-                    "schema_version": "1.4.0",
+                    "schema_version": "1.5.0",
                     "subpackage_versions": {},
                     "config": {},
                     "config_sha256": "0" * 64,

--- a/tests/cli/test_provenance_across_segments.py
+++ b/tests/cli/test_provenance_across_segments.py
@@ -1,0 +1,214 @@
+#
+# Copyright (C) 2026 Leuven Gravity Institute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+"""A signal is recorded against every frame it reaches, not only the one that generated it.
+
+Measured before this was fixed, with a 1.6+1.4 binary from 30 Hz across 32 s segments: the waveform
+spans three frames, ``gwmock find-signal --id 0`` named three of the nine files written, and the six
+it omitted included the **merger** -- the named frame held a peak of 1.29e-23 against 7.28e-23 in one
+it did not name. Continuous waves make it universal rather than occasional, since every pulsar is in
+every frame of the run.
+
+Two mechanisms had to be right, and they fail independently, so they are tested separately:
+
+* a chunk carried into a later segment must still say which event it is, and the segment must record
+  it -- otherwise the batch metadata, which is the documented source of truth, is itself lossy;
+* ``signal_index.yaml`` must accumulate across batches rather than assign, or the id fast path keeps
+  whichever batch wrote last.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+from astropy.units.quantity import Quantity
+
+from gwmock.cli.simulate_utils import update_signal_index
+from gwmock.cli.utils.signal_lookup import find_signals
+from gwmock.data.time_series.time_series import TimeSeries
+from gwmock.mixin.time_series import _contributing_injections, _merge_injection_records
+
+
+def _segment(start: float, duration: float = 4.0, sampling_frequency: float = 16.0) -> TimeSeries:
+    return TimeSeries(
+        data=np.zeros((1, int(duration * sampling_frequency))),
+        start_time=Quantity(start, unit="s"),
+        sampling_frequency=Quantity(sampling_frequency, unit="Hz"),
+    )
+
+
+def _chunk(start: float, duration: float, event_id: int | None = 7, sampling_frequency: float = 16.0) -> TimeSeries:
+    chunk = TimeSeries(
+        data=np.ones((1, int(duration * sampling_frequency))),
+        start_time=Quantity(start, unit="s"),
+        sampling_frequency=Quantity(sampling_frequency, unit="Hz"),
+    )
+    chunk.metadata.update({"injection_parameters": {"coa_time": start + duration}, "event_id": event_id})
+    return chunk
+
+
+class TestWhichChunksCountAsPresent:
+    """The overlap rule, at the boundary, where an off-by-one costs exactly one frame per signal."""
+
+    @pytest.mark.parametrize(
+        ("chunk_start", "chunk_duration", "expected", "why"),
+        [
+            (100.0, 4.0, True, "exactly the segment"),
+            (98.0, 4.0, True, "overlapping the start"),
+            (102.0, 4.0, True, "overlapping the end"),
+            (96.0, 4.0, False, "ends exactly at the segment start, so no sample is inside"),
+            (104.0, 4.0, False, "starts exactly at the segment end, so no sample is inside"),
+            (96.0, 4.0625, True, "ends one sample into the segment"),
+            (103.9375, 4.0, True, "starts on the segment's last sample"),
+            (90.0, 4.0, False, "entirely before"),
+            (110.0, 4.0, False, "entirely after"),
+            (90.0, 30.0, True, "spanning the whole segment and out both sides"),
+        ],
+    )
+    def test_the_boundary_cases(self, chunk_start, chunk_duration, expected, why):
+        """Enumerated across the boundary rather than argued in a comment.
+
+        The endpoints are the cases a plausible implementation gets wrong: ``<=`` instead of ``<``
+        cross-lists a signal against a frame it contributes nothing to, which is a silent over-claim
+        that no downstream check would catch.
+        """
+        segment = _segment(100.0)
+        assert segment.contributes_samples(_chunk(chunk_start, chunk_duration)) is expected, why
+
+
+class TestTheSegmentRecordsWhatReachesIt:
+    """`_contributing_injections` and `_merge_injection_records`, the pieces `simulate` composes."""
+
+    def test_a_carried_chunk_is_recorded_against_the_segment_it_reaches(self):
+        """The whole point: an event generated earlier is still named by the frame it lands in."""
+        segment = _segment(100.0)
+        records = _contributing_injections(segment, [_chunk(96.0, 8.0, event_id=3)])
+        assert [record["event_id"] for record in records] == [3]
+
+    def test_a_chunk_that_does_not_reach_the_segment_is_not_recorded(self):
+        """The converse, so the fix cannot be satisfied by recording everything unconditionally."""
+        segment = _segment(100.0)
+        assert _contributing_injections(segment, [_chunk(80.0, 4.0, event_id=3)]) == []
+
+    def test_a_chunk_without_injection_parameters_is_not_recorded(self):
+        """Noise and background chunks reach the segment too, and are not injections."""
+        segment = _segment(100.0)
+        plain = _chunk(100.0, 4.0)
+        plain.metadata.clear()
+        assert _contributing_injections(segment, [plain]) == []
+
+    def test_one_event_arriving_on_several_chunks_is_recorded_once(self):
+        """A multi-detector batch emits one chunk per detector carrying the same record.
+
+        Without deduplication a three-detector network would list every injection three times, which
+        reads as three injections rather than one.
+        """
+        segment = _segment(100.0)
+        chunks = [_chunk(100.0, 4.0, event_id=5) for _ in range(3)]
+        assert len(_contributing_injections(segment, chunks)) == 3
+        assert len(_merge_injection_records(_contributing_injections(segment, chunks))) == 1
+
+    def test_records_without_an_event_id_are_not_collapsed_together(self):
+        """Absent ids are not evidence of sameness, so merging them would drop real injections."""
+        segment = _segment(100.0)
+        chunks = [_chunk(100.0, 4.0, event_id=None) for _ in range(3)]
+        assert len(_merge_injection_records(_contributing_injections(segment, chunks))) == 3
+
+    def test_the_generated_record_wins_and_order_is_stable(self):
+        """Generated first, then carried, so the common single-segment case reads as it always did."""
+        merged = _merge_injection_records(
+            [{"event_id": 1, "parameters": {"source": "generated"}}],
+            [{"event_id": 1, "parameters": {"source": "carried"}}, {"event_id": 2, "parameters": {}}],
+        )
+        assert [record["event_id"] for record in merged] == [1, 2]
+        assert merged[0]["parameters"]["source"] == "generated"
+
+
+def _write_batch(directory, name: str, frames: list[str], event_ids: list[int]) -> None:
+    update_signal_index(
+        directory,
+        {
+            "signal": {"injections": [{"event_id": i, "parameters": {"coa_time": 12.0}} for i in event_ids]},
+            "outputs": [{"kind": "signal", "path": frame} for frame in frames],
+        },
+        name,
+    )
+
+
+class TestTheIndexAccumulatesAcrossBatches:
+    """`signal_index.yaml`, which assigned where it had to append."""
+
+    def test_one_event_reaching_three_batches_names_all_their_frames(self, tmp_path):
+        """Reproduces the measured failure: three of nine frames, keeping whichever batch wrote last."""
+        for index, name in enumerate(("a", "b", "c")):
+            _write_batch(tmp_path, f"orchestration-{name}.metadata.json", [f"signal/{name}-{index}.gwf"], [0])
+
+        matches = find_signals(tmp_path, event_id=0)
+
+        assert len(matches) == 1
+        assert matches[0]["frames"] == ["signal/a-0.gwf", "signal/b-1.gwf", "signal/c-2.gwf"]
+        assert matches[0]["metadata"] == [
+            "orchestration-a.metadata.json",
+            "orchestration-b.metadata.json",
+            "orchestration-c.metadata.json",
+        ]
+
+    def test_a_rerun_withdraws_only_its_own_contribution(self, tmp_path):
+        """A re-run that now injects nothing must not leave its old frames behind, nor drop others'.
+
+        The old code dropped whole entries whose ``metadata`` matched, which was equivalent only while
+        an entry belonged to one batch. Once entries span batches, dropping the entry would discard
+        the other batches' frames too -- so this asserts both halves.
+        """
+        _write_batch(tmp_path, "orchestration-a.metadata.json", ["signal/a.gwf"], [0])
+        _write_batch(tmp_path, "orchestration-b.metadata.json", ["signal/b.gwf"], [0])
+
+        _write_batch(tmp_path, "orchestration-a.metadata.json", ["signal/a-new.gwf"], [])
+
+        matches = find_signals(tmp_path, event_id=0)
+        assert matches[0]["frames"] == ["signal/b.gwf"], "the re-run's old frame survived, or b's was lost"
+
+    def test_an_index_written_before_the_schema_change_still_answers(self, tmp_path):
+        """An index is a rebuildable cache, so an upgrade must not make it look like data loss."""
+        import yaml
+
+        (tmp_path / "signal_index.yaml").write_text(
+            yaml.safe_dump(
+                {"0": {"frames": ["signal/old.gwf"], "metadata": "orchestration-old.metadata.json", "coa_time": 1.0}}
+            )
+        )
+
+        matches = find_signals(tmp_path, event_id=0)
+
+        assert matches[0]["frames"] == ["signal/old.gwf"]
+        assert matches[0]["metadata"] == ["orchestration-old.metadata.json"]
+
+    def test_both_lookup_paths_report_metadata_the_same_way(self, tmp_path):
+        """The id path and the parameter path must not differ in the *type* of what they return."""
+        _write_batch(tmp_path, "orchestration-a.metadata.json", ["signal/a.gwf"], [0])
+        (tmp_path / "orchestration-a.metadata.json").write_text(
+            __import__("json").dumps(
+                {
+                    "signal": {"injections": [{"event_id": 0, "parameters": {"coa_time": 12.0}}]},
+                    "outputs": [{"kind": "signal", "path": "signal/a.gwf"}],
+                }
+            )
+        )
+
+        by_id: list[dict[str, Any]] = find_signals(tmp_path, event_id=0)
+        by_param = find_signals(tmp_path, param_filters=[("coa_time", "==", 12.0)])
+
+        assert isinstance(by_id[0]["metadata"], list)
+        assert isinstance(by_param[0]["metadata"], list)

--- a/tests/cli/test_provenance_across_segments.py
+++ b/tests/cli/test_provenance_across_segments.py
@@ -195,6 +195,30 @@ class TestTheIndexAccumulatesAcrossBatches:
         assert matches[0]["frames"] == ["signal/old.gwf"]
         assert matches[0]["metadata"] == ["orchestration-old.metadata.json"]
 
+    def test_a_new_batch_does_not_discard_a_pre_migration_entry(self, tmp_path):
+        """Writing after an upgrade must migrate old entries, not quietly delete them.
+
+        Separate from the read-side migration test above, and the reason is a measured gap: dropping
+        the migration inside ``_withdraw_batch`` -- so every pre-1.5.0 entry vanishes on the next
+        write -- left the whole suite green. Reading an old index was covered; *surviving a write*
+        was not, and that is the path a real upgrade takes, since the next batch of a resumed run
+        rewrites the index.
+        """
+        import yaml
+
+        (tmp_path / "signal_index.yaml").write_text(
+            yaml.safe_dump(
+                {"9": {"frames": ["signal/old.gwf"], "metadata": "orchestration-old.metadata.json", "coa_time": 1.0}}
+            )
+        )
+
+        _write_batch(tmp_path, "orchestration-new.metadata.json", ["signal/new.gwf"], [0])
+
+        assert find_signals(tmp_path, event_id=9)[0]["frames"] == ["signal/old.gwf"], (
+            "the pre-1.5.0 entry was discarded when an unrelated batch wrote the index"
+        )
+        assert find_signals(tmp_path, event_id=0)[0]["frames"] == ["signal/new.gwf"]
+
     def test_both_lookup_paths_report_metadata_the_same_way(self, tmp_path):
         """The id path and the parameter path must not differ in the *type* of what they return."""
         _write_batch(tmp_path, "orchestration-a.metadata.json", ["signal/a.gwf"], [0])

--- a/tests/cli/test_signal_lookup.py
+++ b/tests/cli/test_signal_lookup.py
@@ -73,16 +73,19 @@ def test_parse_param_filter_rejects_garbage() -> None:
 def test_signal_index_written(metadata_dir: Path) -> None:
     index = yaml.safe_load((metadata_dir / "signal_index.yaml").read_text())
     assert set(index) == {"0", "1"}
-    assert index["0"]["frames"] == ["signal/signal-0.gwf"]
+    # One batch here, but stored as a list of batch contributions: an event reaching several
+    # segments has one entry per batch, which is what `update_signal_index` was fixed to record.
+    assert index["0"]["batches"] == [{"metadata": "orchestration-0.metadata.json", "frames": ["signal/signal-0.gwf"]}]
     assert index["0"]["coa_time"] == 100.5
-    assert index["1"]["metadata"] == "orchestration-1.metadata.json"
+    assert [batch["metadata"] for batch in index["1"]["batches"]] == ["orchestration-1.metadata.json"]
 
 
 def test_find_by_id_uses_index(metadata_dir: Path) -> None:
     matches = find_signals(metadata_dir, event_id=1)
     assert len(matches) == 1
     assert matches[0]["frames"] == ["signal/signal-1.gwf"]
-    assert matches[0]["metadata"] == "orchestration-1.metadata.json"
+    # A list on both lookup paths, so a consumer never branches on which one it asked.
+    assert matches[0]["metadata"] == ["orchestration-1.metadata.json"]
 
 
 def test_find_by_id_missing_returns_empty(metadata_dir: Path) -> None:


### PR DESCRIPTION
## 📝 Summary

`gwmock find-signal` named one frame when a signal's samples are in several.

Measured with a 1.6+1.4 binary from 30 Hz across 32 s segments, whose waveform spans three frames (nine files across three detectors): the lookup returned **three of nine**, and the six it omitted included the **merger** — the named frame held a peak of 1.29e-23 against 7.28e-23 in one it did not name. For continuous waves it is universal, since every pulsar is in every frame of the run.

Both lookup paths were affected. Parameter lookup is documented as the source of truth, but for a compact binary the later batches recorded `injections: []`, so it returned the same three frames.

Two mechanisms, which fail independently:

1. Chunks carry `event_id` beside `injection_parameters`, and `TimeSeriesMixin.simulate` collects the contributing records **before** injecting. Injection sums chunks into shared channels, so afterwards there is no way to ask which signal put samples where — it has to be asked first. `_segment_injections` unions what a batch generated with what reached it, deduplicated on `event_id` because a multi-detector batch emits one chunk per detector.
2. `signal_index.yaml` accumulates instead of assigning. Contributions are stored per batch rather than as a flat frame list, because a re-run has to withdraw its own contribution and a flattened copy alongside would be a second place for the same fact to live; flattening happens once, on read. Pre-1.5.0 entries are migrated on read rather than rejected — an index is a rebuildable cache, and refusing one would make an upgrade look like data loss.

| | before | after |
|---|---|---|
| CBC `--id` | 3 of 9 frames, missing the merger | 9 of 9 |
| CBC `--param` | 3 of 9 | 9 of 9 |
| CW `--id` | 3 of 9 | 9 of 9 |

`SCHEMA_VERSION` 1.4.0 → 1.5.0. `injections` kept its type while changing its cardinality, so a consumer summing it across a run will overcount and only the version says so. `find_signals` reports `metadata` as a list on both paths.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 💥 Breaking change — `signal_index.yaml` changed shape and `injections` changed meaning. Old indexes are read; external raw-YAML parsers of the index will need updating.
- [x] 📝 Documentation update

## 🧪 How Has This Been Tested?

**Run the suite on `macmini`, not the primary machine (4 cores).** Use your own checkout per `_instructions/test-host-policy.md`. Two traps: `uv` is at `~/.local/bin/uv` and not on the non-interactive SSH PATH; and **do not use `uv sync --all-extras`** — the `cuda` extra has no macOS wheel, so the sync fails, pytest never runs, and a failure count of 0 on the missing log reads exactly like a pass. Use `uv sync --extra jax --extra sgwb`.

- [x] Full suite: 1029 passed on Linux, 1029 on macmini.
- [x] End to end through the CLI for both source types, table above.
- [x] **Both mechanisms mutation-checked.** Reverting the index to assignment fails `test_one_event_reaching_three_batches_names_all_their_frames`; zeroing the carry-forward collection fails `test_a_signal_crossing_a_boundary_is_recorded_against_both_segments` with `assert [] == [0]`; dropping the write-side migration fails `test_a_new_batch_does_not_discard_a_pre_migration_entry`.
- [x] `contributes_samples` is parametrised across the boundary, including chunks ending exactly at the segment start and starting on its last sample, where an off-by-one costs exactly one frame per signal.

Worth reviewers' attention:

- **The wiring, not the helper, was where the defect lived.** A first pass tested `_contributing_injections` thoroughly and left `simulate` uncovered — the helper can be entirely correct with nothing calling it. Only an end-to-end mutation exposed that, which is why one test goes through the orchestrator.
- **An existing test asserted the opposite of this change and kept passing**, because it reads `_batch_injections` (what a batch generated) rather than what reaches the frame. True of that list, false of the metadata; rewritten to pin the distinction rather than deleted.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Known limitations, named rather than fixed

Both predate this work, both have tracker items, and neither is a provenance bug:

- **Checkpoint resume loses spillover** (`gwmock/spillover-lost-on-checkpoint-resume`). `cached_data_chunks` is not a `StateAttribute`, so a resumed run regenerates neither the tail nor its record: through the CLI, segment 1's peak goes from 8.6e-22 to **0.0** after a resume — the merger is gone. The samples vanish whether or not anything records them, so fixing it here would mix a data fix into a metadata one. It does make this PR's claim false at exactly a resume boundary, which is documented where the claim is made.
- **The index has no write lock** (`gwmock/signal-index-concurrent-writers`). Unlocked read-modify-write, reproducible with a barrier. Not made worse here, but a dropped update used to cost one assignment and now costs one batch's frames for every event in it. Bounded in practice: batches are written sequentially within a run, so it bites only when two runs share a metadata directory.

**Not verified:** `execution: batched` across a chunk boundary at production scale, and what any existing external consumer of `signal_index.yaml` does with the new shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Signal provenance now appears in every frame containing the signal, including signals crossing segment boundaries.
  * Signal indexes preserve contributions across batches and provide associated frame and metadata details.
  * Signal lookups consistently return metadata files as a list.
  * Provenance includes event identifiers and deduplicates repeated records.

* **Compatibility**
  * Existing pre-1.5.0 signal indexes remain readable.

* **Documentation**
  * Updated reproducibility and signal lookup guidance to explain multi-frame signal behavior and schema 1.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->