### PR TITLE
fix(checkpoint): carry spillover across a resume so the tail is not lost

### DIFF
--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -725,7 +725,10 @@ def instantiate_simulator(
 
 
 def restore_batch_state(
-    simulator: Simulator, batch: SimulationBatch, last_simulator_state: dict[str, Any] | None = None
+    simulator: Simulator,
+    batch: SimulationBatch,
+    last_simulator_state: dict[str, Any] | None = None,
+    last_simulator_spillover: Any = None,
 ) -> None:
     """Restore simulator state from batch metadata or checkpoint file if available.
 
@@ -775,6 +778,12 @@ def restore_batch_state(
                 last_simulator_state.get("counter"),
             )
             simulator.state = last_simulator_state
+            # Restored only on this branch -- the one that resumes from the checkpoint's *last*
+            # state. The branch above restores from a batch metadata record, which by design does
+            # not carry samples, so there is no spillover to restore there and a run resumed that
+            # way still loses the tail. Stated rather than silently half-handled.
+            if last_simulator_spillover is not None:
+                simulator.cached_data_chunks = last_simulator_spillover
             logger.debug(
                 "[RESTORE] Batch %d: State restored successfully - new_counter=%s",
                 batch.batch_index,
@@ -1223,9 +1232,11 @@ def execute_plan(  # noqa: PLR0915
     if not resuming:
         logger.debug("No checkpoint found or no batches completed yet")
         last_simulator_state = None
+        last_simulator_spillover = None
     elif completed_batch_indices == loaded_batch_indices:
         logger.info("Loaded checkpoint: %d batches already completed", len(completed_batch_indices))
         last_simulator_state = checkpoint_manager.get_last_simulator_state()
+        last_simulator_spillover = checkpoint_manager.get_last_simulator_spillover()
     else:
         # One or more checkpointed batches are missing their outputs. The checkpoint
         # only holds the tail simulator state, so an interior batch cannot be
@@ -1239,6 +1250,7 @@ def execute_plan(  # noqa: PLR0915
         )
         completed_batch_indices = set()
         last_simulator_state = None
+        last_simulator_spillover = None
 
     # Group batches by simulator name to execute sequentially per simulator
     simulator_batches: dict[str, list[SimulationBatch]] = {}
@@ -1289,7 +1301,7 @@ def execute_plan(  # noqa: PLR0915
                         simulator.counter,
                         batch.has_state_snapshot(),
                     )
-                    restore_batch_state(simulator, batch, last_simulator_state)
+                    restore_batch_state(simulator, batch, last_simulator_state, last_simulator_spillover)
                     logger.debug("[EXECUTE] Batch %s: After restore - counter=%s", batch.batch_index, simulator.counter)
                     pre_batch_state = copy.deepcopy(simulator.state)
                     logger.debug(
@@ -1361,6 +1373,9 @@ def execute_plan(  # noqa: PLR0915
                         last_simulator_name=simulator_name,
                         last_completed_batch_index=batch.batch_index,
                         last_simulator_state=copy.deepcopy(simulator.state),
+                        # Beside the state, not inside it: `state` also goes into every batch
+                        # metadata record, and spillover is raw samples. See `save_checkpoint`.
+                        last_simulator_spillover=copy.deepcopy(getattr(simulator, "cached_data_chunks", None)),
                     )
                     logger.debug(
                         "Checkpoint saved after batch %d - state counter=%s",

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -1237,14 +1237,16 @@ def execute_plan(  # noqa: PLR0915
         spillover_batch_index = None
     elif completed_batch_indices == loaded_batch_indices:
         logger.info("Loaded checkpoint: %d batches already completed", len(completed_batch_indices))
-        last_simulator_state = checkpoint_manager.get_last_simulator_state()
-        # Read once, not per batch: spillover can run to hundreds of MB for a long inspiral, and
-        # re-reading the checkpoint inside the loop would pay that on every batch. The scoping the
-        # getter would do is applied at the restore call instead, from these two values.
-        _checkpoint = checkpoint_manager.load_checkpoint() or {}
-        last_simulator_spillover = _checkpoint.get("last_simulator_spillover")
-        spillover_simulator_name = _checkpoint.get("last_simulator_name")
-        spillover_batch_index = _checkpoint.get("last_completed_batch_index")
+        # One load for everything below. Each `load_checkpoint` decodes the whole file including the
+        # spillover, which is 131 MB of base64 for a 1000 s tail, so calling the individual getters
+        # here would pay that decode once per getter before the run even starts. The per-batch
+        # scoping the getters would apply is done at the restore call instead, from these values.
+        checkpoint = checkpoint_manager.load_checkpoint() or {}
+        last_simulator_state = checkpoint.get("last_simulator_state")
+        last_simulator_state = last_simulator_state if isinstance(last_simulator_state, dict) else None
+        last_simulator_spillover = checkpoint.get("last_simulator_spillover")
+        spillover_simulator_name = checkpoint.get("last_simulator_name")
+        spillover_batch_index = checkpoint.get("last_completed_batch_index")
     else:
         # One or more checkpointed batches are missing their outputs. The checkpoint
         # only holds the tail simulator state, so an interior batch cannot be
@@ -1327,6 +1329,12 @@ def execute_plan(  # noqa: PLR0915
                     restore_batch_state(simulator, batch, last_simulator_state, spillover_for_batch)
                     logger.debug("[EXECUTE] Batch %s: After restore - counter=%s", batch.batch_index, simulator.counter)
                     pre_batch_state = copy.deepcopy(simulator.state)
+                    # Spillover too, and separately, because it is not part of `state`. `simulate`
+                    # consumes `cached_data_chunks` and replaces it with the new tail, so a retry
+                    # after a failed write would re-run against consumed chunks and produce
+                    # different data than the first attempt -- silently, since a retry that
+                    # succeeds looks like a success.
+                    pre_batch_spillover = copy.deepcopy(getattr(simulator, "cached_data_chunks", None))
                     logger.debug(
                         "[EXECUTE] Batch %s: Captured pre_batch_state - keys=%s",
                         batch.batch_index,
@@ -1376,9 +1384,15 @@ def execute_plan(  # noqa: PLR0915
                         # Update the state after successful save
                         _simulator.update_state()
 
-                    def restore_state_for_retry(_simulator=simulator, _pre_batch_state=pre_batch_state):
+                    def restore_state_for_retry(
+                        _simulator=simulator,
+                        _pre_batch_state=pre_batch_state,
+                        _pre_batch_spillover=pre_batch_spillover,
+                    ):
                         """Restore simulator state to pre-batch state before retry."""
                         _simulator.state = copy.deepcopy(_pre_batch_state)
+                        if _pre_batch_spillover is not None:
+                            _simulator.cached_data_chunks = copy.deepcopy(_pre_batch_spillover)
 
                     # Execute batch with retry mechanism that restores state on failure
                     retry_with_backoff(

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -1233,10 +1233,18 @@ def execute_plan(  # noqa: PLR0915
         logger.debug("No checkpoint found or no batches completed yet")
         last_simulator_state = None
         last_simulator_spillover = None
+        spillover_simulator_name = None
+        spillover_batch_index = None
     elif completed_batch_indices == loaded_batch_indices:
         logger.info("Loaded checkpoint: %d batches already completed", len(completed_batch_indices))
         last_simulator_state = checkpoint_manager.get_last_simulator_state()
-        last_simulator_spillover = checkpoint_manager.get_last_simulator_spillover()
+        # Read once, not per batch: spillover can run to hundreds of MB for a long inspiral, and
+        # re-reading the checkpoint inside the loop would pay that on every batch. The scoping the
+        # getter would do is applied at the restore call instead, from these two values.
+        _checkpoint = checkpoint_manager.load_checkpoint() or {}
+        last_simulator_spillover = _checkpoint.get("last_simulator_spillover")
+        spillover_simulator_name = _checkpoint.get("last_simulator_name")
+        spillover_batch_index = _checkpoint.get("last_completed_batch_index")
     else:
         # One or more checkpointed batches are missing their outputs. The checkpoint
         # only holds the tail simulator state, so an interior batch cannot be
@@ -1251,6 +1259,8 @@ def execute_plan(  # noqa: PLR0915
         completed_batch_indices = set()
         last_simulator_state = None
         last_simulator_spillover = None
+        spillover_simulator_name = None
+        spillover_batch_index = None
 
     # Group batches by simulator name to execute sequentially per simulator
     simulator_batches: dict[str, list[SimulationBatch]] = {}
@@ -1301,7 +1311,20 @@ def execute_plan(  # noqa: PLR0915
                         simulator.counter,
                         batch.has_state_snapshot(),
                     )
-                    restore_batch_state(simulator, batch, last_simulator_state, last_simulator_spillover)
+                    # Scoped before it is handed over. A plan can execute several simulators and
+                    # the checkpoint holds one tail, so an unscoped hand-off can put one simulator's
+                    # spillover into another's segment -- real strain of the right shape, in the
+                    # wrong place. It is also only valid for the batch immediately after the one
+                    # that produced it.
+                    spillover_for_batch = (
+                        last_simulator_spillover
+                        if (
+                            spillover_simulator_name == batch.simulator_name
+                            and spillover_batch_index == batch.batch_index - 1
+                        )
+                        else None
+                    )
+                    restore_batch_state(simulator, batch, last_simulator_state, spillover_for_batch)
                     logger.debug("[EXECUTE] Batch %s: After restore - counter=%s", batch.batch_index, simulator.counter)
                     pre_batch_state = copy.deepcopy(simulator.state)
                     logger.debug(

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -26,7 +26,7 @@ from gwmock_noise import SimulationResult
 from tqdm import tqdm
 
 from gwmock.cli.adapter_orchestration import AdapterOrchestrationResult, AdapterOrchestrator
-from gwmock.cli.utils.checkpoint import CheckpointManager
+from gwmock.cli.utils.checkpoint import CheckpointManager, spillover_applies
 from gwmock.cli.utils.config import OrchestrationConfig, SimulatorConfig, resolve_class_path
 from gwmock.cli.utils.environment import capture_environment
 from gwmock.cli.utils.hash import compute_content_hash, compute_file_hash
@@ -1221,7 +1221,14 @@ def execute_plan(  # noqa: PLR0915
 
     # Initialize checkpoint manager for resumption support
     checkpoint_manager = CheckpointManager(plan.checkpoint_directory)
-    loaded_batch_indices = checkpoint_manager.get_completed_batch_indices()
+    # One decode for the whole setup. The file now carries the spillover -- 131 MB of base64 for a
+    # 1000 s tail -- and every `load_checkpoint` decodes all of it, so each convenience getter used
+    # here would pay that again before the run started.
+    checkpoint = checkpoint_manager.load_checkpoint() or {}
+    # A set, matching what `get_completed_batch_indices` returned: it is compared against
+    # `reconcile_completed_batches`'s output below, and a list never equals a set, which silently
+    # sends every resume down the "outputs are missing" branch.
+    loaded_batch_indices = set(checkpoint.get("completed_batch_indices") or [])
     resuming = bool(loaded_batch_indices)
 
     # Reconcile the checkpoint against the filesystem: a batch may be recorded as
@@ -1237,11 +1244,8 @@ def execute_plan(  # noqa: PLR0915
         spillover_batch_index = None
     elif completed_batch_indices == loaded_batch_indices:
         logger.info("Loaded checkpoint: %d batches already completed", len(completed_batch_indices))
-        # One load for everything below. Each `load_checkpoint` decodes the whole file including the
-        # spillover, which is 131 MB of base64 for a 1000 s tail, so calling the individual getters
-        # here would pay that decode once per getter before the run even starts. The per-batch
-        # scoping the getters would apply is done at the restore call instead, from these values.
-        checkpoint = checkpoint_manager.load_checkpoint() or {}
+        # From the single decode above. The per-batch scoping the getter would apply is done at the
+        # restore call instead, from these values.
         last_simulator_state = checkpoint.get("last_simulator_state")
         last_simulator_state = last_simulator_state if isinstance(last_simulator_state, dict) else None
         last_simulator_spillover = checkpoint.get("last_simulator_spillover")
@@ -1320,9 +1324,11 @@ def execute_plan(  # noqa: PLR0915
                     # that produced it.
                     spillover_for_batch = (
                         last_simulator_spillover
-                        if (
-                            spillover_simulator_name == batch.simulator_name
-                            and spillover_batch_index == batch.batch_index - 1
+                        if spillover_applies(
+                            spillover_simulator_name,
+                            spillover_batch_index,
+                            batch.simulator_name,
+                            batch.batch_index,
                         )
                         else None
                     )

--- a/src/gwmock/cli/utils/checkpoint.py
+++ b/src/gwmock/cli/utils/checkpoint.py
@@ -25,7 +25,8 @@ class CheckpointManager:
         "completed_batch_indices": [0, 1, 2, ...],
         "last_simulator_name": "signal",
         "last_completed_batch_index": 2,
-        "last_simulator_state": {...}
+        "last_simulator_state": {...},
+        "last_simulator_spillover": ...  # chunks continuing into the next segment, or null
     }
 
     The checkpoint is written atomically:
@@ -191,17 +192,33 @@ class CheckpointManager:
         last_state = checkpoint.get("last_simulator_state")
         return last_state if isinstance(last_state, dict) else None
 
-    def get_last_simulator_spillover(self) -> Any:
+    def get_last_simulator_spillover(self, simulator_name: str | None = None, batch_index: int | None = None) -> Any:
         """Return the spillover chunks saved with the last completed batch, if any.
 
         ``None`` both when the checkpoint predates this field and when the last segment had no
         spillover, which are the same thing to a caller: there is nothing to carry in.
+
+        Args:
+            simulator_name: Restrict to spillover produced by this simulator. A plan can execute
+                several, and the checkpoint holds one tail; without this the wrong simulator can
+                receive it. ``None`` skips the check, for callers that have already established it.
+            batch_index: The batch about to run. Spillover is only valid for the batch immediately
+                following the one that produced it.
 
         Returns:
             The chunks that belong to the next segment, or ``None``.
         """
         checkpoint = self.load_checkpoint()
         if checkpoint is None:
+            return None
+        if simulator_name is not None and checkpoint.get("last_simulator_name") != simulator_name:
+            # A plan can hold several simulators, and only one of them produced this tail. Handing
+            # it to another would inject one simulator's spillover into another's segment -- wrong
+            # data that looks entirely plausible, since it is real strain of the right shape.
+            return None
+        if batch_index is not None and checkpoint.get("last_completed_batch_index") != batch_index - 1:
+            # Spillover belongs to the batch immediately after the one that produced it. Restoring
+            # it anywhere else places a tail at the wrong time.
             return None
         return checkpoint.get("last_simulator_spillover")
 

--- a/src/gwmock/cli/utils/checkpoint.py
+++ b/src/gwmock/cli/utils/checkpoint.py
@@ -14,6 +14,50 @@ from gwmock.data.serialize.encoder import Encoder
 logger = logging.getLogger("gwmock")
 
 
+def spillover_applies(
+    saved_simulator_name: str | None,
+    saved_batch_index: int | None,
+    simulator_name: str | None,
+    batch_index: int | None,
+) -> bool:
+    """Whether spillover saved by one batch may be given to another.
+
+    One function rather than the same two comparisons at each call site: the checkpoint getter and
+    ``execute_plan`` both need this, and the reason `execute_plan` cannot simply call the getter is
+    cost -- each load decodes the whole file, spillover included. Two copies of a predicate this
+    consequential would drift.
+
+    Both conditions guard against a *wrongly accepted* tail, which is worse than a rejected one: it
+    is real strain of the right shape placed at the wrong time, in the wrong simulator's segment,
+    and nothing downstream would flag it.
+
+    ``None`` for either caller-supplied value skips that check, for callers that have already
+    established it.
+
+    **Not checked, and it cannot be from here:** whether the checkpoint belongs to *this plan* at
+    all. Nothing in a checkpoint identifies the config that produced it, so reusing a checkpoint
+    directory across two different runs with the same simulator name and batch numbering will pass
+    both tests below. That predates spillover -- ``last_simulator_state`` was never scoped either --
+    but spillover makes the consequence bigger. Tracked as
+    ``gwmock/checkpoint-has-no-plan-identity``.
+
+    Args:
+        saved_simulator_name: ``last_simulator_name`` from the checkpoint.
+        saved_batch_index: ``last_completed_batch_index`` from the checkpoint.
+        simulator_name: The simulator about to run, or ``None`` to skip the check.
+        batch_index: The batch about to run, or ``None`` to skip the check.
+
+    Returns:
+        ``True`` if the saved spillover belongs to this simulator and batch.
+    """
+    if simulator_name is not None and saved_simulator_name != simulator_name:
+        return False
+    # Spillover belongs to the batch immediately after the one that produced it. A plan whose batch
+    # indices are not contiguous therefore rejects spillover it could have used -- which loses a
+    # tail rather than misplacing one, the safe direction, and no such plan exists today.
+    return not (batch_index is not None and saved_batch_index != batch_index - 1)
+
+
 class CheckpointManager:
     """Manages checkpoint files for simulation recovery.
 
@@ -211,14 +255,12 @@ class CheckpointManager:
         checkpoint = self.load_checkpoint()
         if checkpoint is None:
             return None
-        if simulator_name is not None and checkpoint.get("last_simulator_name") != simulator_name:
-            # A plan can hold several simulators, and only one of them produced this tail. Handing
-            # it to another would inject one simulator's spillover into another's segment -- wrong
-            # data that looks entirely plausible, since it is real strain of the right shape.
-            return None
-        if batch_index is not None and checkpoint.get("last_completed_batch_index") != batch_index - 1:
-            # Spillover belongs to the batch immediately after the one that produced it. Restoring
-            # it anywhere else places a tail at the wrong time.
+        if not spillover_applies(
+            checkpoint.get("last_simulator_name"),
+            checkpoint.get("last_completed_batch_index"),
+            simulator_name,
+            batch_index,
+        ):
             return None
         return checkpoint.get("last_simulator_spillover")
 

--- a/src/gwmock/cli/utils/checkpoint.py
+++ b/src/gwmock/cli/utils/checkpoint.py
@@ -91,6 +91,7 @@ class CheckpointManager:
         last_simulator_name: str,
         last_completed_batch_index: int,
         last_simulator_state: dict[str, Any],
+        last_simulator_spillover: Any = None,
     ) -> None:
         """Save checkpoint after completing a batch.
 
@@ -99,6 +100,18 @@ class CheckpointManager:
             last_simulator_name: Name of the simulator that completed the batch
             last_completed_batch_index: Index of the batch that just completed
             last_simulator_state: State dict of the simulator after completion
+            last_simulator_spillover: Chunks that extend past the completed segment and belong to
+                the next one -- the tail of any signal crossing the boundary.
+
+                Carried **beside** the state rather than in it, deliberately. ``state`` is also
+                serialized into every batch metadata record, and those are provenance documents
+                meant to stay small and readable; spillover is raw samples, megabytes of them for a
+                long inspiral. Putting it in ``state`` would bloat every metadata record and, since
+                those are written with plain ``json``, fail outright on a ``TimeSeriesList``.
+
+                Without this a resumed run starts with no spillover, so the tail is never placed and
+                the segment after the resume point silently loses that content: a measured peak of
+                8.6e-22 became 0.0, with the merger simply absent.
 
         Raises:
             OSError: If checkpoint cannot be written
@@ -108,6 +121,7 @@ class CheckpointManager:
             "last_simulator_name": last_simulator_name,
             "last_completed_batch_index": last_completed_batch_index,
             "last_simulator_state": last_simulator_state,
+            "last_simulator_spillover": last_simulator_spillover,
         }
 
         # Write to temp file first (atomic write pattern)
@@ -176,6 +190,20 @@ class CheckpointManager:
             return None
         last_state = checkpoint.get("last_simulator_state")
         return last_state if isinstance(last_state, dict) else None
+
+    def get_last_simulator_spillover(self) -> Any:
+        """Return the spillover chunks saved with the last completed batch, if any.
+
+        ``None`` both when the checkpoint predates this field and when the last segment had no
+        spillover, which are the same thing to a caller: there is nothing to carry in.
+
+        Returns:
+            The chunks that belong to the next segment, or ``None``.
+        """
+        checkpoint = self.load_checkpoint()
+        if checkpoint is None:
+            return None
+        return checkpoint.get("last_simulator_spillover")
 
     def should_skip_batch(self, batch_index: int) -> bool:
         """Check if a batch has already been completed.

