### PR TITLE
fix(index): make signal-index updates safe against concurrent writers

### DIFF
--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -8,13 +8,16 @@ import atexit
 import copy
 import json
 import logging
+import os
 import platform
 import re
 import shutil
 import signal
 import subprocess
+import tempfile
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from importlib import import_module
 from importlib import metadata as importlib_metadata
 from pathlib import Path
@@ -591,6 +594,83 @@ def _withdraw_batch(index: dict[str, Any], metadata_file_name: str) -> dict[str,
     return migrated
 
 
+try:  # pragma: no cover - the except branch is unreachable on the supported platforms
+    import fcntl
+except ImportError:  # pragma: no cover - Windows, which the CI matrix does not cover
+    fcntl = None  # type: ignore[assignment]
+
+
+@contextmanager
+def _exclusive_index_lock(index_file: Path) -> Iterator[None]:
+    """Hold an exclusive cross-process lock for the whole read-modify-write of the index.
+
+    A lock is needed rather than a thread lock because the writers are separate *runs* sharing a
+    metadata directory, in separate interpreters. The lock lives in a sidecar file rather than on
+    the index itself: the index is replaced by :func:`_atomically_write_index`, and a lock held on
+    a replaced inode protects nothing once the rename lands.
+
+    The sidecar is created and left in place, never unlinked. Deleting it on release would let a
+    second process hold a lock on an unlinked inode while a third creates a fresh one and takes a
+    lock nobody else can see -- the classic unlink race. An empty stray file is the cheaper cost.
+
+    Where ``fcntl`` is unavailable (Windows, which this project does not test) the body runs
+    unlocked and says so once, rather than failing at import: an unsynchronised index is what the
+    caller had before, while an ImportError would take out a working single-writer run.
+
+    Args:
+        index_file: Path to ``signal_index.yaml``; the sidecar sits beside it.
+
+    Yields:
+        Nothing. The lock is held for the duration of the block.
+    """
+    if fcntl is None:  # pragma: no cover - not reachable on POSIX
+        logger.warning("fcntl unavailable: the signal index is updated without a lock, so concurrent runs can race.")
+        yield
+        return
+
+    lock_file = index_file.with_name(index_file.name + ".lock")
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    with lock_file.open("a+") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> None:
+    """Write the index so a reader sees either the old file or the new one, never a fragment.
+
+    ``open(path, "w")`` truncates in place, so a crash or a full disk part-way through the dump
+    leaves an unparsable file -- and the loader in :func:`update_signal_index` treats an
+    unparsable index as "create a new one", which turns one failed write into the silent loss of
+    every entry the index already held. Writing a sibling temporary and renaming makes the
+    replacement atomic within the directory, so a failure leaves the previous index untouched.
+
+    The temporary is created in the destination directory because ``os.replace`` is only atomic
+    within a filesystem, and ``/tmp`` is routinely a different one.
+
+    Args:
+        index_file: Destination path.
+        index: The index mapping to serialise.
+
+    Raises:
+        OSError: If the file cannot be written or renamed.
+        yaml.YAMLError: If the index cannot be serialised.
+    """
+    descriptor, name = tempfile.mkstemp(dir=index_file.parent, prefix=index_file.name + ".", suffix=".tmp")
+    temporary = Path(name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            yaml.safe_dump(index, handle, default_flow_style=False, sort_keys=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, index_file)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
 def update_signal_index(
     metadata_directory: Path,
     metadata: dict[str, Any],
@@ -603,15 +683,18 @@ def update_signal_index(
     frame file(s) that contain it plus the batch metadata file, enabling O(1)
     signal->frame lookup by id.
 
-    **Not safe against concurrent writers.** This is an unlocked read-modify-write, so two
-    processes updating the index at once can lose one side's contribution -- reproduced
-    deterministically with a barrier. It predates the per-batch accumulation below and is not
-    made worse by it, but the accumulation does change what is lost: a dropped update used to
-    cost one assignment, and now costs one batch's frames for every event in it. gwmock writes
-    batches sequentially within a run, so this bites only when two runs share a metadata
-    directory. Tracked as ``gwmock/signal-index-concurrent-writers``. Parameter-based lookup reads the injections
-    recorded in the batch metadata files (their source of truth); this index is
-    only the id shortcut. A batch with no injected signals writes nothing.
+    **Safe against concurrent writers**, which it was not before: the read-modify-write was
+    unlocked, so two runs sharing a metadata directory lost one side's events -- reproduced
+    deterministically with two processes and a barrier, where the loser's signals stayed in the
+    frames while vanishing from the id lookup. The whole cycle now runs under an exclusive
+    ``flock`` on a sidecar file, and the result is renamed into place rather than written over
+    the live index, so a failed or interrupted write leaves the previous index intact instead of
+    truncating it -- which mattered because the loader below treats an unparsable index as
+    "create a new one", turning one bad write into the loss of every entry.
+
+    Parameter-based lookup reads the injections recorded in the batch metadata files (their
+    source of truth); this index is only the id shortcut. A batch with no injected signals
+    writes nothing.
 
     Args:
         metadata_directory: Directory where metadata and the index live.
@@ -624,6 +707,30 @@ def update_signal_index(
     if not injections and not index_file.exists():
         return
 
+    with _exclusive_index_lock(index_file):
+        _update_signal_index_locked(index_file, injections, metadata, metadata_file_name, encoding)
+
+
+def _update_signal_index_locked(
+    index_file: Path,
+    injections: list[dict[str, Any]],
+    metadata: dict[str, Any],
+    metadata_file_name: str,
+    encoding: str,
+) -> None:
+    """Do the read-modify-write, with the caller holding the index lock.
+
+    Split out so the critical section is a single named span: the read, the withdrawal and the
+    write must all be inside one lock, and a reader of :func:`update_signal_index` should not have
+    to trace an indented block to confirm it.
+
+    Args:
+        index_file: Path to ``signal_index.yaml``.
+        injections: The batch's injected signals.
+        metadata: The batch metadata record just written.
+        metadata_file_name: File name of that batch metadata record.
+        encoding: File encoding for reading the index file.
+    """
     if index_file.exists():
         try:
             with index_file.open(encoding=encoding) as f:
@@ -659,8 +766,7 @@ def update_signal_index(
         entry["batches"].append({"metadata": metadata_file_name, "frames": signal_frames})
 
     try:
-        with index_file.open("w") as f:
-            yaml.safe_dump(index, f, default_flow_style=False, sort_keys=True)
+        _atomically_write_index(index_file, index)
     except (OSError, yaml.YAMLError) as e:
         logger.error("Failed to save signal index: %s", e)
         raise

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -625,12 +625,12 @@ def _exclusive_index_lock(index_file: Path) -> Iterator[None]:
     second process hold a lock on an unlinked inode while a third creates a fresh one and takes a
     lock nobody else can see -- the classic unlink race. An empty stray file is the cheaper cost.
 
-    **The sidecar carries the index's own mode**, which is not cosmetic: ``flock`` needs a
+    **The sidecar is never tighter than the index**, which is not cosmetic: ``flock`` needs a
     writable descriptor, so whoever may write the index must be able to open the sidecar for
     append. Leaving the sidecar at the umask default while the index is group-writable gives a
     second account read access to the index and a ``PermissionError`` at the lock -- the
-    multi-account case this locking exists to serve, broken at the gate. The two modes are kept
-    equal so the set of accounts that can take the lock is the set that can write the index.
+    multi-account case this locking exists to serve, broken at the gate. Alignment only ever
+    widens; see :func:`_align_lock_mode`.
 
     Where ``fcntl`` is unavailable (Windows, which this project does not test) the body runs
     unlocked and says so once, rather than failing at import: an unsynchronised index is what the
@@ -649,7 +649,19 @@ def _exclusive_index_lock(index_file: Path) -> Iterator[None]:
 
     lock_file = index_file.with_name(index_file.name + ".lock")
     lock_file.parent.mkdir(parents=True, exist_ok=True)
-    with lock_file.open("a+") as handle:
+    try:
+        handle = lock_file.open("a+")
+    except PermissionError as error:
+        # This, not the chmod below, is where a second account actually fails: `flock` needs a
+        # writable descriptor, so a sidecar tighter than the index stops a writer at the gate with
+        # a bare Errno 13 that says nothing about locks. Name the cause and the repair.
+        raise PermissionError(
+            f"Cannot open the signal-index lock at {lock_file} for writing, so this run cannot "
+            f"safely update {index_file.name}. Taking the lock needs write access to the sidecar; "
+            "have its owner widen it to match the index (the owner's next gwmock run does this "
+            "automatically)."
+        ) from error
+    with handle:
         # After the open, so the very first run aligns its own sidecar rather than leaving it at
         # the umask default for the next one to repair.
         _align_lock_mode(lock_file, index_file)
@@ -661,25 +673,33 @@ def _exclusive_index_lock(index_file: Path) -> Iterator[None]:
 
 
 def _align_lock_mode(lock_file: Path, index_file: Path) -> None:
-    """Give the sidecar the same permissions as the index, best effort.
+    """Widen the sidecar so everyone who may write the index can take the lock. Best effort.
 
-    Only the file's owner may ``chmod`` it, so this cannot be an invariant every caller can
-    restore: a second account finding a too-tight sidecar can do nothing about it, and should get
-    the eventual ``PermissionError`` rather than a confusing failure here. The owner's next run
-    repairs it, which also upgrades sidecars written before this behaviour existed.
+    **Widen only.** Matching the index exactly would also *narrow*, and a sidecar is a permission
+    surface in its own right: an operator may deliberately open it to an account that takes locks
+    without writing the index. Silently pulling that back on the owner's next run would remove a
+    capability with no signal and no opt-out, to fix a problem nobody had. Too-tight sidecars are
+    the failure this repairs; too-loose ones are somebody's decision.
+
+    Only the file's owner may ``chmod``, so this cannot be an invariant every caller restores.
+    The owner's next run repairs a sidecar written before this behaviour existed.
 
     Args:
         lock_file: The sidecar; may not exist yet.
-        index_file: The index whose mode the sidecar should match; may not exist yet either.
+        index_file: The index whose access the sidecar must not be tighter than.
     """
     desired = _existing_index_mode(index_file)
-    if desired is None:
+    current = _existing_index_mode(lock_file)
+    if desired is None or current is None:
+        return
+    widened = current | desired
+    if widened == current:
         return
     try:
-        if _existing_index_mode(lock_file) != desired:
-            os.chmod(lock_file, desired)
+        os.chmod(lock_file, widened)
     except (FileNotFoundError, PermissionError):
         return
+    logger.debug("Widened %s from %s to %s to match the index.", lock_file, oct(current), oct(widened))
 
 
 def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> None:

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -716,7 +716,13 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> None:
         if existing_mode is not None:
             # An index that already exists keeps whatever mode it was given, so a deliberately
             # group-writable index survives an update.
-            os.fchmod(descriptor, existing_mode)
+            #
+            # `os.chmod` on the path, not `os.fchmod` on the descriptor: `fchmod` does not exist
+            # on Windows, and this line runs on every update once an index exists -- it would
+            # break the second write on exactly the platform the lock is written to degrade
+            # gracefully for. The path is a uuid4 name we just created in a directory we hold,
+            # so there is no meaningful window for it to be swapped.
+            os.chmod(temporary, existing_mode)
         with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
             yaml.safe_dump(index, handle, default_flow_style=False, sort_keys=True)
             handle.flush()

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -625,6 +625,13 @@ def _exclusive_index_lock(index_file: Path) -> Iterator[None]:
     second process hold a lock on an unlinked inode while a third creates a fresh one and takes a
     lock nobody else can see -- the classic unlink race. An empty stray file is the cheaper cost.
 
+    **The sidecar carries the index's own mode**, which is not cosmetic: ``flock`` needs a
+    writable descriptor, so whoever may write the index must be able to open the sidecar for
+    append. Leaving the sidecar at the umask default while the index is group-writable gives a
+    second account read access to the index and a ``PermissionError`` at the lock -- the
+    multi-account case this locking exists to serve, broken at the gate. The two modes are kept
+    equal so the set of accounts that can take the lock is the set that can write the index.
+
     Where ``fcntl`` is unavailable (Windows, which this project does not test) the body runs
     unlocked and says so once, rather than failing at import: an unsynchronised index is what the
     caller had before, while an ImportError would take out a working single-writer run.
@@ -643,11 +650,36 @@ def _exclusive_index_lock(index_file: Path) -> Iterator[None]:
     lock_file = index_file.with_name(index_file.name + ".lock")
     lock_file.parent.mkdir(parents=True, exist_ok=True)
     with lock_file.open("a+") as handle:
+        # After the open, so the very first run aligns its own sidecar rather than leaving it at
+        # the umask default for the next one to repair.
+        _align_lock_mode(lock_file, index_file)
         fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
         try:
             yield
         finally:
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _align_lock_mode(lock_file: Path, index_file: Path) -> None:
+    """Give the sidecar the same permissions as the index, best effort.
+
+    Only the file's owner may ``chmod`` it, so this cannot be an invariant every caller can
+    restore: a second account finding a too-tight sidecar can do nothing about it, and should get
+    the eventual ``PermissionError`` rather than a confusing failure here. The owner's next run
+    repairs it, which also upgrades sidecars written before this behaviour existed.
+
+    Args:
+        lock_file: The sidecar; may not exist yet.
+        index_file: The index whose mode the sidecar should match; may not exist yet either.
+    """
+    desired = _existing_index_mode(index_file)
+    if desired is None:
+        return
+    try:
+        if _existing_index_mode(lock_file) != desired:
+            os.chmod(lock_file, desired)
+    except (FileNotFoundError, PermissionError):
+        return
 
 
 def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> None:

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -13,11 +13,13 @@ import platform
 import re
 import shutil
 import signal
+import stat
 import subprocess
 import tempfile
 import time
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from functools import cache
 from importlib import import_module
 from importlib import metadata as importlib_metadata
 from pathlib import Path
@@ -600,6 +602,16 @@ except ImportError:  # pragma: no cover - Windows, which the CI matrix does not 
     fcntl = None  # type: ignore[assignment]
 
 
+@cache
+def _warn_unlocked_once() -> None:
+    """Say once per process that the index is being updated without a lock.
+
+    Cached rather than flagged so the "warns once" claim is enforced by the decorator instead of
+    by a global nobody re-checks.
+    """
+    logger.warning("fcntl unavailable: the signal index is updated without a lock, so concurrent runs can race.")
+
+
 @contextmanager
 def _exclusive_index_lock(index_file: Path) -> Iterator[None]:
     """Hold an exclusive cross-process lock for the whole read-modify-write of the index.
@@ -624,7 +636,7 @@ def _exclusive_index_lock(index_file: Path) -> Iterator[None]:
         Nothing. The lock is held for the duration of the block.
     """
     if fcntl is None:  # pragma: no cover - not reachable on POSIX
-        logger.warning("fcntl unavailable: the signal index is updated without a lock, so concurrent runs can race.")
+        _warn_unlocked_once()
         yield
         return
 
@@ -665,10 +677,33 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> None:
             yaml.safe_dump(index, handle, default_flow_style=False, sort_keys=True)
             handle.flush()
             os.fsync(handle.fileno())
+        # `mkstemp` creates 0600 and ignores the umask, and `os.replace` keeps the temporary's
+        # mode -- so replacing without this would quietly tighten a 0644 index to 0600 and lock a
+        # second account out of `find-signal` on exactly the shared metadata directory this
+        # locking exists for. Carry the existing index's mode over; for a first write, fall back
+        # to what a plain `open(..., "w")` would have produced under the caller's umask.
+        os.chmod(temporary, _mode_for_index(index_file))
         os.replace(temporary, index_file)
     except BaseException:
         temporary.unlink(missing_ok=True)
         raise
+
+
+def _mode_for_index(index_file: Path) -> int:
+    """Return the mode the replaced index should carry.
+
+    Args:
+        index_file: The index being replaced; may not exist yet.
+
+    Returns:
+        The existing file's permission bits, or the umask-respecting default for a new file.
+    """
+    try:
+        return stat.S_IMODE(index_file.stat().st_mode)
+    except FileNotFoundError:
+        umask = os.umask(0)
+        os.umask(umask)
+        return 0o666 & ~umask
 
 
 def update_signal_index(
@@ -691,6 +726,12 @@ def update_signal_index(
     the live index, so a failed or interrupted write leaves the previous index intact instead of
     truncating it -- which mattered because the loader below treats an unparsable index as
     "create a new one", turning one bad write into the loss of every entry.
+
+    The guarantee is exactly as strong as the filesystem's ``flock``: it holds for a local
+    filesystem and for any shared one that honours POSIX advisory locks across the participating
+    hosts, and it does **not** hold where it silently does not -- some NFS configurations and
+    cluster filesystems -- in which case this reverts to the unlocked race it closes. Settling
+    that for a given deployment is a two-host stress test, not a code question.
 
     Parameter-based lookup reads the injections recorded in the batch metadata files (their
     source of truth); this index is only the id shortcut. A batch with no injected signals

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import atexit
 import copy
+import errno
 import json
 import logging
 import os
@@ -602,6 +603,13 @@ except ImportError:  # pragma: no cover - Windows, which the CI matrix does not 
     fcntl = None  # type: ignore[assignment]
 
 
+# `flock` errnos meaning "this filesystem cannot do advisory locks", as opposed to "you may not".
+# Only these fall back to an unlocked write; a refusal such as EACCES still raises.
+_LOCKING_UNSUPPORTED = frozenset(
+    getattr(errno, name) for name in ("EOPNOTSUPP", "ENOLCK", "ENOSYS", "ENOTSUP") if hasattr(errno, name)
+)
+
+
 @cache
 def _warn_unlocked_once() -> None:
     """Say once per process that the index is being updated without a lock.
@@ -665,7 +673,18 @@ def _exclusive_index_lock(index_file: Path) -> Iterator[None]:
         # After the open, so the very first run aligns its own sidecar rather than leaving it at
         # the umask default for the next one to repair.
         _align_lock_mode(lock_file, index_file)
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        except OSError as error:
+            if error.errno not in _LOCKING_UNSUPPORTED:
+                raise
+            # The filesystem does not implement advisory locks. Failing here would break a write
+            # that succeeds -- and did succeed before locking existed -- on exactly the shared
+            # filesystems this feature is aimed at. Degrade to the previous unsynchronised
+            # behaviour and say so, the same trade as a missing `fcntl` module.
+            _warn_unlocked_once()
+            yield
+            return
         try:
             yield
         finally:
@@ -733,6 +752,15 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> None:
     temporary = index_file.with_name(f"{index_file.name}.{uuid.uuid4().hex}.tmp")
     descriptor = os.open(temporary, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o666)
     try:
+        # Adopt the raw descriptor immediately. Anything that raises between `os.open` and
+        # `os.fdopen` -- the chmod below used to sit there -- leaves a descriptor that the
+        # cleanup path unlinks the file for but never closes, and this runs once per batch.
+        handle = os.fdopen(descriptor, "w", encoding="utf-8")
+    except BaseException:
+        os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+        raise
+    try:
         if existing_mode is not None:
             # An index that already exists keeps whatever mode it was given, so a deliberately
             # group-writable index survives an update.
@@ -743,7 +771,7 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> None:
             # gracefully for. The path is a uuid4 name we just created in a directory we hold,
             # so there is no meaningful window for it to be swapped.
             os.chmod(temporary, existing_mode)
-        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+        with handle:
             yaml.safe_dump(index, handle, default_flow_style=False, sort_keys=True)
             handle.flush()
             os.fsync(handle.fileno())

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -15,8 +15,8 @@ import shutil
 import signal
 import stat
 import subprocess
-import tempfile
 import time
+import uuid
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from functools import cache
@@ -670,40 +670,44 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> None:
         OSError: If the file cannot be written or renamed.
         yaml.YAMLError: If the index cannot be serialised.
     """
-    descriptor, name = tempfile.mkstemp(dir=index_file.parent, prefix=index_file.name + ".", suffix=".tmp")
-    temporary = Path(name)
+    # `os.replace` carries the temporary's mode to the destination, so the temporary must be
+    # created the way the destination should end up. `tempfile.mkstemp` is wrong here: it forces
+    # 0600 and ignores the umask, which would quietly tighten a 0644 index and lock a second
+    # account out of `find-signal` on the shared metadata directory this locking exists for.
+    # Opening with an explicit 0o666 lets the kernel apply the umask and any default ACLs exactly
+    # as a plain `open(..., "w")` would have -- no process-global umask read, which would race
+    # with any other thread creating a file (gwmock runs a resource monitor thread).
+    existing_mode = _existing_index_mode(index_file)
+    temporary = index_file.with_name(f"{index_file.name}.{uuid.uuid4().hex}.tmp")
+    descriptor = os.open(temporary, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o666)
     try:
+        if existing_mode is not None:
+            # An index that already exists keeps whatever mode it was given, so a deliberately
+            # group-writable index survives an update.
+            os.fchmod(descriptor, existing_mode)
         with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
             yaml.safe_dump(index, handle, default_flow_style=False, sort_keys=True)
             handle.flush()
             os.fsync(handle.fileno())
-        # `mkstemp` creates 0600 and ignores the umask, and `os.replace` keeps the temporary's
-        # mode -- so replacing without this would quietly tighten a 0644 index to 0600 and lock a
-        # second account out of `find-signal` on exactly the shared metadata directory this
-        # locking exists for. Carry the existing index's mode over; for a first write, fall back
-        # to what a plain `open(..., "w")` would have produced under the caller's umask.
-        os.chmod(temporary, _mode_for_index(index_file))
         os.replace(temporary, index_file)
     except BaseException:
         temporary.unlink(missing_ok=True)
         raise
 
 
-def _mode_for_index(index_file: Path) -> int:
-    """Return the mode the replaced index should carry.
+def _existing_index_mode(index_file: Path) -> int | None:
+    """Return the index's current permission bits, or ``None`` when it does not exist yet.
 
     Args:
-        index_file: The index being replaced; may not exist yet.
+        index_file: The index being replaced.
 
     Returns:
-        The existing file's permission bits, or the umask-respecting default for a new file.
+        Permission bits to preserve, or ``None`` to let the umask decide.
     """
     try:
         return stat.S_IMODE(index_file.stat().st_mode)
     except FileNotFoundError:
-        umask = os.umask(0)
-        os.umask(umask)
-        return 0o666 & ~umask
+        return None
 
 
 def update_signal_index(

--- a/tests/cli/test_signal_index_concurrency.py
+++ b/tests/cli/test_signal_index_concurrency.py
@@ -66,12 +66,18 @@ def _metadata(event_id: int, batch: int) -> dict:
     }
 
 
-def _writer(directory: str, event_id: int, batch: int, barrier: Barrier) -> None:
+def _writer(directory: str, event_id: int, batch: int, ready: Barrier, barrier: Barrier) -> None:
     """Update the index with the barrier armed inside the read-modify-write.
 
     ``_withdraw_batch`` is the first call after the index is read and before it is written, so
     patching it here puts the rendezvous exactly in the window the lock is supposed to close.
     Patching happens in the forked child, so the parent and the other child are unaffected.
+
+    Two barriers, not one. ``ready`` is untimed and makes both children enter
+    ``update_signal_index`` together; without it a slow child can arrive after the other has
+    already finished, read the completed index, and merge cleanly -- the assertion then passes
+    on unfixed code without the two stale reads ever overlapping. ``barrier`` is the timed
+    in-critical-section rendezvous.
     """
     import gwmock.cli.simulate_utils as module
 
@@ -85,6 +91,7 @@ def _writer(directory: str, event_id: int, batch: int, barrier: Barrier) -> None
         return original(index, metadata_file_name)
 
     module._withdraw_batch = _rendezvous_then_withdraw
+    ready.wait(timeout=30)
     update_signal_index(Path(directory), _metadata(event_id, batch), f"orchestration-{batch}.metadata.json")
 
 
@@ -96,9 +103,10 @@ def test_two_processes_updating_the_index_keep_both_events(tmp_path: Path) -> No
     contribution with an index built from its own pre-race read.
     """
     context = mp.get_context("fork")
+    ready = context.Barrier(2)
     barrier = context.Barrier(2)
     processes = [
-        context.Process(target=_writer, args=(str(tmp_path), event_id, batch, barrier))
+        context.Process(target=_writer, args=(str(tmp_path), event_id, batch, ready, barrier))
         for batch, event_id in enumerate((11, 22))
     ]
     for process in processes:

--- a/tests/cli/test_signal_index_concurrency.py
+++ b/tests/cli/test_signal_index_concurrency.py
@@ -38,13 +38,14 @@ the cost of one timeout per process.
 
 from __future__ import annotations
 
-import contextlib
 import multiprocessing as mp
 import os
 import stat
 import threading
+import time
 from multiprocessing.synchronize import Barrier
 from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
@@ -57,6 +58,10 @@ pytestmark = pytest.mark.unit
 # the fixed path (where the second process is locked out and can never arrive) stays quick.
 _BARRIER_TIMEOUT_SECONDS = 2.0
 
+# A lock wait longer than this is proof the other child was inside the critical section. Well
+# under the barrier timeout that produces it, and far above scheduler noise.
+_LOCK_WAIT_EVIDENCE_SECONDS = 0.5
+
 
 def _metadata(event_id: int, batch: int) -> dict:
     """One batch's metadata injecting a single distinct event."""
@@ -66,7 +71,14 @@ def _metadata(event_id: int, batch: int) -> dict:
     }
 
 
-def _writer(directory: str, event_id: int, batch: int, ready: Barrier, barrier: Barrier) -> None:
+def _writer(
+    directory: str,
+    event_id: int,
+    batch: int,
+    ready: Barrier,
+    barrier: Barrier,
+    evidence: Any,
+) -> None:
     """Update the index with the barrier armed inside the read-modify-write.
 
     ``_withdraw_batch`` is the first call after the index is read and before it is written, so
@@ -78,6 +90,13 @@ def _writer(directory: str, event_id: int, batch: int, ready: Barrier, barrier: 
     already finished, read the completed index, and merge cleanly -- the assertion then passes
     on unfixed code without the two stale reads ever overlapping. ``barrier`` is the timed
     in-critical-section rendezvous.
+
+    ``evidence`` records whether this child actually met the other inside the critical section,
+    and how long it waited for the lock. Without it the test has a silent false-green: if
+    scheduling skew exceeds the barrier timeout, the first child finishes before the second even
+    reads, the second sees a completed index, both events survive, and the assertion passes on
+    unfixed code having never raced -- measured at 10/10 with 2.5 s of induced skew. The caller
+    turns that into a loud failure.
     """
     import gwmock.cli.simulate_utils as module
 
@@ -86,11 +105,30 @@ def _writer(directory: str, event_id: int, batch: int, ready: Barrier, barrier: 
     def _rendezvous_then_withdraw(index: dict, metadata_file_name: str) -> dict:
         # A broken barrier is expected under the fix: the other process is blocked on the lock
         # and cannot arrive, which is the whole point -- the critical section is exclusive.
-        with contextlib.suppress(threading.BrokenBarrierError):
+        try:
             barrier.wait(timeout=_BARRIER_TIMEOUT_SECONDS)
+            evidence["rendezvous"] = True
+        except threading.BrokenBarrierError:
+            pass
         return original(index, metadata_file_name)
 
     module._withdraw_batch = _rendezvous_then_withdraw
+
+    # Time the exclusive acquisition: under the fix exactly one child waits out the other's
+    # critical section here, which is the positive evidence that the lock did the serialising.
+    # On unfixed code there is no flock call at all, so this stays zero.
+    if module.fcntl is not None:
+        real_flock = module.fcntl.flock
+
+        def _timed_flock(descriptor: int, operation: int) -> Any:
+            if operation != module.fcntl.LOCK_EX:
+                return real_flock(descriptor, operation)
+            started = time.perf_counter()
+            result = real_flock(descriptor, operation)
+            evidence["lock_wait"] = max(evidence["lock_wait"], time.perf_counter() - started)
+            return result
+
+        module.fcntl.flock = _timed_flock
     ready.wait(timeout=30)
     update_signal_index(Path(directory), _metadata(event_id, batch), f"orchestration-{batch}.metadata.json")
 
@@ -105,8 +143,10 @@ def test_two_processes_updating_the_index_keep_both_events(tmp_path: Path) -> No
     context = mp.get_context("fork")
     ready = context.Barrier(2)
     barrier = context.Barrier(2)
+    manager = context.Manager()
+    evidence = [manager.dict(rendezvous=False, lock_wait=0.0) for _ in range(2)]
     processes = [
-        context.Process(target=_writer, args=(str(tmp_path), event_id, batch, ready, barrier))
+        context.Process(target=_writer, args=(str(tmp_path), event_id, batch, ready, barrier, evidence[batch]))
         for batch, event_id in enumerate((11, 22))
     ]
     for process in processes:
@@ -115,6 +155,18 @@ def test_two_processes_updating_the_index_keep_both_events(tmp_path: Path) -> No
         process.join(timeout=60)
 
     assert all(process.exitcode == 0 for process in processes), [p.exitcode for p in processes]
+
+    # Did the scenario actually happen? Either the two children met inside the critical section
+    # (they can only do that when nothing serialises them) or one of them waited on the lock while
+    # the other held it. Neither means the writes never overlapped, so a passing assertion below
+    # would prove nothing -- fail here instead of reporting a green that was never earned.
+    met = any(record["rendezvous"] for record in evidence)
+    waited = max(record["lock_wait"] for record in evidence)
+    assert met or waited > _LOCK_WAIT_EVIDENCE_SECONDS, (
+        f"scenario did not run: rendezvous={met}, longest lock wait={waited:.3f}s. "
+        "The two updates were serialised by scheduling rather than by the lock, so this run "
+        "neither exercised the race nor demonstrated the fix."
+    )
 
     index = yaml.safe_load((tmp_path / "signal_index.yaml").read_text())
     # The whole point: both survive. Asserting only on the count would pass an index holding one
@@ -145,6 +197,33 @@ def test_atomic_write_keeps_the_index_readable_by_others(tmp_path: Path) -> None
         update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
         preserved = stat.S_IMODE(index_file.stat().st_mode)
         assert preserved == 0o664, oct(preserved)
+    finally:
+        os.umask(previous)
+
+
+def test_lock_sidecar_is_writable_by_whoever_may_write_the_index(tmp_path: Path) -> None:
+    """The sidecar must not be tighter than the index it guards.
+
+    ``flock`` needs a writable descriptor, so an account that may write the index but cannot open
+    the sidecar for append gets a ``PermissionError`` at the lock -- the multi-account case this
+    locking exists for, broken at the gate. Found by review, not by the permissions work above,
+    which only looked at the index's own mode.
+    """
+    previous = os.umask(0o022)
+    try:
+        update_signal_index(tmp_path, _metadata(3, 0), "orchestration-0.metadata.json")
+        index_file = tmp_path / "signal_index.yaml"
+        lock_file = tmp_path / "signal_index.yaml.lock"
+        assert lock_file.exists()
+
+        # Group-writable index: a second account in the group may write it, so it must be able to
+        # take the lock too.
+        index_file.chmod(0o664)
+        update_signal_index(tmp_path, _metadata(4, 1), "orchestration-1.metadata.json")
+        index_mode = stat.S_IMODE(index_file.stat().st_mode)
+        lock_mode = stat.S_IMODE(lock_file.stat().st_mode)
+        assert index_mode == 0o664, oct(index_mode)
+        assert lock_mode == index_mode, f"index {oct(index_mode)} but sidecar {oct(lock_mode)}"
     finally:
         os.umask(previous)
 

--- a/tests/cli/test_signal_index_concurrency.py
+++ b/tests/cli/test_signal_index_concurrency.py
@@ -19,13 +19,30 @@ race, and the loser's events vanish from the id lookup while their samples sit i
 **Processes, not threads.** The contended state is a file, and the fix is an OS-level file lock,
 which is per-process. A threaded version of this test can pass on the unfixed code for the wrong
 reason (the GIL serialising the small critical section) and would not discriminate. Each writer
-here is a real forked process, and a barrier holds both inside the window between read and write
-so the race is deterministic rather than probabilistic.
+here is a real forked process.
+
+**Where the barrier goes, and why it has a timeout.** An earlier version of this test put the
+barrier before ``update_signal_index``, which only starts the two processes together and leaves
+the race to the scheduler: measured against the unfixed code it passed **3 trials in 60**, so it
+green-lit the bug 5% of the time and the mutation testing built on it was equally probabilistic.
+The barrier now sits *inside* the read-modify-write, patched over ``_withdraw_batch`` -- the
+first call after the index is read and before it is written.
+
+It must be a *timed* barrier, and that is not a detail. Under the fix the two processes cannot
+both be inside the critical section, so waiting for each other unconditionally would deadlock
+the correct code. Timing out means: unfixed, both arrive and proceed together from stale reads,
+and one write is lost; fixed, the first holder waits, times out, finishes and releases, and the
+second then reads a file that already has the first event. Deterministic in both directions, at
+the cost of one timeout per process.
 """
 
 from __future__ import annotations
 
+import contextlib
 import multiprocessing as mp
+import os
+import stat
+import threading
 from multiprocessing.synchronize import Barrier
 from pathlib import Path
 
@@ -35,6 +52,10 @@ import yaml
 from gwmock.cli.simulate_utils import update_signal_index
 
 pytestmark = pytest.mark.unit
+
+# Long enough that a slow forked child still arrives when the code is unfixed, short enough that
+# the fixed path (where the second process is locked out and can never arrive) stays quick.
+_BARRIER_TIMEOUT_SECONDS = 2.0
 
 
 def _metadata(event_id: int, batch: int) -> dict:
@@ -46,21 +67,33 @@ def _metadata(event_id: int, batch: int) -> dict:
 
 
 def _writer(directory: str, event_id: int, batch: int, barrier: Barrier) -> None:
-    """Update the index, both processes held at the barrier before the write lands.
+    """Update the index with the barrier armed inside the read-modify-write.
 
-    The barrier sits *before* the call rather than inside it, because the goal is to start both
-    read-modify-write cycles together; holding them mid-cycle would need to reach into the
-    function under test and would stop being a test of its contract.
+    ``_withdraw_batch`` is the first call after the index is read and before it is written, so
+    patching it here puts the rendezvous exactly in the window the lock is supposed to close.
+    Patching happens in the forked child, so the parent and the other child are unaffected.
     """
-    barrier.wait(timeout=30)
+    import gwmock.cli.simulate_utils as module
+
+    original = module._withdraw_batch
+
+    def _rendezvous_then_withdraw(index: dict, metadata_file_name: str) -> dict:
+        # A broken barrier is expected under the fix: the other process is blocked on the lock
+        # and cannot arrive, which is the whole point -- the critical section is exclusive.
+        with contextlib.suppress(threading.BrokenBarrierError):
+            barrier.wait(timeout=_BARRIER_TIMEOUT_SECONDS)
+        return original(index, metadata_file_name)
+
+    module._withdraw_batch = _rendezvous_then_withdraw
     update_signal_index(Path(directory), _metadata(event_id, batch), f"orchestration-{batch}.metadata.json")
 
 
 def test_two_processes_updating_the_index_keep_both_events(tmp_path: Path) -> None:
     """Neither writer's event may be lost when both update the index at once.
 
-    Fails on the unfixed code: the read-modify-write is unlocked, so whichever process writes
-    second overwrites the first's contribution with an index built from the pre-race read.
+    Fails on the unfixed code: the read-modify-write is unlocked, so both processes reach the
+    in-critical-section barrier together, and whichever writes second overwrites the first's
+    contribution with an index built from its own pre-race read.
     """
     context = mp.get_context("fork")
     barrier = context.Barrier(2)
@@ -81,6 +114,31 @@ def test_two_processes_updating_the_index_keep_both_events(tmp_path: Path) -> No
     assert set(index) == {"11", "22"}, index
     assert index["11"]["batches"][0]["frames"] == ["signal/signal-0.gwf"]
     assert index["22"]["batches"][0]["frames"] == ["signal/signal-1.gwf"]
+
+
+def test_atomic_write_keeps_the_index_readable_by_others(tmp_path: Path) -> None:
+    """Replacing the index must not tighten its permissions.
+
+    ``mkstemp`` creates 0600 and ignores the umask, and ``os.replace`` carries that mode over, so
+    an atomic write is a silent way to lock a second account out of the shared metadata directory
+    that the locking exists to support. Both reviewers found this by probing rather than from a
+    test, which is why one exists now.
+    """
+    previous = os.umask(0o022)
+    try:
+        update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+        index_file = tmp_path / "signal_index.yaml"
+        created = stat.S_IMODE(index_file.stat().st_mode)
+        assert created == 0o644, oct(created)
+
+        # An existing index's own mode wins over the default, so a deliberately group-writable
+        # index stays that way across an update.
+        index_file.chmod(0o664)
+        update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
+        preserved = stat.S_IMODE(index_file.stat().st_mode)
+        assert preserved == 0o664, oct(preserved)
+    finally:
+        os.umask(previous)
 
 
 def test_index_survives_a_write_that_fails_partway(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_signal_index_concurrency.py
+++ b/tests/cli/test_signal_index_concurrency.py
@@ -178,8 +178,10 @@ def test_two_processes_updating_the_index_keep_both_events(tmp_path: Path) -> No
     else:
         pytest.fail(
             f"scenario did not run in {_SCENARIO_ATTEMPTS} attempts: rendezvous={met}, "
-            f"longest lock wait={waited:.3f}s. The two updates were serialised by scheduling "
-            "rather than by the lock, so no attempt exercised the race or demonstrated the fix."
+            f"longest lock wait={waited:.3f}s -- neither a rendezvous nor lock contention was "
+            "observed, so no attempt exercised the race or demonstrated the fix. Two causes look "
+            "identical here: the scheduler serialised the writers, or the patched hook no longer "
+            "sits between the read and the write in update_signal_index."
         )
 
     index = yaml.safe_load((directory / "signal_index.yaml").read_text())
@@ -238,6 +240,34 @@ def test_lock_sidecar_is_writable_by_whoever_may_write_the_index(tmp_path: Path)
         lock_mode = stat.S_IMODE(lock_file.stat().st_mode)
         assert index_mode == 0o664, oct(index_mode)
         assert lock_mode == index_mode, f"index {oct(index_mode)} but sidecar {oct(lock_mode)}"
+    finally:
+        os.umask(previous)
+
+
+def test_a_deliberately_open_sidecar_is_not_narrowed(tmp_path: Path) -> None:
+    """Alignment widens a too-tight sidecar; it must not undo an operator's decision.
+
+    A sidecar is a permission surface in its own right: an operator may open it to an account
+    that takes locks without writing the index. Matching the index exactly would silently pull
+    that back on the owner's next run, removing a capability nobody asked to remove.
+    """
+    previous = os.umask(0o022)
+    try:
+        update_signal_index(tmp_path, _metadata(5, 0), "orchestration-0.metadata.json")
+        lock_file = tmp_path / "signal_index.yaml.lock"
+        index_file = tmp_path / "signal_index.yaml"
+        assert stat.S_IMODE(index_file.stat().st_mode) == 0o644
+
+        lock_file.chmod(0o666)
+        update_signal_index(tmp_path, _metadata(6, 1), "orchestration-1.metadata.json")
+        assert stat.S_IMODE(lock_file.stat().st_mode) == 0o666, oct(stat.S_IMODE(lock_file.stat().st_mode))
+
+        # ...and the widening direction still works from the same starting point.
+        lock_file.chmod(0o600)
+        index_file.chmod(0o664)
+        update_signal_index(tmp_path, _metadata(7, 2), "orchestration-2.metadata.json")
+        widened = stat.S_IMODE(lock_file.stat().st_mode)
+        assert widened & 0o060 == 0o060, oct(widened)
     finally:
         os.umask(previous)
 

--- a/tests/cli/test_signal_index_concurrency.py
+++ b/tests/cli/test_signal_index_concurrency.py
@@ -38,6 +38,7 @@ the cost of one timeout per process.
 
 from __future__ import annotations
 
+import errno
 import multiprocessing as mp
 import os
 import stat
@@ -270,6 +271,66 @@ def test_a_deliberately_open_sidecar_is_not_narrowed(tmp_path: Path) -> None:
         assert widened & 0o060 == 0o060, oct(widened)
     finally:
         os.umask(previous)
+
+
+def test_a_filesystem_without_advisory_locks_still_writes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A filesystem that cannot do ``flock`` must degrade, not fail the run.
+
+    Some network and cluster filesystems reject ``flock`` outright. Propagating that would break
+    a write that succeeds -- and succeeded before locking existed -- on exactly the shared
+    storage this feature targets. The guarantee is lost there, which the docstring says; the run
+    is not.
+    """
+    import gwmock.cli.simulate_utils as module
+
+    def _unsupported(descriptor: int, operation: int) -> None:
+        raise OSError(errno.ENOLCK, "no locks available")
+
+    monkeypatch.setattr(module.fcntl, "flock", _unsupported)
+    update_signal_index(tmp_path, _metadata(9, 0), "orchestration-0.metadata.json")
+    index = yaml.safe_load((tmp_path / "signal_index.yaml").read_text())
+    assert "9" in index, index
+
+
+def test_a_refused_lock_is_not_swallowed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only *unsupported* is tolerated; a refused lock must still fail.
+
+    The escape hatch above must not become a blanket ``except OSError``, or a genuine permission
+    problem would silently drop the serialisation it is meant to enforce.
+    """
+    import gwmock.cli.simulate_utils as module
+
+    def _refused(descriptor: int, operation: int) -> None:
+        raise OSError(errno.EACCES, "permission denied")
+
+    monkeypatch.setattr(module.fcntl, "flock", _refused)
+    with pytest.raises(OSError, match="permission denied"):
+        update_signal_index(tmp_path, _metadata(10, 0), "orchestration-0.metadata.json")
+
+
+def test_a_failed_write_leaks_no_descriptor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The temporary's descriptor must be closed on every failure path.
+
+    ``update_signal_index`` runs once per batch, so a descriptor leaked when the write fails
+    accumulates for the life of the process.
+    """
+    update_signal_index(tmp_path, _metadata(11, 0), "orchestration-0.metadata.json")
+
+    def _boom(*args: Any, **kwargs: Any) -> None:
+        raise OSError("disk on fire")
+
+    before = len(os.listdir(f"/proc/{os.getpid()}/fd")) if Path("/proc/self/fd").exists() else None
+    monkeypatch.setattr("gwmock.cli.simulate_utils.yaml.safe_dump", _boom)
+    for batch in range(1, 6):
+        with pytest.raises(OSError, match="disk on fire"):
+            update_signal_index(tmp_path, _metadata(11 + batch, batch), f"orchestration-{batch}.metadata.json")
+    monkeypatch.undo()
+
+    if before is not None:
+        after = len(os.listdir(f"/proc/{os.getpid()}/fd"))
+        assert after <= before + 1, f"descriptors grew from {before} to {after} over five failed writes"
+    # Whatever the platform, no temporary may be left behind.
+    assert not list(tmp_path.glob("*.tmp")), list(tmp_path.glob("*.tmp"))
 
 
 def test_index_survives_a_write_that_fails_partway(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_signal_index_concurrency.py
+++ b/tests/cli/test_signal_index_concurrency.py
@@ -62,6 +62,9 @@ _BARRIER_TIMEOUT_SECONDS = 2.0
 # under the barrier timeout that produces it, and far above scheduler noise.
 _LOCK_WAIT_EVIDENCE_SECONDS = 0.5
 
+# How many times to re-run the two writers when scheduling, not the lock, serialised them.
+_SCENARIO_ATTEMPTS = 3
+
 
 def _metadata(event_id: int, batch: int) -> dict:
     """One batch's metadata injecting a single distinct event."""
@@ -141,34 +144,45 @@ def test_two_processes_updating_the_index_keep_both_events(tmp_path: Path) -> No
     contribution with an index built from its own pre-race read.
     """
     context = mp.get_context("fork")
-    ready = context.Barrier(2)
-    barrier = context.Barrier(2)
     manager = context.Manager()
-    evidence = [manager.dict(rendezvous=False, lock_wait=0.0) for _ in range(2)]
-    processes = [
-        context.Process(target=_writer, args=(str(tmp_path), event_id, batch, ready, barrier, evidence[batch]))
-        for batch, event_id in enumerate((11, 22))
-    ]
-    for process in processes:
-        process.start()
-    for process in processes:
-        process.join(timeout=60)
 
-    assert all(process.exitcode == 0 for process in processes), [p.exitcode for p in processes]
+    # Retry, bounded, on a fresh directory each time. The validity check below refuses to pass a
+    # run the scheduler serialised, and on a loaded machine that can happen by luck -- retrying
+    # keeps a busy CI runner from going red over timing while never letting a non-run count as a
+    # pass. Failing only after every attempt missed keeps both directions honest.
+    for attempt in range(_SCENARIO_ATTEMPTS):
+        directory = tmp_path / f"attempt-{attempt}"
+        directory.mkdir()
+        ready = context.Barrier(2)
+        barrier = context.Barrier(2)
+        evidence = [manager.dict(rendezvous=False, lock_wait=0.0) for _ in range(2)]
+        processes = [
+            context.Process(target=_writer, args=(str(directory), event_id, batch, ready, barrier, evidence[batch]))
+            for batch, event_id in enumerate((11, 22))
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=60)
 
-    # Did the scenario actually happen? Either the two children met inside the critical section
-    # (they can only do that when nothing serialises them) or one of them waited on the lock while
-    # the other held it. Neither means the writes never overlapped, so a passing assertion below
-    # would prove nothing -- fail here instead of reporting a green that was never earned.
-    met = any(record["rendezvous"] for record in evidence)
-    waited = max(record["lock_wait"] for record in evidence)
-    assert met or waited > _LOCK_WAIT_EVIDENCE_SECONDS, (
-        f"scenario did not run: rendezvous={met}, longest lock wait={waited:.3f}s. "
-        "The two updates were serialised by scheduling rather than by the lock, so this run "
-        "neither exercised the race nor demonstrated the fix."
-    )
+        assert all(process.exitcode == 0 for process in processes), [p.exitcode for p in processes]
 
-    index = yaml.safe_load((tmp_path / "signal_index.yaml").read_text())
+        # Did the scenario actually happen? Either the two children met inside the critical
+        # section (they can only do that when nothing serialises them) or one waited on the lock
+        # while the other held it. Neither means the writes never overlapped, so the assertions
+        # below would prove nothing.
+        met = any(record["rendezvous"] for record in evidence)
+        waited = max(record["lock_wait"] for record in evidence)
+        if met or waited > _LOCK_WAIT_EVIDENCE_SECONDS:
+            break
+    else:
+        pytest.fail(
+            f"scenario did not run in {_SCENARIO_ATTEMPTS} attempts: rendezvous={met}, "
+            f"longest lock wait={waited:.3f}s. The two updates were serialised by scheduling "
+            "rather than by the lock, so no attempt exercised the race or demonstrated the fix."
+        )
+
+    index = yaml.safe_load((directory / "signal_index.yaml").read_text())
     # The whole point: both survive. Asserting only on the count would pass an index holding one
     # event twice, which a broken merge could produce.
     assert set(index) == {"11", "22"}, index

--- a/tests/cli/test_signal_index_concurrency.py
+++ b/tests/cli/test_signal_index_concurrency.py
@@ -1,0 +1,115 @@
+# Copyright (C) 2026 Leuven Gravity Institute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+"""Two writers must not lose each other's entries in ``signal_index.yaml``.
+
+The index is written by a read-modify-write. Two runs sharing a metadata directory therefore
+race, and the loser's events vanish from the id lookup while their samples sit in the frames --
+``gwmock find-signal`` then reports nothing for an event that was injected.
+
+**Processes, not threads.** The contended state is a file, and the fix is an OS-level file lock,
+which is per-process. A threaded version of this test can pass on the unfixed code for the wrong
+reason (the GIL serialising the small critical section) and would not discriminate. Each writer
+here is a real forked process, and a barrier holds both inside the window between read and write
+so the race is deterministic rather than probabilistic.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+from multiprocessing.synchronize import Barrier
+from pathlib import Path
+
+import pytest
+import yaml
+
+from gwmock.cli.simulate_utils import update_signal_index
+
+pytestmark = pytest.mark.unit
+
+
+def _metadata(event_id: int, batch: int) -> dict:
+    """One batch's metadata injecting a single distinct event."""
+    return {
+        "signal": {"injections": [{"event_id": event_id, "parameters": {"coa_time": 100.0 + event_id}}]},
+        "outputs": [{"kind": "signal", "path": f"signal/signal-{batch}.gwf"}],
+    }
+
+
+def _writer(directory: str, event_id: int, batch: int, barrier: Barrier) -> None:
+    """Update the index, both processes held at the barrier before the write lands.
+
+    The barrier sits *before* the call rather than inside it, because the goal is to start both
+    read-modify-write cycles together; holding them mid-cycle would need to reach into the
+    function under test and would stop being a test of its contract.
+    """
+    barrier.wait(timeout=30)
+    update_signal_index(Path(directory), _metadata(event_id, batch), f"orchestration-{batch}.metadata.json")
+
+
+def test_two_processes_updating_the_index_keep_both_events(tmp_path: Path) -> None:
+    """Neither writer's event may be lost when both update the index at once.
+
+    Fails on the unfixed code: the read-modify-write is unlocked, so whichever process writes
+    second overwrites the first's contribution with an index built from the pre-race read.
+    """
+    context = mp.get_context("fork")
+    barrier = context.Barrier(2)
+    processes = [
+        context.Process(target=_writer, args=(str(tmp_path), event_id, batch, barrier))
+        for batch, event_id in enumerate((11, 22))
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=60)
+
+    assert all(process.exitcode == 0 for process in processes), [p.exitcode for p in processes]
+
+    index = yaml.safe_load((tmp_path / "signal_index.yaml").read_text())
+    # The whole point: both survive. Asserting only on the count would pass an index holding one
+    # event twice, which a broken merge could produce.
+    assert set(index) == {"11", "22"}, index
+    assert index["11"]["batches"][0]["frames"] == ["signal/signal-0.gwf"]
+    assert index["22"]["batches"][0]["frames"] == ["signal/signal-1.gwf"]
+
+
+def test_index_survives_a_write_that_fails_partway(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed write must not destroy the entries already in the index.
+
+    Separate defect from the race, and the more damaging one. The final write truncates the file
+    in place, and the loader treats an unparsable index as "create new index" -- so a crash or a
+    full disk mid-dump silently discards *every* prior entry on the next update, rather than
+    losing one race's worth.
+    """
+    update_signal_index(tmp_path, _metadata(7, 0), "orchestration-0.metadata.json")
+    index_file = tmp_path / "signal_index.yaml"
+    before = index_file.read_text()
+    assert "7" in yaml.safe_load(before)
+
+    real_safe_dump = yaml.safe_dump
+
+    def _fail_after_writing_some(data, stream=None, **kwargs):  # type: ignore[no-untyped-def]
+        if stream is not None:
+            stream.write("partial: [")  # a prefix that is not valid YAML on its own
+            raise OSError("no space left on device")
+        return real_safe_dump(data, stream, **kwargs)
+
+    monkeypatch.setattr("gwmock.cli.simulate_utils.yaml.safe_dump", _fail_after_writing_some)
+    with pytest.raises(OSError, match="no space left on device"):
+        update_signal_index(tmp_path, _metadata(8, 1), "orchestration-1.metadata.json")
+    monkeypatch.undo()
+
+    # The pre-existing entry must still be there and still parse.
+    recovered = yaml.safe_load(index_file.read_text())
+    assert recovered is not None, "index was truncated by the failed write"
+    assert "7" in recovered, recovered


### PR DESCRIPTION
## 📝 Summary

Tier: T2 (code semantics — silent data loss).

`update_signal_index` had two independent defects, both losing data silently with exit
code 0.

**1. Unlocked read-modify-write.** Two runs sharing a metadata directory raced. The
loser's events vanished from `signal_index.yaml` while their samples stayed in the
frames, so `gwmock find-signal` reported nothing for an event that had been injected.

**2. Non-atomic write.** The write truncated the index in place, and the loader treats an
unparsable index as "create a new index" — so a crash or a full disk part-way through
discarded *every* entry, not just one race's worth. Not in the original report, found
while reading, and the more damaging of the two.

Fix:

- Exclusive `flock` on a sidecar file across the whole read-modify-write. A sidecar
  rather than the index, because the index is replaced and a lock on a replaced inode
  protects nothing after the rename. Never unlinked (unlink race).
- The index is written to a uniquely-named sibling and `os.replace`d into position, so a
  failed write leaves the previous index intact.
- The temporary is opened `O_CREAT|O_EXCL` with `0o666` so the kernel applies the umask
  and default ACLs as `open(..., "w")` would; an existing index's mode is preserved.
  `tempfile.mkstemp` would force `0600` and lock other accounts out of a shared metadata
  directory.
- `flock` needs a writable descriptor, so a sidecar tighter than the index blocks a
  legitimate writer at the gate. It is **widened** to match the index when too tight —
  never narrowed, since an operator may deliberately open it to an account that takes
  locks without writing the index — and a writer that still cannot open it gets an error
  naming the sidecar and the repair instead of a bare `EACCES`.
- A filesystem that cannot do advisory locks (`EOPNOTSUPP`/`ENOLCK`/`ENOSYS`) falls back
  to the previous unlocked behaviour with a one-time warning, rather than failing a write
  that would otherwise succeed. A *refused* lock (`EACCES`) still raises.

The guarantee is exactly as strong as the filesystem's `flock`, stated in the docstring:
it holds locally and on shared filesystems honouring POSIX advisory locks across hosts,
and not where NFS or a cluster filesystem does not.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not
      work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** `uv run pytest tests/cli/test_signal_index_concurrency.py` — 8 tests
      covering both defects, the permission surfaces, the unsupported-filesystem fallback
      and descriptor hygiene.
- [x] **Full suite:** `uv run pytest` — 1060 passed, 23 skipped.
- [x] **Written test-first and confirmed failing on unfixed `main`,** with the specific
      failure modes rather than generic errors: the race leaves `{'11'}` missing `'22'`;
      the partial write leaves `partial: [` → `ParserError`.
- [x] **Discrimination measured, not assumed:** the race test passes **15/15 on the fix
      and 0/15 on unfixed code**. It refuses to pass a run the *scheduler* serialised
      rather than the lock — each writer records whether the two met inside the critical
      section and how long one waited for `LOCK_EX` (≈2.0 s under the fix, a 4× margin
      over the 0.5 s threshold) — retries three times, and fails loudly if no attempt
      raced.
- [x] **Mutation-tested:** eight targeted mutations, each killed by the test that owns
      it — `flock`→no-op, `LOCK_EX`→`LOCK_SH`, atomic replace→in-place write, drop the
      mode-preserving `chmod`, temp `0600`, never preserve an existing mode, drop sidecar
      alignment, sidecar→`0600`.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation — the `update_signal_index`
      docstring stated the opposite ("Not safe against concurrent writers") and now
      states the guarantee and its filesystem caveat.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective.

## 📷 Screenshots (if applicable)

Not applicable.

## Not addressed, deliberately

- **No parent-directory `fsync`.** Durability, not atomicity: power loss can lose the
  last rename but cannot expose a partial index. Nothing else in the codebase fsyncs.
- **`LOCK_EX` blocks without a timeout.** `flock` releases on process death, so only a
  hung live writer blocks; `LOCK_NB`+retry turns a wait into a hard failure, worse for a
  long batch run.
- **No Windows locking.** Absent `fcntl`, updates run unlocked with a one-time warning
  rather than failing at import; the CI matrix is Linux and macOS.
- **Not verified across hosts.** All testing is single-host. Whether the cluster
  filesystems this project uses honour `flock` between machines is untested, and the
  fallback above is silent apart from one warning.
