### PR TITLE
docs(index): the concurrency guarantee does not hold across hosts

### DIFF
--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -808,7 +808,7 @@ def update_signal_index(
     frame file(s) that contain it plus the batch metadata file, enabling O(1)
     signal->frame lookup by id.
 
-    **Safe against concurrent writers on one host**, which it was not before: the
+    **Safe against concurrent writers on one host, when the lock is taken**, which it was not before: the
     read-modify-write was unlocked, so two runs sharing a metadata directory lost one side's
     events -- reproduced deterministically with two processes and a barrier, where the loser's
     signals stayed in the frames while vanishing from the id lookup. The whole cycle now runs
@@ -834,8 +834,11 @@ def update_signal_index(
         filesystem revalidates instead of the index.
 
         **Until this is repaired, do not run concurrent writers against one metadata directory
-        from more than one host.** Concurrent writers on a single host are safe: one host has one
-        cache.
+        from more than one host.** Concurrent writers on a single host are safe *when the lock is
+        actually taken* — one host has one cache, so the staleness above cannot arise. They are
+        **not** safe on the two paths where :func:`_exclusive_index_lock` deliberately proceeds
+        unlocked: no ``fcntl`` module, and a filesystem that rejects ``flock``. Both warn once
+        and then race exactly as this function did before the lock existed.
 
     Parameter-based lookup reads the injections recorded in the batch metadata files (their
     source of truth); this index is only the id shortcut. A batch with no injected signals

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -808,20 +808,34 @@ def update_signal_index(
     frame file(s) that contain it plus the batch metadata file, enabling O(1)
     signal->frame lookup by id.
 
-    **Safe against concurrent writers**, which it was not before: the read-modify-write was
-    unlocked, so two runs sharing a metadata directory lost one side's events -- reproduced
-    deterministically with two processes and a barrier, where the loser's signals stayed in the
-    frames while vanishing from the id lookup. The whole cycle now runs under an exclusive
-    ``flock`` on a sidecar file, and the result is renamed into place rather than written over
-    the live index, so a failed or interrupted write leaves the previous index intact instead of
-    truncating it -- which mattered because the loader below treats an unparsable index as
-    "create a new one", turning one bad write into the loss of every entry.
+    **Safe against concurrent writers on one host**, which it was not before: the
+    read-modify-write was unlocked, so two runs sharing a metadata directory lost one side's
+    events -- reproduced deterministically with two processes and a barrier, where the loser's
+    signals stayed in the frames while vanishing from the id lookup. The whole cycle now runs
+    under an exclusive ``flock`` on a sidecar file, and the result is renamed into place rather
+    than written over the live index, so a failed or interrupted write leaves the previous index
+    intact instead of truncating it -- which mattered because the loader below treats an
+    unparsable index as "create a new one", turning one bad write into the loss of every entry.
 
-    The guarantee is exactly as strong as the filesystem's ``flock``: it holds for a local
-    filesystem and for any shared one that honours POSIX advisory locks across the participating
-    hosts, and it does **not** hold where it silently does not -- some NFS configurations and
-    cluster filesystems -- in which case this reverts to the unlocked race it closes. Settling
-    that for a given deployment is a two-host stress test, not a code question.
+    .. warning::
+
+        **Writers on different hosts can still lose each other's entries, even where the lock
+        works.** Measured on an NFS home shared by two machines (2026-08-07): the lock excluded
+        correctly -- the second writer blocked 26.7 s waiting for the first -- and the update was
+        lost anyway. Acquiring the lock revalidates the *sidecar*, not ``signal_index.yaml``, so
+        the second writer read its client's cached view of the index, found nothing, started from
+        an empty mapping and wrote a file holding only its own event. The first writer's data was
+        on the server throughout.
+
+        The cause is not the lock. It is that ``_atomically_write_index`` replaces the index by
+        rename, giving it a new inode, which a client holding a cached entry for the old path
+        does not resolve to. Atomic replacement and cache coherence pull in opposite directions
+        here, and the sidecar -- chosen so the lock survives the rename -- is the thing the
+        filesystem revalidates instead of the index.
+
+        **Until this is repaired, do not run concurrent writers against one metadata directory
+        from more than one host.** Concurrent writers on a single host are safe: one host has one
+        cache.
 
     Parameter-based lookup reads the injections recorded in the batch metadata files (their
     source of truth); this index is only the id shortcut. A batch with no injected signals


### PR DESCRIPTION
## 📝 Summary

Tier: T1 (docs-only — no code semantics change; every changed line is prose inside a
docstring).

#323 stated that `update_signal_index` is "Safe against concurrent writers", qualified to
filesystems "that honour POSIX advisory locks across the participating hosts". Measured on an
NFS home shared by two machines: **that filesystem does honour them, and the guarantee still
fails.**

Two hosts, one metadata directory. The writer on host A committed event 101 and read it back.
The writer on host B **blocked 26.7 s** on the lock — exclusion works, measured twice at 28.8 s
and 26.7 s — then wrote an index containing only event 202. Event 101 was silently gone.

The cause is not the lock. Acquiring it revalidates the **sidecar**, not `signal_index.yaml`, so
host B read its client's cached view of the index, found nothing, started from an empty mapping,
and discarded A's entries while correctly holding the lock. A's data was on the server
throughout — the same process saw it seconds later once it opened the index directly.

It is structural rather than an oversight: `_atomically_write_index` replaces the index by
rename, which gives it a new inode, and a client holding a cached entry for the old path will not
resolve to it. The sidecar was chosen precisely so the lock survives that rename — and it is
therefore the file the kernel revalidates instead of the index.

This PR changes no code. It replaces a promise the code does not keep with the measured
limitation, and says plainly not to run concurrent writers against one metadata directory from
more than one host until the repair lands. Single-host concurrency is unaffected and remains
safe: one host has one cache.

Repair is designed separately; the leading candidate is a sequence number kept in the sidecar,
since the sidecar is the one file the lock does make coherent.

## ✨ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [x] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

## 🧪 How Has This Been Tested?

- [x] **Full suite:** `uv run pytest` on the review machine — 1060 passed, 23 skipped, unchanged
      from `main`.
- [x] **Two-host measurement** that produced the claim being corrected: writer on `alma10`,
      reader on `stadius-nc-5`, shared NFS home, with a four-snapshot cache diagnostic showing
      the index invisible while the lock was held and visible moments later once opened directly.
- [x] **Diff audited as prose-only** — no executable line changed.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation — this PR *is* that change.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective — n/a, no behaviour change. The
      cross-host regression test belongs with the repair, and must be cross-host: a single-host
      test provably cannot catch this.

## 📷 Screenshots (if applicable)

Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified concurrency guarantees for signal index updates on single-host and multi-host filesystems.
  * Documented limitations that may cause lost updates when multiple hosts write concurrently.
  * Added guidance to avoid concurrent cross-host writers until the underlying issue is resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->