--- a/src/gwmock/data/time_series/time_series.py
+++ b/src/gwmock/data/time_series/time_series.py
@@ -449,7 +449,17 @@ class TimeSeries(JSONSerializable):
         """
         return {
             "__type__": "TimeSeries",
-            "data": [self[i].value.tolist() for i in range(self.num_of_channels)],
+            # The raw array, not `tolist()`. The encoder base64s an ndarray and writes JSON text
+            # numbers for a list, and that is not cosmetic once spillover chunks go into a
+            # checkpoint written after every batch. Measured at 100 s x 3 detectors, 4096 Hz:
+            # 44.1 MB and 9.02 s as lists (35.9 bytes/sample) against 13.1 MB and 0.43 s as base64
+            # (10.7 bytes/sample). At a realistic 1000 s binary-neutron-star tail, measured rather
+            # than extrapolated: 131 MB and 1.1 s, which is 1.33x the raw float64 bytes.
+            #
+            # Not free of loss: base64 here goes through whatever dtype the array holds, and the
+            # constructor widens float32 to float64 on the way back, so a narrow chunk returns wider
+            # than it left. That predates this and costs memory rather than accuracy.
+            "data": np.asarray([self[i].value for i in range(self.num_of_channels)]),
             # Carried because a serialized chunk is a *spillover tail* waiting in a checkpoint, and
             # the next segment reads exactly these on restore. Omitting them restores the samples
             # while silently dropping `injection_parameters` and `event_id` -- so the run continues

--- a/src/gwmock/data/time_series/time_series.py
+++ b/src/gwmock/data/time_series/time_series.py
@@ -456,9 +456,10 @@ class TimeSeries(JSONSerializable):
             # (10.7 bytes/sample). At a realistic 1000 s binary-neutron-star tail, measured rather
             # than extrapolated: 131 MB and 1.1 s, which is 1.33x the raw float64 bytes.
             #
-            # Not free of loss: base64 here goes through whatever dtype the array holds, and the
-            # constructor widens float32 to float64 on the way back, so a narrow chunk returns wider
-            # than it left. That predates this and costs memory rather than accuracy.
+            # It also fixes a loss the list form had: `tolist()` went through Python floats and
+            # widened float32 to float64 on the way back. Base64 carries the dtype, so a float32
+            # chunk returns float32 -- checked for both widths rather than assumed, because the
+            # comment here previously claimed the opposite and was wrong.
             "data": np.asarray([self[i].value for i in range(self.num_of_channels)]),
             # Carried because a serialized chunk is a *spillover tail* waiting in a checkpoint, and
             # the next segment reads exactly these on restore. Omitting them restores the samples

--- a/src/gwmock/data/time_series/time_series.py
+++ b/src/gwmock/data/time_series/time_series.py
@@ -450,6 +450,20 @@ class TimeSeries(JSONSerializable):
         return {
             "__type__": "TimeSeries",
             "data": [self[i].value.tolist() for i in range(self.num_of_channels)],
+            # Carried because a serialized chunk is a *spillover tail* waiting in a checkpoint, and
+            # the next segment reads exactly these on restore. Omitting them restores the samples
+            # while silently dropping `injection_parameters` and `event_id` -- so the run continues
+            # with data that no longer says which signal it is -- and drops the channel identity
+            # that `inject` copies onto a tail for the same reason.
+            "metadata": dict(self.metadata),
+            "channels": [
+                {
+                    "name": self[i].name,
+                    "channel": None if self[i].channel is None else str(self[i].channel),
+                    "unit": str(self[i].unit),
+                }
+                for i in range(self.num_of_channels)
+            ],
             "start_time": self.start_time.value,
             "start_time_unit": str(self.start_time.unit),
             "sampling_frequency": self.sampling_frequency.value,
@@ -469,4 +483,20 @@ class TimeSeries(JSONSerializable):
         data = np.array(json_dict["data"])
         start_time = Quantity(json_dict["start_time"], unit=json_dict["start_time_unit"])
         sampling_frequency = Quantity(json_dict["sampling_frequency"], unit=json_dict["sampling_frequency_unit"])
-        return cls(data=data, start_time=start_time, sampling_frequency=sampling_frequency)
+        series = cls(data=data, start_time=start_time, sampling_frequency=sampling_frequency)
+
+        # Both keys are absent from records written before this was carried, so both default rather
+        # than raise: a checkpoint is read by whatever version happens to resume the run, and
+        # refusing an older one would turn an upgrade mid-run into a lost run.
+        series.metadata.update(json_dict.get("metadata") or {})
+        for index, channel in enumerate(json_dict.get("channels") or []):
+            if index >= series.num_of_channels:
+                break
+            target = series[index]
+            target.name = channel.get("name")
+            target.channel = channel.get("channel")
+            unit = channel.get("unit")
+            if unit is not None:
+                # `unit` is read-only on a gwpy array; override_unit is the supported way to set it.
+                target.override_unit(unit)
+        return series

--- a/src/gwmock/mixin/time_series.py
+++ b/src/gwmock/mixin/time_series.py
@@ -79,6 +79,18 @@ class TimeSeriesMixin:  # pylint: disable=too-few-public-methods,too-many-instan
     """
 
     start_time = StateAttribute(Quantity(0, unit="s"))
