### PR TITLE
fix(checkpoint): refuse to resume from a checkpoint another run wrote

### DIFF
--- a/src/gwmock/cli/simulate.py
+++ b/src/gwmock/cli/simulate.py
@@ -58,6 +58,7 @@ def _maybe_isolate(
     isolate: bool,
     output_dir: str | None,
     overwrite: bool,
+    ignore_checkpoint: bool = False,
     author: str | None,
     email: str | None,
     dry_run: bool = False,
@@ -103,6 +104,8 @@ def _maybe_isolate(
         child_args += ["--output-dir", output_dir]
     if overwrite:
         child_args.append("--overwrite")
+    if ignore_checkpoint:
+        child_args.append("--ignore-checkpoint")
     if author:
         child_args += ["--author", author]
     if email:
@@ -120,6 +123,7 @@ def _simulate_impl(  # pylint: disable=too-many-locals, too-many-branches, too-m
     output_dir: str | None = None,
     metadata_dir: str | None = None,
     overwrite: bool = False,
+    ignore_checkpoint: bool = False,
     metadata: bool = True,
     author: str | None = None,
     email: str | None = None,
@@ -198,6 +202,7 @@ def _simulate_impl(  # pylint: disable=too-many-locals, too-many-branches, too-m
                 isolate=isolate,
                 output_dir=output_dir,
                 overwrite=overwrite,
+                ignore_checkpoint=ignore_checkpoint,
                 author=author,
                 email=email,
                 dry_run=dry_run,
@@ -280,6 +285,7 @@ def _simulate_impl(  # pylint: disable=too-many-locals, too-many-branches, too-m
                 output_directory=final_output_dir,
                 metadata_directory=final_metadata_dir or Path("metadata"),
                 overwrite=overwrite,
+                ignore_checkpoint=ignore_checkpoint,
                 max_retries=3,
             )
 
@@ -311,6 +317,16 @@ def simulate_command(
         ),
     ] = None,
     overwrite: Annotated[bool, typer.Option("--overwrite", help="Overwrite existing files.")] = False,
+    ignore_checkpoint: Annotated[
+        bool,
+        typer.Option(
+            "--ignore-checkpoint",
+            help=(
+                "Start fresh, ignoring any checkpoint in the directory. Use when a resume is refused "
+                "because the checkpoint belongs to a different run and you know it is stale."
+            ),
+        ),
+    ] = False,
     metadata: Annotated[bool, typer.Option("--metadata", help="Generate metadata files (only in config mode).")] = True,
     author: Annotated[str | None, typer.Option("--author", help="Author name for the simulation.")] = None,
     email: Annotated[str | None, typer.Option("--email", help="Author email for the simulation.")] = None,
@@ -363,6 +379,7 @@ def simulate_command(
         output_dir=output_dir,
         metadata_dir=metadata_dir,
         overwrite=overwrite,
+        ignore_checkpoint=ignore_checkpoint,
         metadata=metadata,
         author=author,
         email=email,

--- a/src/gwmock/cli/simulate.py
+++ b/src/gwmock/cli/simulate.py
@@ -120,6 +120,11 @@ def _maybe_isolate(
 
 def _simulate_impl(  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
     config_file_names: str | list[str],
+    # Keyword-only: these are seven options of which five are bools, so a positional call binds them
+    # by accident rather than by intent. `ignore_checkpoint` sits between two of those bools and
+    # skips the checkpoint when truthy, which is the failure this change exists to prevent. Every
+    # caller already passes by keyword, so nothing is broken by saying so.
+    *,
     output_dir: str | None = None,
     metadata_dir: str | None = None,
     overwrite: bool = False,

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -26,7 +26,7 @@ from gwmock_noise import SimulationResult
 from tqdm import tqdm
 
 from gwmock.cli.adapter_orchestration import AdapterOrchestrationResult, AdapterOrchestrator
-from gwmock.cli.utils.checkpoint import CheckpointManager, spillover_applies
+from gwmock.cli.utils.checkpoint import CheckpointManager, require_matching_config, spillover_applies
 from gwmock.cli.utils.config import OrchestrationConfig, SimulatorConfig, resolve_class_path
 from gwmock.cli.utils.environment import capture_environment
 from gwmock.cli.utils.hash import compute_content_hash, compute_file_hash
@@ -1225,6 +1225,12 @@ def execute_plan(  # noqa: PLR0915
     # 1000 s tail -- and every `load_checkpoint` decodes all of it, so each convenience getter used
     # here would pay that again before the run started.
     checkpoint = checkpoint_manager.load_checkpoint() or {}
+    # Checked before anything is read from it. A checkpoint another configuration wrote will
+    # otherwise be believed: the batches it records as complete are skipped and their outputs never
+    # produced, with no warning and exit code 0.
+    plan_sha256 = next((batch.config_sha256 for batch in plan.batches if batch.config_sha256), None)
+    if checkpoint:
+        require_matching_config(checkpoint.get("config_sha256"), plan_sha256, checkpoint_manager.checkpoint_file)
     # A set, matching what `get_completed_batch_indices` returned: it is compared against
     # `reconcile_completed_batches`'s output below, and a list never equals a set, which silently
     # sends every resume down the "outputs are missing" branch.
@@ -1419,6 +1425,7 @@ def execute_plan(  # noqa: PLR0915
                         # Beside the state, not inside it: `state` also goes into every batch
                         # metadata record, and spillover is raw samples. See `save_checkpoint`.
                         last_simulator_spillover=copy.deepcopy(getattr(simulator, "cached_data_chunks", None)),
+                        config_sha256=plan_sha256,
                     )
                     logger.debug(
                         "Checkpoint saved after batch %d - state counter=%s",

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -1181,6 +1181,10 @@ def execute_plan(  # noqa: PLR0915
     output_directory: Path,
     metadata_directory: Path,
     overwrite: bool,
+    # Keyword-only from here. Inserting `ignore_checkpoint` before `max_retries` made a positional
+    # call bind the retry count to it -- any non-zero count is truthy and would silently skip the
+    # checkpoint, which is the failure this whole change exists to prevent.
+    *,
     ignore_checkpoint: bool = False,
     max_retries: int = 3,
 ) -> None:
@@ -1213,6 +1217,8 @@ def execute_plan(  # noqa: PLR0915
         output_directory: Directory for output files
         metadata_directory: Directory for metadata files
         overwrite: Whether to overwrite existing files
+        ignore_checkpoint: Discard any checkpoint in the directory and start fresh. The way past
+            a refused resume for a caller that cannot delete the file by hand.
         max_retries: Maximum retries per batch
     """
     logger.info("Executing simulation plan: %d batches", plan.total_batches)

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -26,7 +26,7 @@ from gwmock_noise import SimulationResult
 from tqdm import tqdm
 
 from gwmock.cli.adapter_orchestration import AdapterOrchestrationResult, AdapterOrchestrator
-from gwmock.cli.utils.checkpoint import CheckpointManager, require_matching_config, spillover_applies
+from gwmock.cli.utils.checkpoint import CheckpointManager, require_matching_config, run_fingerprint, spillover_applies
 from gwmock.cli.utils.config import OrchestrationConfig, SimulatorConfig, resolve_class_path
 from gwmock.cli.utils.environment import capture_environment
 from gwmock.cli.utils.hash import compute_content_hash, compute_file_hash
@@ -1181,6 +1181,7 @@ def execute_plan(  # noqa: PLR0915
     output_directory: Path,
     metadata_directory: Path,
     overwrite: bool,
+    ignore_checkpoint: bool = False,
     max_retries: int = 3,
 ) -> None:
     """Execute a complete simulation plan.
@@ -1224,11 +1225,20 @@ def execute_plan(  # noqa: PLR0915
     # One decode for the whole setup. The file now carries the spillover -- 131 MB of base64 for a
     # 1000 s tail -- and every `load_checkpoint` decodes all of it, so each convenience getter used
     # here would pay that again before the run started.
-    checkpoint = checkpoint_manager.load_checkpoint() or {}
+    # `--ignore-checkpoint` discards it here rather than deleting the file: the refusal below is a
+    # dead end for anything that cannot answer a prompt -- an automated campaign would fail on a
+    # stale file with no way forward but manual intervention -- and deleting on the user's behalf is
+    # the one action that cannot be undone.
+    checkpoint = {} if ignore_checkpoint else (checkpoint_manager.load_checkpoint() or {})
+    if ignore_checkpoint:
+        logger.warning("Ignoring any checkpoint in %s: --ignore-checkpoint was given.", plan.checkpoint_directory)
     # Checked before anything is read from it. A checkpoint another configuration wrote will
     # otherwise be believed: the batches it records as complete are skipped and their outputs never
     # produced, with no warning and exit code 0.
-    plan_sha256 = next((batch.config_sha256 for batch in plan.batches if batch.config_sha256), None)
+    # Not `batch.config_sha256` on its own: that hashes the config *file*, so the same file run with
+    # a different `--output-dir` fingerprints identically and the guard waves it through -- measured
+    # at 2 frames where a clean run writes 3. The identity has to include where the outputs go.
+    plan_sha256 = run_fingerprint([batch.config_sha256 for batch in plan.batches], output_directory, metadata_directory)
     if checkpoint:
         require_matching_config(checkpoint.get("config_sha256"), plan_sha256, checkpoint_manager.checkpoint_file)
     # A set, matching what `get_completed_batch_indices` returned: it is compared against

--- a/src/gwmock/cli/utils/checkpoint.py
+++ b/src/gwmock/cli/utils/checkpoint.py
@@ -14,6 +14,57 @@ from gwmock.data.serialize.encoder import Encoder
 logger = logging.getLogger("gwmock")
 
 
+class ForeignCheckpointError(RuntimeError):
+    """A checkpoint in this directory was written by a different configuration."""
+
+
+def require_matching_config(saved_sha256: str | None, plan_sha256: str | None, checkpoint_file: Path) -> None:
+    """Refuse to resume from a checkpoint another configuration wrote.
+
+    **Why this refuses instead of quietly starting fresh.** Silently ignoring the checkpoint would
+    fix the data loss and hide its cause: the user would be left with a stale checkpoint in the
+    directory, no idea it was there, and a full re-run they did not ask for. Refusing says which two
+    things collided and lets them choose. It is also the safer default -- deleting someone's
+    checkpoint on their behalf is not recoverable, and stopping is.
+
+    **What went wrong without it,** measured: two configs run from one working directory, the first
+    interrupted after two batches. The second loaded the first's checkpoint, skipped those batches as
+    already complete, and wrote one frame where a clean run writes three. Exit code 0, no warning.
+    `_batch_outputs_present` does not catch it because it looks up
+    ``{simulator_name}-{batch_index}.metadata.json`` -- a name with nothing config-specific in it --
+    and then verifies the outputs *that file* records, so the first run's metadata satisfies the
+    check on the second run's behalf.
+
+    A checkpoint written before this field existed has ``None`` and is accepted, with a warning. The
+    alternative -- refusing -- would break a legitimate resume for anyone who upgrades mid-run, which
+    is a certain cost against an uncertain one.
+
+    Args:
+        saved_sha256: ``config_sha256`` from the checkpoint, or ``None`` if it predates the field.
+        plan_sha256: Hash of the configuration about to run, or ``None`` if unavailable.
+        checkpoint_file: Path named in the error, so the message says what to delete or move.
+
+    Raises:
+        ForeignCheckpointError: If both hashes are known and they differ.
+    """
+    if saved_sha256 is None:
+        logger.warning(
+            "Checkpoint %s predates configuration fingerprinting, so it cannot be checked against "
+            "the configuration being run. If it was written by a different config, batches it "
+            "records as complete will be skipped and their outputs never produced.",
+            checkpoint_file,
+        )
+        return
+    if plan_sha256 is None or saved_sha256 == plan_sha256:
+        return
+    raise ForeignCheckpointError(
+        f"The checkpoint at {checkpoint_file} was written by a different configuration "
+        f"(checkpoint {saved_sha256[:12]}, this run {plan_sha256[:12]}). Resuming from it would "
+        f"skip the batches it records as complete and never produce their outputs. Delete or move "
+        f"the checkpoint to start this configuration fresh, or run it from its own directory."
+    )
+
+
 def spillover_applies(
     saved_simulator_name: str | None,
     saved_batch_index: int | None,
@@ -70,7 +121,8 @@ class CheckpointManager:
         "last_simulator_name": "signal",
         "last_completed_batch_index": 2,
         "last_simulator_state": {...},
-        "last_simulator_spillover": ...  # chunks continuing into the next segment, or null
+        "last_simulator_spillover": ...,  # chunks continuing into the next segment, or null
+        "config_sha256": "..."  # which configuration produced this run, or null if pre-1.5.0
     }
 
     The checkpoint is written atomically:
@@ -137,6 +189,7 @@ class CheckpointManager:
         last_completed_batch_index: int,
         last_simulator_state: dict[str, Any],
         last_simulator_spillover: Any = None,
+        config_sha256: str | None = None,
     ) -> None:
         """Save checkpoint after completing a batch.
 
@@ -158,6 +211,11 @@ class CheckpointManager:
                 the segment after the resume point silently loses that content: a measured peak of
                 8.6e-22 became 0.0, with the merger simply absent.
 
+            config_sha256: Hash of the configuration that produced this run, so a resume can tell
+                whether the checkpoint belongs to it. Without this a second config run from the same
+                working directory resumes from the first's checkpoint and *skips its batches*:
+                measured at 1 frame written where a clean run writes 3, exit code 0, no warning.
+
         Raises:
             OSError: If checkpoint cannot be written
         """
@@ -167,6 +225,7 @@ class CheckpointManager:
             "last_completed_batch_index": last_completed_batch_index,
             "last_simulator_state": last_simulator_state,
             "last_simulator_spillover": last_simulator_spillover,
+            "config_sha256": config_sha256,
         }
 
         # Write to temp file first (atomic write pattern)

--- a/src/gwmock/cli/utils/checkpoint.py
+++ b/src/gwmock/cli/utils/checkpoint.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import logging
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +14,50 @@ from gwmock.data.serialize.decoder import Decoder
 from gwmock.data.serialize.encoder import Encoder
 
 logger = logging.getLogger("gwmock")
+
+
+def run_fingerprint(config_hashes: Iterable[str | None], output_directory: Path, metadata_directory: Path) -> str:
+    """Identify a run by everything that decides where its outputs go, not just its config file.
+
+    The config file hash alone is not the run. Two invocations of the *same* file with different
+    ``--output-dir`` produce identical hashes, so a checkpoint from the first is accepted by the
+    second, which then skips the batches it records and writes nothing for them into the new
+    directory -- measured at 2 frames where a clean run writes 3. That is the bug the fingerprint
+    exists to stop, arriving through a different door.
+
+    The output and metadata directories are resolved, so ``./out`` and an absolute path to the same
+    place are one run rather than two, and a relative path is not mistaken for a different one when
+    the working directory changes.
+
+    Every batch's config hash goes in, not the first: a plan assembled from several metadata records
+    can mix configurations, and taking one of them would let the rest through unchecked.
+
+    **Two things it does not cover, both verified in review rather than assumed.**
+
+    *Cosmetic edits refuse a valid resume.* The hash is over config bytes, so adding a comment or
+    reindenting changes it and a legitimate resume is turned away. Annoying, and the safe direction;
+    ``--ignore-checkpoint`` is the way out.
+
+    *External inputs are invisible.* The same config file with a different population CSV behind it
+    fingerprints identically, so a resume can mix the old catalogue's completed batches with the new
+    one's remaining batches. This does not make anything worse than before -- nothing checked it
+    previously either -- but it is the sharp edge left in this guard, and hashing referenced inputs
+    is the fix if it ever bites.
+
+    Args:
+        config_hashes: Per-batch ``config_sha256`` values, in plan order. ``None`` entries are kept
+            as a literal marker rather than dropped, so a plan with an unhashed batch does not
+            fingerprint the same as one without that batch.
+        output_directory: Where this run writes its data.
+        metadata_directory: Where this run writes its metadata and index.
+
+    Returns:
+        A hex digest identifying the run.
+    """
+    parts = [hash_value if hash_value is not None else "<none>" for hash_value in config_hashes]
+    parts.append(str(Path(output_directory).resolve()))
+    parts.append(str(Path(metadata_directory).resolve()))
+    return hashlib.sha256("\x00".join(parts).encode("utf-8")).hexdigest()
 
 
 class ForeignCheckpointError(RuntimeError):
@@ -37,7 +83,12 @@ def require_matching_config(saved_sha256: str | None, plan_sha256: str | None, c
 
     A checkpoint written before this field existed has ``None`` and is accepted, with a warning. The
     alternative -- refusing -- would break a legitimate resume for anyone who upgrades mid-run, which
-    is a certain cost against an uncertain one.
+    is a certain cost against an uncertain one. **The residual is real:** every pre-fingerprint
+    checkpoint stays exactly as exposed as before, and interrupted runs are precisely the population
+    that resumes, so this is not a rare corner. It closes as those checkpoints age out.
+
+    ``--ignore-checkpoint`` exists because refusing is otherwise a dead end for anything that cannot
+    answer a prompt.
 
     Args:
         saved_sha256: ``config_sha256`` from the checkpoint, or ``None`` if it predates the field.

--- a/tests/cli/test_checkpoint_plan_identity.py
+++ b/tests/cli/test_checkpoint_plan_identity.py
@@ -34,7 +34,12 @@ from pathlib import Path
 
 import pytest
 
-from gwmock.cli.utils.checkpoint import CheckpointManager, ForeignCheckpointError, require_matching_config
+from gwmock.cli.utils.checkpoint import (
+    CheckpointManager,
+    ForeignCheckpointError,
+    require_matching_config,
+    run_fingerprint,
+)
 
 #: Only ever formatted into an error message -- nothing here opens it -- so any path serves. Named
 #: rather than written inline so it does not read as a real location a test might depend on.
@@ -78,6 +83,51 @@ class TestTheGuardItself:
     def test_an_unknown_plan_hash_is_allowed(self):
         """Nothing to compare against is not evidence of a mismatch."""
         require_matching_config("a" * 64, None, _ANY_CHECKPOINT)
+
+
+class TestTheFingerprintIsTheRunNotTheConfigFile:
+    """The config hash alone is not run identity, and treating it as one leaves the bug reachable.
+
+    Found in review after the first version of this fix shipped the narrower identity: the same
+    config file with a different ``--output-dir`` hashes identically, so the checkpoint is accepted
+    and its batches skipped -- measured at 2 frames where a clean run writes 3.
+    """
+
+    def test_the_output_directory_changes_it(self, tmp_path):
+        first = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta")
+        second = run_fingerprint(["a" * 64], tmp_path / "out2", tmp_path / "meta")
+        assert first != second
+
+    def test_the_metadata_directory_changes_it(self, tmp_path):
+        first = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta")
+        second = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta2")
+        assert first != second
+
+    def test_an_equivalent_path_does_not(self, tmp_path):
+        """Resolved, so `./out` and its absolute form are one run -- a false refusal is still a bug."""
+        (tmp_path / "out").mkdir()
+        (tmp_path / "meta").mkdir()
+        first = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta")
+        second = run_fingerprint(["a" * 64], tmp_path / "out" / ".", tmp_path / "meta")
+        assert first == second
+
+    def test_every_batch_hash_counts_not_just_the_first(self, tmp_path):
+        """A plan assembled from several metadata records can mix configs; one of them is not enough."""
+        first = run_fingerprint(["a" * 64, "b" * 64], tmp_path / "out", tmp_path / "meta")
+        second = run_fingerprint(["a" * 64, "c" * 64], tmp_path / "out", tmp_path / "meta")
+        assert first != second
+
+    def test_an_unhashed_batch_is_not_the_same_as_no_batch(self, tmp_path):
+        """`None` is kept as a marker; dropping it would collapse two different plans onto one id."""
+        first = run_fingerprint(["a" * 64, None], tmp_path / "out", tmp_path / "meta")
+        second = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta")
+        assert first != second
+
+    def test_the_same_run_fingerprints_the_same(self, tmp_path):
+        """The property every resume depends on: unchanged inputs give an unchanged identity."""
+        assert run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta") == run_fingerprint(
+            ["a" * 64], tmp_path / "out", tmp_path / "meta"
+        )
 
 
 class TestTheFingerprintSurvivesTheCheckpoint:
@@ -148,6 +198,62 @@ def test_a_second_configuration_in_the_same_directory_is_refused_end_to_end(tmp_
     assert "different configuration" in (second.stdout + second.stderr)
     written = list((tmp_path / "output" / "signal").glob("*B-*.gwf"))
     assert not written, f"the refused run still wrote {[p.name for p in written]}"
+
+
+@pytest.mark.integration
+def test_ignore_checkpoint_gets_past_the_refusal(tmp_path):
+    """The refusal must have a way out that is not "delete the file by hand".
+
+    Without one it is a dead end for anything that cannot answer a prompt: an automated campaign
+    that knows the checkpoint is stale would fail on it with no forward path. Raised in review, and
+    the reason the default stays a refusal rather than a warning -- the escape is explicit, so
+    nothing is skipped by accident.
+    """
+    pytest.importorskip("ripplegw", reason="ripplegw not installed")
+    import json
+    import shutil
+    import signal as signal_module
+    import subprocess
+    import time
+
+    executable = shutil.which("gwmock")
+    if executable is None:
+        pytest.skip("the gwmock console script is not on PATH")
+
+    (tmp_path / "pop_a.csv").write_text(_POPULATION.format(mass_1="1.6", mass_2="1.4"))
+    (tmp_path / "a.yaml").write_text(_CONFIG.format(population="pop_a.csv", tag="A"))
+
+    checkpoint = tmp_path / ".gwmock_checkpoints" / "simulation.checkpoint.json"
+    first = subprocess.Popen(  # noqa: S603 - absolute path from `shutil.which`
+        [executable, "simulate", "a.yaml"], cwd=tmp_path, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+    try:
+        deadline = time.monotonic() + 600.0
+        while not checkpoint.exists() and first.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.1)
+        assert checkpoint.exists()
+        assert json.loads(checkpoint.read_text()).get("completed_batch_indices")
+        first.send_signal(signal_module.SIGINT)
+        first.wait(timeout=120)
+    finally:
+        if first.poll() is None:  # pragma: no cover - only on an unexpected hang
+            first.kill()
+
+    # A different output directory is a different run, so this would be refused without the flag --
+    # which the test above pins. Here it must go through and produce a complete dataset.
+    completed = subprocess.run(  # noqa: S603 - absolute path from `shutil.which`
+        [executable, "simulate", "a.yaml", "--output-dir", "elsewhere", "--ignore-checkpoint"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=900,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "different configuration" not in (completed.stdout + completed.stderr)
+    frames = sorted((tmp_path / "elsewhere" / "signal").glob("*ET1*.gwf"))
+    assert len(frames) == 3, f"ignoring the checkpoint should give a complete run, got {[f.name for f in frames]}"
 
 
 _POPULATION = (

--- a/tests/cli/test_checkpoint_plan_identity.py
+++ b/tests/cli/test_checkpoint_plan_identity.py
@@ -104,11 +104,20 @@ class TestTheFingerprintIsTheRunNotTheConfigFile:
         assert first != second
 
     def test_an_equivalent_path_does_not(self, tmp_path):
-        """Resolved, so `./out` and its absolute form are one run -- a false refusal is still a bug."""
+        """Two spellings of one directory are one run -- a false refusal is still a bug.
+
+        Uses ``out/../out`` rather than ``out/.``: `Path` collapses a lone ``.`` at construction, so
+        that spelling never reaches `resolve()` and the assertion compared a value with itself. ``..``
+        survives construction, so this exercises the normalization it claims to. The premise is
+        asserted rather than assumed, because that is precisely what went wrong the first time.
+        """
         (tmp_path / "out").mkdir()
         (tmp_path / "meta").mkdir()
+        roundabout = tmp_path / "out" / ".." / "out"
+        assert str(roundabout) != str(tmp_path / "out"), "the spellings collapsed before resolve(); this proves nothing"
+
         first = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta")
-        second = run_fingerprint(["a" * 64], tmp_path / "out" / ".", tmp_path / "meta")
+        second = run_fingerprint(["a" * 64], roundabout, tmp_path / "meta")
         assert first == second
 
     def test_every_batch_hash_counts_not_just_the_first(self, tmp_path):
@@ -127,6 +136,30 @@ class TestTheFingerprintIsTheRunNotTheConfigFile:
         """The property every resume depends on: unchanged inputs give an unchanged identity."""
         assert run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta") == run_fingerprint(
             ["a" * 64], tmp_path / "out", tmp_path / "meta"
+        )
+
+
+class TestTheEscapeHatchCannotBeBoundByAccident:
+    """`ignore_checkpoint` skips the guard, so nothing may reach it positionally.
+
+    It was inserted before `max_retries`, which is an int: a positional call passing a retry count
+    would bind it here, and any non-zero count is truthy. The checkpoint would be skipped silently,
+    which is the exact failure this change exists to prevent -- reintroduced by an argument order.
+    """
+
+    @pytest.mark.parametrize(
+        ("module", "name"),
+        [("gwmock.cli.simulate_utils", "execute_plan"), ("gwmock.cli.simulate", "_simulate_impl")],
+    )
+    def test_it_is_keyword_only(self, module, name):
+        import importlib
+        import inspect
+
+        parameter = inspect.signature(getattr(importlib.import_module(module), name)).parameters["ignore_checkpoint"]
+
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY, (
+            f"{name} accepts ignore_checkpoint positionally, so a caller passing a later argument "
+            f"by position can switch off the checkpoint guard without meaning to"
         )
 
 

--- a/tests/cli/test_checkpoint_plan_identity.py
+++ b/tests/cli/test_checkpoint_plan_identity.py
@@ -1,0 +1,187 @@
+#
+# Copyright (C) 2026 Leuven Gravity Institute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+"""A checkpoint must say which configuration wrote it, and a resume must check.
+
+Measured before this existed: two configs run from one working directory, the first interrupted
+after two of three batches. The second **loaded the first's checkpoint, skipped those batches as
+already complete, and wrote one frame where a clean run writes three** — exit code 0, no warning.
+Silent data loss from an ordinary action, since every shipped example puts `.gwmock_checkpoints` and
+`metadata/` relative to the working directory.
+
+`_batch_outputs_present` does not catch it, and cannot: it looks up
+``{simulator_name}-{batch_index}.metadata.json`` — a name with nothing config-specific in it — and
+then verifies the outputs *that file* records. The first run's metadata records the first run's
+frames, which exist, so the check passes on one run's evidence while a different run is executing.
+
+The refusal is deliberate rather than a silent fresh start: ignoring the foreign checkpoint would fix
+the data loss and hide its cause, leaving a stale checkpoint in place and an unexplained full re-run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gwmock.cli.utils.checkpoint import CheckpointManager, ForeignCheckpointError, require_matching_config
+
+#: Only ever formatted into an error message -- nothing here opens it -- so any path serves. Named
+#: rather than written inline so it does not read as a real location a test might depend on.
+_ANY_CHECKPOINT = Path("checkpoints") / "simulation.checkpoint.json"
+
+
+class TestTheGuardItself:
+    """`require_matching_config`, isolated from everything that has to call it."""
+
+    def test_a_different_configuration_is_refused(self):
+        with pytest.raises(ForeignCheckpointError, match="different configuration"):
+            require_matching_config("a" * 64, "b" * 64, _ANY_CHECKPOINT)
+
+    def test_the_message_names_both_hashes_and_the_file(self):
+        """The user has to be able to act on it: which two collided, and what to move."""
+        with pytest.raises(ForeignCheckpointError) as raised:
+            require_matching_config("a" * 64, "b" * 64, Path("/runs/x/.gwmock_checkpoints/simulation.checkpoint.json"))
+
+        message = str(raised.value)
+        assert "aaaaaaaaaaaa" in message
+        assert "bbbbbbbbbbbb" in message
+        assert "/runs/x/.gwmock_checkpoints/simulation.checkpoint.json" in message
+
+    def test_the_same_configuration_is_allowed(self):
+        """The case that must not break: an ordinary resume of the run that wrote the checkpoint."""
+        require_matching_config("a" * 64, "a" * 64, _ANY_CHECKPOINT)
+
+    def test_a_checkpoint_without_a_hash_is_allowed_with_a_warning(self, caplog):
+        """Refusing would break a legitimate resume for anyone who upgrades mid-run.
+
+        A certain cost against an uncertain one, so it warns instead -- but it does warn, because the
+        checkpoint genuinely cannot be checked and the consequence if it is foreign is silent.
+        """
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            require_matching_config(None, "b" * 64, _ANY_CHECKPOINT)
+
+        assert "predates configuration fingerprinting" in caplog.text
+
+    def test_an_unknown_plan_hash_is_allowed(self):
+        """Nothing to compare against is not evidence of a mismatch."""
+        require_matching_config("a" * 64, None, _ANY_CHECKPOINT)
+
+
+class TestTheFingerprintSurvivesTheCheckpoint:
+    """It is only a guard if it is written, and written checkpoints are what a resume reads."""
+
+    def test_the_hash_is_saved_and_read_back(self, tmp_path):
+        manager = CheckpointManager(tmp_path)
+        manager.save_checkpoint([0], "orchestration", 0, {"counter": 1}, config_sha256="c" * 64)
+
+        assert (manager.load_checkpoint() or {}).get("config_sha256") == "c" * 64
+
+    def test_a_checkpoint_saved_without_one_reads_as_none(self, tmp_path):
+        """Not as a missing key: the guard distinguishes "unknown" from "known and different"."""
+        manager = CheckpointManager(tmp_path)
+        manager.save_checkpoint([0], "orchestration", 0, {"counter": 1})
+
+        assert (manager.load_checkpoint() or {}).get("config_sha256") is None
+
+
+@pytest.mark.integration
+def test_a_second_configuration_in_the_same_directory_is_refused_end_to_end(tmp_path):
+    """The whole failure, through the CLI, because the unit tests above cannot reach the wiring.
+
+    Two configs differing only in their population and output names, run from one directory. Before
+    the guard the second wrote 1 frame of 3 and exited 0; it must now refuse and write none.
+
+    Deterministic: the interrupt waits for the checkpoint file to appear rather than for a delay, so
+    it lands after a batch has committed however slow the machine is.
+    """
+    pytest.importorskip("ripplegw", reason="ripplegw not installed")
+    import json
+    import shutil
+    import signal as signal_module
+    import subprocess
+    import time
+
+    executable = shutil.which("gwmock")
+    if executable is None:
+        pytest.skip("the gwmock console script is not on PATH")
+
+    (tmp_path / "pop_a.csv").write_text(_POPULATION.format(mass_1="1.6", mass_2="1.4"))
+    (tmp_path / "pop_b.csv").write_text(_POPULATION.format(mass_1="30.0", mass_2="25.0"))
+    (tmp_path / "a.yaml").write_text(_CONFIG.format(population="pop_a.csv", tag="A"))
+    (tmp_path / "b.yaml").write_text(_CONFIG.format(population="pop_b.csv", tag="B"))
+
+    checkpoint = tmp_path / ".gwmock_checkpoints" / "simulation.checkpoint.json"
+    first = subprocess.Popen(  # noqa: S603 - absolute path from `shutil.which`
+        [executable, "simulate", "a.yaml"], cwd=tmp_path, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+    try:
+        deadline = time.monotonic() + 600.0
+        while not checkpoint.exists() and first.poll() is None and time.monotonic() < deadline:
+            time.sleep(0.1)
+        assert checkpoint.exists(), "no checkpoint was written, so there is nothing for the second run to find"
+        completed = set(json.loads(checkpoint.read_text()).get("completed_batch_indices") or [])
+        assert completed, "the checkpoint records no completed batch, so the second run would skip nothing"
+        first.send_signal(signal_module.SIGINT)
+        first.wait(timeout=120)
+    finally:
+        if first.poll() is None:  # pragma: no cover - only on an unexpected hang
+            first.kill()
+
+    second = subprocess.run(  # noqa: S603 - absolute path from `shutil.which`
+        [executable, "simulate", "b.yaml"], cwd=tmp_path, capture_output=True, text=True, timeout=900, check=False
+    )
+
+    assert second.returncode != 0, "the second configuration resumed from the first's checkpoint instead of refusing"
+    assert "different configuration" in (second.stdout + second.stderr)
+    written = list((tmp_path / "output" / "signal").glob("*B-*.gwf"))
+    assert not written, f"the refused run still wrote {[p.name for p in written]}"
+
+
+_POPULATION = (
+    "detector_frame_mass_1,detector_frame_mass_2,coa_time,distance,"
+    "declination,right_ascension,polarization_angle,inclination\n"
+    "{mass_1},{mass_2},1000000610.0,100.0,0.3,1.1,0.2,0.5\n"
+)
+
+_CONFIG = """
+globals:
+    simulator-arguments:
+        sampling-frequency: 1024
+        duration: 32
+        total-duration: 96
+        start-time: 1000000540
+    working-directory: .
+    output-directory: output
+    metadata-directory: metadata
+
+orchestration:
+    population:
+        backend: FilePopulationLoader
+        source-type: bns
+        arguments:
+            path: {population}
+    signal:
+        waveform-model: IMRPhenomXPHM
+        minimum-frequency: 30
+        earth-rotation: true
+        detectors:
+            - ET-Triangle-Sardinia
+        output:
+            output_directory: signal
+            file_name: 'E-{{{{ detectors }}}}_STRAIN_{tag}-{{{{ start_time }}}}-{{{{ duration }}}}.gwf'
+            arguments:
+                channel: '{{{{ detectors }}}}:STRAIN'
+"""


### PR DESCRIPTION
## 📝 Summary

Two configs run from one working directory, the first interrupted after two of its three batches. The second **loaded the first's checkpoint, skipped those batches as already complete, and wrote one frame where a clean run writes three** — exit code 0, no warning.

Silent data loss from an ordinary action: every shipped example puts `.gwmock_checkpoints` and `metadata/` relative to the working directory, so running two configs from one directory is a normal thing to do.

**The guard that exists for this cannot catch it.** `_batch_outputs_present` looks up `{simulator_name}-{batch_index}.metadata.json` — a name with nothing config-specific in it — then verifies the outputs *that file* records. The first run's metadata records the first run's frames, which exist, so the check passes on one run's evidence while a different run is executing.

Checkpoints now carry a **run fingerprint**: every batch's `config_sha256` plus the resolved output and metadata directories. `require_matching_config` refuses a mismatched resume before anything is read from the checkpoint, naming both hashes and the file so the user can see which two runs collided and what to move.

| scenario | before | after |
| --- | --- | --- |
| different config, same directory | 1 frame of 3, exit 0 | 0 frames, exit non-zero |
| same config, different `--output-dir` | 2 frames of 3, exit 0 | 0 frames, exit non-zero |
| legitimate resume of the same run | 3 frames | 3 frames |
| refused run with `--ignore-checkpoint` | — | 3 frames |

**Why the identity is the run, not the config file.** The first version of this fix hashed only the config file, which left the same bug reachable through `--output-dir` — reproduced at 2 frames of 3. Directories are resolved so `./out` and its absolute form stay one run; every batch's hash counts rather than the first, because a plan assembled from several metadata records can mix configurations.

**Why it refuses rather than silently starting fresh.** Ignoring the foreign checkpoint would fix the data loss and hide its cause — a stale checkpoint left in place and a full re-run nobody asked for. Refusing is also the recoverable direction: deleting someone's checkpoint on their behalf is not.

**`--ignore-checkpoint`** exists because a refusal with no way out is a dead end for an automated campaign that cannot answer a prompt. It discards the checkpoint for that invocation and warns; it deletes nothing. The default stays a refusal, so nothing is skipped by accident.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature — `--ignore-checkpoint`

Checkpoints gain a field. One written before this is accepted **with a warning** rather than refused, so upgrading mid-run does not break a legitimate resume.

## 🧪 How Has This Been Tested?

**Run on `macmini`, not the primary machine (4 cores).** Own checkout per `_instructions/test-host-policy.md`. Two traps: `uv` is at `~/.local/bin/uv`, not on the non-interactive SSH PATH; and **do not `uv sync --all-extras`** — the `cuda` extra has no macOS wheel, the sync aborts, pytest never runs, and a failure count of 0 on the missing log reads exactly like a pass. Use `uv sync --extra jax --extra sgwb` and check for the summary line.

- [x] Full suite: **1050 passed** on Linux and on macmini.
- [x] Every row of the table above reproduced through the CLI.
- [x] Both halves mutation-checked: removing the guard and not saving the fingerprint each fail the end-to-end test. The `--output-dir` hole and the escape hatch each have their own end-to-end test.
- [x] Fingerprint properties unit-tested: output directory, metadata directory, all batch hashes, path equivalence, and stability across identical inputs.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

## Known gaps, stated rather than fixed

All three established in review; none is worse than before this branch.

- **Cosmetic config edits refuse a valid resume.** The hash is over config bytes, so adding a comment or reindenting changes it. Safe direction, and `--ignore-checkpoint` is the way out.
- **External inputs are invisible.** The same config file with a different population CSV behind it fingerprints identically, so a resume can mix catalogues. Hashing referenced inputs is the fix if it bites.
- **Legacy checkpoints stay exposed.** A pre-fingerprint checkpoint is trusted with a warning, and interrupted runs are exactly the population that resumes, so this is not a rare corner. It closes as those checkpoints age out.

Separately, `gwmock/signal-index-concurrent-writers` shares the root cause — two runs sharing a directory — but `signal_index.yaml` has no fingerprint and is not gated here. Reviewers judged it lower severity, since the index is a rebuildable cache that `simulate` never consumes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to start simulations without using existing checkpoints.
  * Checkpoints now verify that saved progress matches the simulation configuration and output locations.
  * Compatible checkpoints continue to resume normally, while mismatched checkpoints are rejected with diagnostics.
  * Older checkpoints without configuration details remain supported with a warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->