+    #: Spillover: the part of a chunk that extends past the segment being built, waiting for the
+    #: next one.
+    #:
+    #: **Not a `StateAttribute`, and not for want of trying.** A resumed run starts with none of it,
+    #: so the tail of any signal crossing the resume point is never placed and the following segment
+    #: loses that content silently -- 8.6e-22 to 0.0, the merger absent. The obvious fix, making this
+    #: stateful, does not work: `state` is serialized into every *batch metadata record* as well as
+    #: into the checkpoint, so it would write the spillover samples into a provenance document that
+    #: is meant to stay small and readable -- megabytes of base64 per record -- and those records are
+    #: dumped with plain `json`, which has no encoder for a `TimeSeriesList`. Persisting spillover
+    #: needs a checkpoint-only channel, separate from `state`. Tracked as
+    #: `gwmock/spillover-lost-on-checkpoint-resume`.
     cached_data_chunks = TimeSeriesList()
     #: Injection records for every signal that reaches the segment currently being built, including
     #: signals generated for an *earlier* segment whose content extends into this one. Rebuilt per

--- a/src/gwmock/mixin/time_series.py
+++ b/src/gwmock/mixin/time_series.py
@@ -82,28 +82,25 @@ class TimeSeriesMixin:  # pylint: disable=too-few-public-methods,too-many-instan
     #: Spillover: the part of a chunk that extends past the segment being built, waiting for the
     #: next one.
     #:
-    #: **Not a `StateAttribute`, and not for want of trying.** A resumed run starts with none of it,
-    #: so the tail of any signal crossing the resume point is never placed and the following segment
-    #: loses that content silently -- 8.6e-22 to 0.0, the merger absent. The obvious fix, making this
-    #: stateful, does not work: `state` is serialized into every *batch metadata record* as well as
-    #: into the checkpoint, so it would write the spillover samples into a provenance document that
-    #: is meant to stay small and readable -- megabytes of base64 per record -- and those records are
-    #: dumped with plain `json`, which has no encoder for a `TimeSeriesList`. Persisting spillover
-    #: needs a checkpoint-only channel, separate from `state`. Tracked as
-    #: `gwmock/spillover-lost-on-checkpoint-resume`.
+    #: **Not a `StateAttribute`, deliberately, and it is still persisted.** It used to be neither,
+    #: and a resumed run started with none of it: the tail of any signal crossing the resume point
+    #: was never placed and the following segment lost that content silently -- 7.280e-23 to exactly
+    #: 0.0, the merger absent, with the frames before it bit-identical.
+    #:
+    #: The obvious fix, making this stateful, does not work: `state` is serialized into every *batch
+    #: metadata record* as well as into the checkpoint, so it would write spillover samples into a
+    #: provenance document meant to stay small and readable, and those records are dumped with plain
+    #: `json`, which has no encoder for a `TimeSeriesList`. So it travels as its own checkpoint
+    #: field, `last_simulator_spillover`, scoped to the simulator and batch that produced it.
     cached_data_chunks = TimeSeriesList()
     #: Injection records for every signal that reaches the segment currently being built, including
     #: signals generated for an *earlier* segment whose content extends into this one. Rebuilt per
     #: segment by :meth:`simulate`; a subclass writing provenance should union this with whatever it
     #: generated itself. Empty for simulators that do not inject.
     #:
-    #: **Lost across a checkpoint resume**, along with the samples themselves: ``cached_data_chunks``
-    #: is not a :class:`~gwmock.simulator.state.StateAttribute`, so a resumed run regenerates neither
-    #: the spillover nor its record, and the segment after the resume point silently loses the rest of
-    #: any signal crossing it. That is a data bug older than this attribute -- the samples go missing
-    #: whether or not anything records them -- so it is tracked separately as
-    #: ``gwmock/spillover-lost-on-checkpoint-resume`` rather than papered over here. What it means for
-    #: provenance is that "recorded against every frame it reaches" is false at exactly that boundary.
+    #: Survives a checkpoint resume, because the chunks carrying these records do: see
+    #: ``cached_data_chunks`` above. It did not until the spillover was persisted -- a resumed run
+    #: lost both the samples and their provenance at the resume boundary.
     carried_injections: list[dict[str, Any]]
 
     def __init__(

--- a/tests/cli/test_spillover_survives_resume.py
+++ b/tests/cli/test_spillover_survives_resume.py
@@ -1,0 +1,175 @@
+#
+# Copyright (C) 2026 Leuven Gravity Institute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+"""A resumed run must place the tail of a signal that crosses the resume point.
+
+Measured on ``main`` with a 1.6+1.4 binary from 30 Hz across 32 s segments: interrupt after the
+first batch checkpoints, re-run the same config, and the third frame -- the one holding the
+**merger** -- comes back at a peak of exactly ``0.0`` against ``7.280e-23`` uninterrupted. The two
+frames before it are bit-identical, so nothing about the run looks wrong; the loudest part of the
+signal is simply absent.
+
+The cause is that spillover lived only in memory. ``cached_data_chunks`` holds the part of a chunk
+extending past the segment being built, and it was neither a ``StateAttribute`` nor saved anywhere
+else, so a resumed process started with none of it.
+
+Two things had to be right, and they fail independently:
+
+* the checkpoint has to carry the chunks at all, and carry their ``metadata`` with them -- restoring
+  the samples while dropping ``injection_parameters`` and ``event_id`` would look like a fix while
+  losing the provenance the frames are indexed by;
+* ``restore_batch_state`` has to put them back on the simulator.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from astropy.units.quantity import Quantity
+
+from gwmock.cli.utils.checkpoint import CheckpointManager
+from gwmock.data.time_series.time_series import TimeSeries
+from gwmock.data.time_series.time_series_list import TimeSeriesList
+
+
+def _chunk(start: float = 100.0, samples: int = 8, event_id: int = 3) -> TimeSeries:
+    chunk = TimeSeries(
+        data=np.arange(1.0, samples + 1.0).reshape(1, samples),
+        start_time=Quantity(start, unit="s"),
+        sampling_frequency=Quantity(8.0, unit="Hz"),
+    )
+    chunk.metadata.update({"injection_parameters": {"coa_time": start + 1.0}, "event_id": event_id})
+    chunk[0].name = "H1:STRAIN"
+    return chunk
+
+
+class TestTheCheckpointCarriesSpillover:
+    """The serialization half."""
+
+    def test_samples_and_provenance_both_survive(self, tmp_path):
+        """Both, because restoring one without the other is the failure that looks like success.
+
+        ``to_json_dict`` carried neither ``metadata`` nor the channel identity, so a fix that only
+        made the chunks reachable would have resumed with data that no longer says which signal it
+        is -- and ``inject`` copies the channel name onto a tail deliberately, for the same reason.
+        """
+        manager = CheckpointManager(tmp_path)
+        manager.save_checkpoint([0], "orchestration", 0, {"counter": 1}, TimeSeriesList([_chunk()]))
+
+        restored = manager.get_last_simulator_spillover()
+
+        assert len(restored) == 1
+        np.testing.assert_array_equal(np.asarray(restored[0]).ravel(), np.arange(1.0, 9.0))
+        assert restored[0].metadata["event_id"] == 3
+        assert restored[0].metadata["injection_parameters"] == {"coa_time": 101.0}
+        # `restored[0]` is the first *series*; its channels are indexed one level in.
+        assert restored[0][0].name == "H1:STRAIN"
+        assert float(restored[0].start_time.value) == 100.0
+
+    def test_a_checkpoint_written_before_this_field_reads_as_no_spillover(self, tmp_path):
+        """An upgrade mid-run must not turn a resumable checkpoint into a crash.
+
+        ``None`` covers both "written by an older gwmock" and "that segment had no spillover", which
+        are the same thing to the caller: there is nothing to carry in.
+        """
+        import json
+
+        (tmp_path / "simulation.checkpoint.json").write_text(
+            json.dumps(
+                {
+                    "completed_batch_indices": [0],
+                    "last_simulator_name": "orchestration",
+                    "last_completed_batch_index": 0,
+                    "last_simulator_state": {"counter": 1},
+                }
+            )
+        )
+
+        assert CheckpointManager(tmp_path).get_last_simulator_spillover() is None
+
+
+class TestRestorePutsSpilloverBack:
+    """The wiring half, which the serialization test above cannot reach."""
+
+    @staticmethod
+    def _simulator_and_batch():
+        from gwmock.cli.utils.simulation_plan import SimulationBatch
+
+        class _Simulator:
+            def __init__(self):
+                self.cached_data_chunks = TimeSeriesList()
+                self.counter = 1
+
+            @property
+            def state(self):
+                return {"counter": self.counter}
+
+            @state.setter
+            def state(self, value):
+                self.counter = value.get("counter", self.counter)
+
+        batch = SimulationBatch.__new__(SimulationBatch)
+        object.__setattr__(batch, "batch_index", 1)
+        object.__setattr__(batch, "simulator_name", "orchestration")
+        object.__setattr__(batch, "metadata", None)
+        return _Simulator(), batch
+
+    def test_the_simulator_gets_the_chunks(self):
+        """Without this the checkpoint holds the tail and nothing ever reads it back."""
+        from gwmock.cli.simulate_utils import restore_batch_state
+
+        simulator, batch = self._simulator_and_batch()
+        spillover = TimeSeriesList([_chunk()])
+
+        restore_batch_state(simulator, batch, {"counter": 1}, spillover)
+
+        assert len(simulator.cached_data_chunks) == 1
+        assert simulator.cached_data_chunks[0].metadata["event_id"] == 3
+
+    def test_no_spillover_leaves_the_simulator_alone(self):
+        """A resumed run whose previous segment spilled nothing must not be handed an empty list.
+
+        The distinction matters because ``None`` and ``TimeSeriesList()`` are both falsy: assigning
+        unconditionally would work here and silently clobber chunks in any caller that had already
+        populated them.
+        """
+        from gwmock.cli.simulate_utils import restore_batch_state
+
+        simulator, batch = self._simulator_and_batch()
+        simulator.cached_data_chunks = TimeSeriesList([_chunk(event_id=9)])
+
+        restore_batch_state(simulator, batch, {"counter": 1}, None)
+
+        assert len(simulator.cached_data_chunks) == 1
+        assert simulator.cached_data_chunks[0].metadata["event_id"] == 9
+
+
+@pytest.mark.integration
+def test_a_resumed_run_keeps_the_merger():
+    """The end-to-end statement, recorded here because the unit tests cannot make it.
+
+    Not automated: it needs a real interrupt at a real checkpoint boundary, and the timing is
+    process-dependent. Reproduced by hand on 2026-08-06 with the config in the investigation record,
+    interrupting once ``.gwmock_checkpoints/simulation.checkpoint.json`` appears and re-running:
+
+    ======================  ==============  =================  ===================
+    frame                   uninterrupted   resumed on main    resumed with fix
+    ======================  ==============  =================  ===================
+    ...540                  1.286e-23       1.286e-23          1.286e-23
+    ...572                  1.837e-23       1.837e-23          1.837e-23
+    ...604 (merger)         7.280e-23       **0.000e+00**      7.280e-23
+    ======================  ==============  =================  ===================
+
+    Skipped rather than deleted so the procedure stays with the code it describes.
+    """
+    pytest.skip("manual: requires interrupting a real run at a checkpoint boundary")

--- a/tests/cli/test_spillover_survives_resume.py
+++ b/tests/cli/test_spillover_survives_resume.py
@@ -188,24 +188,51 @@ class TestARetryDoesNotConsumeTheSpillover:
     success, so nothing would say which of the two a frame came from.
     """
 
-    def test_the_retry_restore_is_wired_to_both(self):
-        """Reads the closure `execute_plan` builds, so a revert to state-only fails here.
+    def test_a_forced_failure_leaves_the_second_attempt_the_same_tail(self):
+        """A real retry, not an inspection of the source that implements one.
 
-        Inspecting the source rather than running a failing batch: provoking a real retry needs a
-        write failure deep inside `execute_plan`, and the thing worth pinning is only that the
-        closure touches both attributes.
+        An earlier version of this test read `execute_plan`'s closure with `inspect.getsource`. That
+        catches a revert to state-only and nothing else -- it cannot tell whether restoring the tail
+        actually gives the second attempt the same input. This drives `retry_with_backoff` with the
+        same capture-and-restore `execute_plan` builds, and a callable that fails once.
+
+        The assertion is what each attempt *consumed*: with the restore, both attempts see the full
+        tail; without it, the second sees what the first left behind.
         """
-        import inspect
+        import copy
 
-        from gwmock.cli import simulate_utils
+        from gwmock.cli.simulate_utils import retry_with_backoff
 
-        source = inspect.getsource(simulate_utils.execute_plan)
-        start = source.index("def restore_state_for_retry(")
-        closure = source[start : source.index("# Execute batch with retry", start)]
+        class _Simulator:
+            def __init__(self):
+                self.cached_data_chunks = TimeSeriesList([_chunk(event_id=4)])
+                self.state = {"counter": 0}
 
-        assert "_simulator.state" in closure
-        assert "cached_data_chunks" in closure, (
-            "the retry restores state but not spillover, so a retried batch runs from consumed chunks"
+        simulator = _Simulator()
+        pre_batch_state = copy.deepcopy(simulator.state)
+        pre_batch_spillover = copy.deepcopy(simulator.cached_data_chunks)
+
+        consumed: list[int] = []
+
+        def _attempt():
+            # What `TimeSeriesMixin.simulate` does to this attribute: read it, then replace it with
+            # the new tail. The second attempt therefore starts from whatever the first left.
+            consumed.append(len(simulator.cached_data_chunks))
+            simulator.cached_data_chunks = TimeSeriesList()
+            if len(consumed) == 1:
+                raise RuntimeError("forced write failure")
+            return "ok"
+
+        def _restore(_simulator=simulator, _state=pre_batch_state, _spillover=pre_batch_spillover):
+            _simulator.state = copy.deepcopy(_state)
+            _simulator.cached_data_chunks = copy.deepcopy(_spillover)
+
+        result = retry_with_backoff(_attempt, max_retries=2, initial_delay=0.0, state_restore_func=_restore)
+
+        assert result == "ok"
+        assert consumed == [1, 1], (
+            f"the two attempts consumed {consumed}; [1, 0] means the retry ran from chunks the "
+            f"first attempt had already taken, so it would write different data"
         )
 
 
@@ -305,6 +332,7 @@ def test_a_resumed_run_places_the_tail_end_to_end(tmp_path):
     On the unfixed code the third peak is exactly 0.0 against 7.280e-23.
     """
     pytest.importorskip("ripplegw", reason="ripplegw not installed")
+    import json
     import signal as signal_module
     import subprocess
     import time
@@ -332,6 +360,15 @@ def test_a_resumed_run_places_the_tail_end_to_end(tmp_path):
         while not checkpoint.exists() and process.poll() is None and time.monotonic() < deadline:
             time.sleep(0.1)
         assert checkpoint.exists(), "no checkpoint was written, so there was nothing to resume from"
+        # The one way this test could pass without testing anything: if the interrupt lands after
+        # the *last* batch has checkpointed, the resume has nothing left to do and the frames match
+        # trivially. Reading the checkpoint here rules that out rather than trusting the timing.
+        completed = set(json.loads(checkpoint.read_text()).get("completed_batch_indices") or [])
+        assert completed, "the checkpoint records no completed batch, so there is nothing to resume from"
+        assert len(completed) < 3, (
+            f"the interrupt landed with batches {sorted(completed)} complete out of 3; the resume "
+            f"would have nothing to carry, so this run proves nothing"
+        )
         process.send_signal(signal_module.SIGINT)
         process.wait(timeout=120)
     finally:

--- a/tests/cli/test_spillover_survives_resume.py
+++ b/tests/cli/test_spillover_survives_resume.py
@@ -179,6 +179,36 @@ class TestRestorePutsSpilloverBack:
         assert simulator.cached_data_chunks[0].metadata["event_id"] == 9
 
 
+class TestARetryDoesNotConsumeTheSpillover:
+    """A retried batch must start from the same tail the first attempt did.
+
+    `simulate` consumes `cached_data_chunks` and replaces it with the *new* tail, so restoring only
+    `state` on retry leaves the second attempt working from consumed chunks. It would then write
+    different data than the first attempt tried to -- and a retry that succeeds looks like a
+    success, so nothing would say which of the two a frame came from.
+    """
+
+    def test_the_retry_restore_is_wired_to_both(self):
+        """Reads the closure `execute_plan` builds, so a revert to state-only fails here.
+
+        Inspecting the source rather than running a failing batch: provoking a real retry needs a
+        write failure deep inside `execute_plan`, and the thing worth pinning is only that the
+        closure touches both attributes.
+        """
+        import inspect
+
+        from gwmock.cli import simulate_utils
+
+        source = inspect.getsource(simulate_utils.execute_plan)
+        start = source.index("def restore_state_for_retry(")
+        closure = source[start : source.index("# Execute batch with retry", start)]
+
+        assert "_simulator.state" in closure
+        assert "cached_data_chunks" in closure, (
+            "the retry restores state but not spillover, so a retried batch runs from consumed chunks"
+        )
+
+
 _RESUME_CONFIG = """
 globals:
     simulator-arguments:

--- a/tests/cli/test_spillover_survives_resume.py
+++ b/tests/cli/test_spillover_survives_resume.py
@@ -98,6 +98,31 @@ class TestTheCheckpointCarriesSpillover:
         assert CheckpointManager(tmp_path).get_last_simulator_spillover() is None
 
 
+class TestSpilloverIsScopedToItsOwnBatch:
+    """One checkpoint holds one tail, and handing it to the wrong consumer is worse than losing it.
+
+    A plan can execute several simulators, and a lost tail is a hole -- visible, once you look for
+    it. A *misplaced* tail is real strain of the right shape at the wrong time, in the wrong
+    simulator's segment, and nothing downstream would flag it.
+    """
+
+    def test_another_simulators_spillover_is_refused(self, tmp_path):
+        manager = CheckpointManager(tmp_path)
+        manager.save_checkpoint([0], "orchestration", 0, {"counter": 1}, TimeSeriesList([_chunk()]))
+
+        assert manager.get_last_simulator_spillover("noise", 1) is None
+        assert manager.get_last_simulator_spillover("orchestration", 1) is not None
+
+    def test_spillover_is_refused_for_any_batch_but_the_next_one(self, tmp_path):
+        """It belongs to the batch immediately after the one that produced it, and nowhere else."""
+        manager = CheckpointManager(tmp_path)
+        manager.save_checkpoint([0], "orchestration", 0, {"counter": 1}, TimeSeriesList([_chunk()]))
+
+        assert manager.get_last_simulator_spillover("orchestration", 1) is not None
+        assert manager.get_last_simulator_spillover("orchestration", 0) is None, "the batch that produced it"
+        assert manager.get_last_simulator_spillover("orchestration", 2) is None, "a later batch"
+
+
 class TestRestorePutsSpilloverBack:
     """The wiring half, which the serialization test above cannot reach."""
 
@@ -154,22 +179,142 @@ class TestRestorePutsSpilloverBack:
         assert simulator.cached_data_chunks[0].metadata["event_id"] == 9
 
 
-@pytest.mark.integration
-def test_a_resumed_run_keeps_the_merger():
-    """The end-to-end statement, recorded here because the unit tests cannot make it.
+_RESUME_CONFIG = """
+globals:
+    simulator-arguments:
+        sampling-frequency: 1024
+        duration: 32
+        total-duration: 96
+        start-time: 1000000540
+    working-directory: .
+    output-directory: output
+    metadata-directory: metadata
 
-    Not automated: it needs a real interrupt at a real checkpoint boundary, and the timing is
-    process-dependent. Reproduced by hand on 2026-08-06 with the config in the investigation record,
-    interrupting once ``.gwmock_checkpoints/simulation.checkpoint.json`` appears and re-running:
+orchestration:
+    population:
+        backend: FilePopulationLoader
+        source-type: bns
+        arguments:
+            path: pop.csv
+    signal:
+        waveform-model: IMRPhenomXPHM
+        minimum-frequency: 30
+        earth-rotation: true
+        detectors:
+            - ET-Triangle-Sardinia
+        output:
+            output_directory: signal
+            file_name: 'E-{{ detectors }}_STRAIN_BNS-{{ start_time }}-{{ duration }}.gwf'
+            arguments:
+                channel: '{{ detectors }}:STRAIN'
+"""
 
-    ======================  ==============  =================  ===================
-    frame                   uninterrupted   resumed on main    resumed with fix
-    ======================  ==============  =================  ===================
-    ...540                  1.286e-23       1.286e-23          1.286e-23
-    ...572                  1.837e-23       1.837e-23          1.837e-23
-    ...604 (merger)         7.280e-23       **0.000e+00**      7.280e-23
-    ======================  ==============  =================  ===================
+#: A 1.6+1.4 binary coalescing 6 s into the third 32 s segment. From 30 Hz its inspiral runs about
+#: 48 s, so it spans all three -- which is the only reason this test can see anything.
+_RESUME_POPULATION = (
+    "detector_frame_mass_1,detector_frame_mass_2,coa_time,distance,"
+    "declination,right_ascension,polarization_angle,inclination\n"
+    "1.6,1.4,1000000610.0,100.0,0.3,1.1,0.2,0.5\n"
+)
 
-    Skipped rather than deleted so the procedure stays with the code it describes.
+
+def _gwmock_executable() -> str:
+    """Return the absolute path to the console script, or skip.
+
+    Absolute rather than leaving PATH resolution to the subprocess: that is both a lint failure and
+    a real ambiguity when more than one environment is active.
     """
-    pytest.skip("manual: requires interrupting a real run at a checkpoint boundary")
+    import shutil
+
+    executable = shutil.which("gwmock")
+    if executable is None:
+        pytest.skip("the gwmock console script is not on PATH")
+    return executable
+
+
+def _run_to_completion(directory):
+    import subprocess
+
+    subprocess.run(  # noqa: S603 - absolute path, resolved by `_gwmock_executable`
+        [_gwmock_executable(), "simulate", "config.yaml"],
+        cwd=directory,
+        capture_output=True,
+        check=True,
+        timeout=900,
+    )
+
+
+def _peaks(directory) -> list[float]:
+    import glob
+
+    from gwpy.io.gwf import iter_channel_names
+    from gwpy.timeseries import TimeSeries as GWpyTimeSeries
+
+    files = sorted(glob.glob(str(directory / "output" / "signal" / "*ET1*.gwf")))
+    if not files:
+        return []
+    channel = next(iter(iter_channel_names(files[0])))
+    return [float(np.max(np.abs(np.asarray(GWpyTimeSeries.read(f, channel).value)))) for f in files]
+
+
+@pytest.mark.integration
+def test_a_resumed_run_places_the_tail_end_to_end(tmp_path):
+    """Interrupt a real run at a real checkpoint, resume it, and require the merger back.
+
+    This is the only test here that guards the **save** side. Everything above hands the spillover
+    to ``save_checkpoint`` itself, so gutting the one call site in ``execute_plan`` leaves them all
+    green -- measured. It is also the only one that exercises the two halves together.
+
+    Deterministic despite involving a signal: the interrupt waits for
+    ``simulation.checkpoint.json`` to appear rather than for a wall-clock delay, so it lands after a
+    batch has committed however slow the machine is. If the file never appears the test fails on the
+    timeout rather than passing vacuously.
+
+    Compared against an uninterrupted run in a separate directory rather than against a literal:
+    the peaks depend on the waveform model and would otherwise need updating whenever ripple changes.
+    On the unfixed code the third peak is exactly 0.0 against 7.280e-23.
+    """
+    pytest.importorskip("ripplegw", reason="ripplegw not installed")
+    import signal as signal_module
+    import subprocess
+    import time
+
+    executable = _gwmock_executable()
+
+    reference = tmp_path / "reference"
+    resumed = tmp_path / "resumed"
+    for directory in (reference, resumed):
+        directory.mkdir()
+        (directory / "config.yaml").write_text(_RESUME_CONFIG)
+        (directory / "pop.csv").write_text(_RESUME_POPULATION)
+
+    _run_to_completion(reference)
+    expected = _peaks(reference)
+    assert len(expected) == 3, f"the reference run wrote {len(expected)} frames, not 3"
+    assert expected[-1] > 0.0, "the reference run has no signal in the last frame, so this proves nothing"
+
+    checkpoint = resumed / ".gwmock_checkpoints" / "simulation.checkpoint.json"
+    process = subprocess.Popen(  # noqa: S603 - absolute path, resolved by `_gwmock_executable`
+        [executable, "simulate", "config.yaml"], cwd=resumed, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+    try:
+        deadline = time.monotonic() + 600.0
+        while not checkpoint.exists() and process.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.1)
+        assert checkpoint.exists(), "no checkpoint was written, so there was nothing to resume from"
+        process.send_signal(signal_module.SIGINT)
+        process.wait(timeout=120)
+    finally:
+        if process.poll() is None:  # pragma: no cover - only on an unexpected hang
+            process.kill()
+
+    _run_to_completion(resumed)
+
+    actual = _peaks(resumed)
+    assert len(actual) == len(expected)
+    for index, (got, want) in enumerate(zip(actual, expected, strict=True)):
+        # atol=0.0: these are ~1e-23, and any default absolute tolerance would make two arbitrary
+        # strain arrays compare equal, so the assertion could not fail.
+        assert got == pytest.approx(want, rel=1e-9, abs=0.0), (
+            f"frame {index} differs after a resume: {got:.3e} against {want:.3e} uninterrupted"
+        )

--- a/tests/data/time_series/test_time_series.py
+++ b/tests/data/time_series/test_time_series.py
@@ -181,8 +181,12 @@ class TestTimeSeriesSerialization:
         assert "start_time_unit" in data
         assert "sampling_frequency" in data
         assert "sampling_frequency_unit" in data
-        assert isinstance(data["data"], list)
-        assert len(data["data"]) == sample_timeseries.num_of_channels
+        # An ndarray, not a list of lists: the encoder base64s an array and writes JSON text
+        # numbers for a list, 10.7 bytes per sample against 35.9. Spillover chunks now go into
+        # checkpoints, where measured on a 1000 s three-detector tail that is 131 MB and 1.1 s
+        # against 44.1 MB and 9.02 s per 100 s of it. What matters to a consumer is the shape.
+        assert isinstance(data["data"], np.ndarray)
+        assert data["data"].shape[0] == sample_timeseries.num_of_channels
 
     def test_from_json_dict_round_trip(self, sample_timeseries: TimeSeries):
         """Test round-trip serialization."""


### PR DESCRIPTION
## 📝 Summary

A run resumed from a checkpoint lost the tail of any signal crossing the resume point — the **samples**, not just the provenance. `cached_data_chunks` holds the part of a chunk extending past the segment being built, and it existed only in memory, so a resumed process started with none of it.

Same procedure both sides — 1.6+1.4 M☉ from 30 Hz across 32 s segments, interrupt once `.gwmock_checkpoints/simulation.checkpoint.json` appears, re-run:

| frame | uninterrupted | resumed on `main` | resumed with this |
|---|---|---|---|
| ...540 | 1.286e-23 | 1.286e-23 | 1.286e-23 |
| ...572 | 1.837e-23 | 1.837e-23 | 1.837e-23 |
| ...604 (merger) | 7.280e-23 | **0.000e+00** | 7.280e-23 |

The frames before the resume point are bit-identical, so nothing about the run looks wrong — the loudest part of the signal is simply absent.

**Two defects, and fixing either alone leaves a hole.** Besides the chunks being unreachable, `TimeSeries.to_json_dict` carried neither `metadata` nor channel identity, so restoring them would have restored samples that no longer say which signal they are — and `inject` copies the channel name onto a tail deliberately, for the same reason.

**Why spillover is not a `StateAttribute`**, which is the obvious fix and does not work: `state` is serialized into every *batch metadata record* as well as the checkpoint, so it would write megabytes of samples into a provenance document meant to stay small, and those records are dumped with plain `json`, which has no encoder for a `TimeSeriesList`. The whole suite fails with exactly that error, which is how the constraint was found. Spillover therefore travels as its own checkpoint field, `last_simulator_spillover`, **scoped to the simulator and batch that produced it** — a plan can execute several simulators, and handing one's tail to another is worse than losing it: real strain of the right shape at the wrong time, which nothing downstream would flag.

**Serialization cost, measured.** `.tolist()` bypassed the encoder's base64 path, which did not matter until spillover started going to disk after every batch. At 100 s × 3 detectors, 4096 Hz: 44.1 MB and 9.02 s as lists against 13.1 MB and 0.43 s as base64. Measured directly at a realistic 1000 s BNS tail rather than extrapolated: **131 MB and 1.1 s, 1.33× the raw float64 bytes**. Round-trip is exact, checked with `atol=0.0`. The checkpoint is also read once per plan rather than per batch, since re-reading 131 MB in the loop would pay that every time.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

Checkpoints gain a field; one written before this reads back as no spillover rather than raising, so an upgrade mid-run does not cost the run.

## 🧪 How Has This Been Tested?

**Run on `macmini`, not the primary machine (4 cores).** Own checkout per `_instructions/test-host-policy.md`. Two traps: `uv` is at `~/.local/bin/uv`, not on the non-interactive SSH PATH; and **do not `uv sync --all-extras`** — the `cuda` extra has no macOS wheel, the sync aborts, pytest never runs, and a failure count of 0 on the missing log reads exactly like a pass. Use `uv sync --extra jax --extra sgwb`, and check for the summary line.

- [x] Full suite: **1036 passed** on Linux and on macmini.
- [x] **End-to-end resume is automated**, not described: the test runs the CLI, waits for the checkpoint *file* rather than a wall-clock delay, interrupts, resumes, and compares against an uninterrupted run in a separate directory. Marked `integration`.
- [x] Every mechanism mutation-checked: stubbing the restore, dropping `metadata` from serialization, and gutting the save call site in `execute_plan` each fail their own test — the last at `0.000e+00 against 1.837e-23`.
- [x] Scoping tested both ways: another simulator's tail is refused, and so is any batch but the immediate successor.

Worth reviewers' attention:

- **The save side was the gap.** Every unit test handed the spillover to `save_checkpoint` directly, so gutting the one call site in `execute_plan` left them all green. A first attempt to close that spied on `save_checkpoint` and then called it directly — it asserts nothing about the call site and passed with the site gutted, so it was deleted rather than kept.
- **Known and not fixed:** dtype widens across the round trip (float32 → float64; costs memory, not accuracy). The other restore branch, which resumes from a batch metadata record, still cannot carry spillover because those records hold no samples by design — stated at the call site. Two independent reviewers disagreed about how reachable that branch is in a real resume, and I have not resolved it.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

## 📷 Screenshots (if applicable)

Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resuming an interrupted simulation now preserves pending spillover data, helping produce results consistent with uninterrupted runs.
  - Spillover is restored only for the matching simulator and immediately following batch, including retry scenarios.
  - Existing checkpoints without spillover remain compatible.

- **Improvements**
  - Time series data now preserves channel names, identifiers, units, and metadata during serialization and restoration.
  - Checkpointed time series data uses a more efficient format while retaining available channel information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->