### PR TITLE
fix(index): refuse to write the signal index on a stale read

### DIFF
--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -494,6 +494,29 @@ class IndexDigestNotRecordedError(RuntimeError):
 _NOT_WORTH_RETRYING = (StaleIndexReadError, IndexDigestNotRecordedError)
 
 
+def _is_not_worth_retrying(error: BaseException) -> bool:
+    """Return whether this failure, or anything it was raised from, is futile to retry.
+
+    The chain is walked because matching the outer type alone is fragile: wrapping one of these
+    in anything else -- ``raise RuntimeError(...) from StaleIndexReadError`` -- would restore the
+    retries, and a stale index read is no more fixable by waiting for having been re-raised.
+
+    Args:
+        error: The exception that ended the attempt.
+
+    Returns:
+        Whether to give up immediately.
+    """
+    seen: set[int] = set()
+    current: BaseException | None = error
+    while current is not None and id(current) not in seen:
+        if isinstance(current, _NOT_WORTH_RETRYING):
+            return True
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+    return False
+
+
 def retry_with_backoff(
     func: Callable[..., Any],
     max_retries: int = 3,
@@ -523,16 +546,15 @@ def retry_with_backoff(
     for attempt in range(max_retries + 1):
         try:
             return func()
-        except _NOT_WORTH_RETRYING:
-            # Waiting changes nothing for these: a stale index read is a cache state, not a
-            # transient fault, and an unrecorded digest needs an operator. Retrying would also
-            # re-simulate the whole batch each time -- these are raised after the frames and
-            # metadata are already written -- so three attempts cost three full simulations and
-            # then fail anyway, with the second onwards tripping over the first attempt's own
-            # outputs. Fail now, loudly; a resumed run re-runs the batch because its checkpoint
-            # was never saved.
-            raise
         except Exception as e:  # pylint: disable=broad-exception-caught
+            if _is_not_worth_retrying(e):
+                # Waiting changes nothing for these: a stale index read is a cache state, not a
+                # transient fault, and an unrecorded digest needs an operator. Retrying also
+                # re-simulates the whole batch each time -- they are raised after the frames and
+                # metadata are already written -- so the attempts cost full simulations and fail
+                # anyway, with the second onwards tripping over the first's own outputs. Fail
+                # now; a resumed run re-runs the batch because its checkpoint was never saved.
+                raise
             last_exception = e
             if attempt < max_retries:
                 logger.warning(
@@ -990,14 +1012,16 @@ def update_signal_index(
     injections = (metadata.get("signal") or {}).get("injections") or []
     index_file = metadata_directory / "signal_index.yaml"
     lock_file = index_file.with_name(index_file.name + ".lock")
-    # `exists()` alone cannot decide this. A stale negative dentry -- the very fault the guard
-    # below exists for -- answers "no index" without contacting the server, and a batch that must
-    # *withdraw* its previous entries would then return having withdrawn nothing, leaving rows
-    # `find-signal --id` still trusts. If the sidecar records a digest, an index exists whether or
-    # not this client can currently see it, so take the lock and let the guard decide.
-    if not injections and not index_file.exists() and _recorded_digest(lock_file) is None:
-        return
     with _exclusive_index_lock(index_file):
+        # Decided inside the lock, deliberately. Nothing read before it can be trusted: a stale
+        # negative dentry -- the very fault this guards -- answers `exists()` for the index
+        # without contacting the server, and the sidecar is created by the same first write, so a
+        # client that probed the directory early caches a negative entry for *both*. An earlier
+        # version returned here on an un-revalidated sidecar read, and a withdraw-only batch then
+        # skipped its withdrawal exactly as before the fix. Taking the lock revalidates the
+        # sidecar, which is the only one of the two whose reading can be believed.
+        if not injections and not index_file.exists() and _recorded_digest(lock_file) is None:
+            return
         _require_fresh_index_read(index_file, lock_file)
         committed = _update_signal_index_locked(index_file, injections, metadata, metadata_file_name, encoding)
         _record_digest(lock_file, committed)
@@ -1903,10 +1927,13 @@ def execute_plan(  # noqa: PLR0915
 
                 except Exception as e:
                     logger.error(
-                        "Failed to execute batch %d for simulator %s after %d retries: %s",
+                        "Failed to execute batch %d for simulator %s after %s: %s",
                         batch.batch_index,
                         simulator_name,
-                        max_retries,
+                        # Not every failure is retried -- a stale index read and an unrecorded
+                        # digest are raised straight past the loop -- and claiming retries that
+                        # never happened misleads exactly when someone is reading logs in anger.
+                        "no retries (not retryable)" if _is_not_worth_retrying(e) else f"{max_retries} retries",
                         e,
                     )
                     raise

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -828,6 +828,10 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> str:
     # Opening with an explicit 0o666 lets the kernel apply the umask and any default ACLs exactly
     # as a plain `open(..., "w")` would have -- no process-global umask read, which would race
     # with any other thread creating a file (gwmock runs a resource monitor thread).
+    # Serialise first. Doing it after the temporary exists would leak both the file and its
+    # descriptor when serialisation fails, because the cleanup below is scoped to the write.
+    payload = yaml.safe_dump(index, default_flow_style=False, sort_keys=True).encode("utf-8")
+    digest = hashlib.sha256(payload).hexdigest()
     existing_mode = _existing_index_mode(index_file)
     temporary = index_file.with_name(f"{index_file.name}.{uuid.uuid4().hex}.tmp")
     descriptor = os.open(temporary, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o666)
@@ -840,8 +844,6 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> str:
         os.close(descriptor)
         temporary.unlink(missing_ok=True)
         raise
-    payload = yaml.safe_dump(index, default_flow_style=False, sort_keys=True).encode("utf-8")
-    digest = hashlib.sha256(payload).hexdigest()
     try:
         if existing_mode is not None:
             # An index that already exists keeps whatever mode it was given, so a deliberately

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -1016,6 +1016,12 @@ def update_signal_index(
     index_file = metadata_directory / "signal_index.yaml"
     lock_file = index_file.with_name(index_file.name + ".lock")
     with _exclusive_index_lock(index_file):
+        # Taking the lock for a batch that turns out to have nothing to do is deliberate: the
+        # decision below cannot be made without a trustworthy read, and only the lock provides
+        # one. Measured at 0.049 s for 1000 no-op batches, and it leaves an empty sidecar in
+        # directories that never gain an index -- harmless, since a later real write sees no
+        # digest and takes the same permissive path as a fresh directory.
+        #
         # Decided inside the lock, deliberately. Nothing read before it can be trusted: a stale
         # negative dentry -- the very fault this guards -- answers `exists()` for the index
         # without contacting the server, and the sidecar is created by the same first write, so a

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -785,8 +785,19 @@ def _recorded_digest(lock_file: Path) -> str | None:
     """
     try:
         recorded = lock_file.read_text(encoding="utf-8").strip()
-    except (OSError, UnicodeDecodeError):
+    except FileNotFoundError:
         return None
+    except (OSError, UnicodeDecodeError) as error:
+        # `None` means "no digest yet", which is the permissive legacy path. A sidecar that
+        # exists and cannot be read is not that: it is a sidecar whose digest we are unable to
+        # check, and treating it as absent would silently disable the guard on a corrupt or
+        # unreadable file. Refuse instead.
+        raise StaleIndexReadError(
+            f"The signal-index sidecar {lock_file} exists but could not be read ({error}), so "
+            "this write cannot verify it is reading the current index. Stop all writers against "
+            f"this metadata directory, then delete {lock_file.name} to re-baseline the digest; "
+            "it holds only the digest and the lock, no data."
+        ) from error
     return recorded or None
 
 
@@ -825,8 +836,10 @@ def _record_digest(lock_file: Path, digest: str) -> None:
         raise IndexDigestNotRecordedError(
             f"The signal index was committed, but its digest could not be recorded in "
             f"{lock_file.name} ({error}). The index itself is intact and correct. Until the "
-            f"digest is re-synced every later write will refuse as stale, so delete {lock_file.name} "
-            "to re-baseline it -- the sidecar holds only the digest and the lock, no data."
+            f"digest is re-synced every later write will refuse as stale. Stop every writer "
+            f"against this directory, then delete {lock_file.name} to re-baseline it -- it holds "
+            "only the digest and the lock, no data. Deleting it while a writer is running lets "
+            "two processes lock different inodes and stop being serialised."
         ) from error
 
 
@@ -875,7 +888,10 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> str:
         # Adopt the raw descriptor immediately. Anything that raises between `os.open` and
         # `os.fdopen` -- the chmod below used to sit there -- leaves a descriptor that the
         # cleanup path unlinks the file for but never closes, and this runs once per batch.
-        handle = os.fdopen(descriptor, "w", encoding="utf-8")
+        # Binary, so the bytes written are the bytes hashed. A text handle translates newlines
+        # on Windows, and the recorded digest would then never match the file -- refusing every
+        # update after the first on exactly the platform the lock already degrades for.
+        handle = os.fdopen(descriptor, "wb")
     except BaseException:
         os.close(descriptor)
         temporary.unlink(missing_ok=True)
@@ -892,7 +908,7 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> str:
             # so there is no meaningful window for it to be swapped.
             os.chmod(temporary, existing_mode)
         with handle:
-            handle.write(payload.decode("utf-8"))
+            handle.write(payload)
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temporary, index_file)

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -847,12 +847,18 @@ def _record_digest(lock_file: Path, digest: str) -> None:
         digest: Digest of the index as committed.
     """
     try:
-        # "a+", not "r+": the sidecar is normally created when the lock is taken, but the
-        # `fcntl is None` branch yields without creating it. With "r+" the index would commit and
-        # this would raise FileNotFoundError on every update, telling the operator to delete a
-        # file that does not exist -- breaking the platform the lock deliberately degrades for.
-        with lock_file.open("a+", encoding="utf-8") as handle:
-            handle.seek(0)
+        # "r+" with a create fallback. The sidecar is normally created when the lock is taken,
+        # but the `fcntl is None` branch yields without creating it, and plain "r+" would then
+        # raise FileNotFoundError on every update -- telling the operator to delete a file that
+        # does not exist, on the platform the lock deliberately degrades for.
+        #
+        # Not "a+": that sets O_APPEND, so writes go to the end whatever the seek position, and
+        # the digest would accumulate rather than replace. Caught by the digest tests.
+        try:
+            handle = lock_file.open("r+", encoding="utf-8")
+        except FileNotFoundError:
+            handle = lock_file.open("w", encoding="utf-8")
+        with handle:
             handle.write(digest)
             handle.truncate()
             handle.flush()

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -497,9 +497,12 @@ _NOT_WORTH_RETRYING = (StaleIndexReadError, IndexDigestNotRecordedError)
 def _is_not_worth_retrying(error: BaseException) -> bool:
     """Return whether this failure, or anything it was raised from, is futile to retry.
 
-    The chain is walked because matching the outer type alone is fragile: wrapping one of these
-    in anything else -- ``raise RuntimeError(...) from StaleIndexReadError`` -- would restore the
-    retries, and a stale index read is no more fixable by waiting for having been re-raised.
+    Only ``__cause__`` is followed, never ``__context__``. Explicit chaining --
+    ``raise RuntimeError(...) from StaleIndexReadError`` -- says the original failure is the
+    reason for this one, so it is still futile to retry. ``__context__`` is set implicitly by
+    *any* exception raised while another is being handled, including a cleanup or logging failure
+    that is itself the real problem: following it made an ``OSError`` raised while handling a
+    stale read non-retryable, which is a different bug from the one this prevents.
 
     Args:
         error: The exception that ended the attempt.
@@ -513,7 +516,7 @@ def _is_not_worth_retrying(error: BaseException) -> bool:
         if isinstance(current, _NOT_WORTH_RETRYING):
             return True
         seen.add(id(current))
-        current = current.__cause__ or current.__context__
+        current = current.__cause__
     return False
 
 
@@ -1075,8 +1078,11 @@ def _require_fresh_index_read(index_file: Path, lock_file: Path) -> None:
         "must be serialised outside gwmock; (2) the index was deleted or rebuilt by hand, which "
         "is legitimate -- it is a rebuildable cache -- but leaves the sidecar describing an index "
         f"that no longer exists; (3) a previous run could not record its digest. For (2) and (3) "
-        f"the recovery is to delete {lock_file.name}, which re-baselines the digest on the next "
-        "write and discards nothing: the sidecar holds only the digest and the lock."
+        f"the recovery is to stop every writer against this directory and then delete "
+        f"{lock_file.name}, which re-baselines the digest on the next write and discards nothing: "
+        "the sidecar holds only the digest and the lock. **Stop the writers first** -- removing "
+        "it while another process holds the old inode lets a third create and lock a new one, so "
+        "two writers hold different locks and are no longer serialised."
     )
 
 

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -847,7 +847,12 @@ def _record_digest(lock_file: Path, digest: str) -> None:
         digest: Digest of the index as committed.
     """
     try:
-        with lock_file.open("r+", encoding="utf-8") as handle:
+        # "a+", not "r+": the sidecar is normally created when the lock is taken, but the
+        # `fcntl is None` branch yields without creating it. With "r+" the index would commit and
+        # this would raise FileNotFoundError on every update, telling the operator to delete a
+        # file that does not exist -- breaking the platform the lock deliberately degrades for.
+        with lock_file.open("a+", encoding="utf-8") as handle:
+            handle.seek(0)
             handle.write(digest)
             handle.truncate()
             handle.flush()
@@ -1063,6 +1068,12 @@ def _require_fresh_index_read(index_file: Path, lock_file: Path) -> None:
     """
     recorded = _recorded_digest(lock_file)
     if recorded is None:
+        if not index_file.exists():
+            # A fresh directory, not a legacy one: the lock creates the sidecar empty, so the
+            # first write into any new directory would otherwise warn that an index which does
+            # not exist "predates the staleness guard". Warning on every clean run is how the
+            # message that matters gets ignored.
+            return
         logger.warning(
             "The signal index at %s has no digest recorded in %s, so this write cannot verify it "
             "is reading the current index. Predates the staleness guard; accepted until a digest "

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -794,7 +794,7 @@ def _record_digest(lock_file: Path, digest: str) -> None:
         logger.warning("Could not record the index digest in %s: %s", lock_file, error)
 
 
-def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> None:
+def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> str:
     """Write the index so a reader sees either the old file or the new one, never a fragment.
 
     ``open(path, "w")`` truncates in place, so a crash or a full disk part-way through the dump
@@ -809,6 +809,13 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> None:
     Args:
         index_file: Destination path.
         index: The index mapping to serialise.
+
+    Returns:
+        The sha256 of the bytes committed. Returned rather than re-read afterwards: the whole
+        defect this guards is that reading ``index_file`` can be served from a stale client
+        cache, so digesting a re-read could record the digest of this client's *stale view* — and
+        a later client with the same stale view would then match it and overwrite silently, which
+        is the bug rather than the fix.
 
     Raises:
         OSError: If the file cannot be written or renamed.
@@ -833,6 +840,8 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> None:
         os.close(descriptor)
         temporary.unlink(missing_ok=True)
         raise
+    payload = yaml.safe_dump(index, default_flow_style=False, sort_keys=True).encode("utf-8")
+    digest = hashlib.sha256(payload).hexdigest()
     try:
         if existing_mode is not None:
             # An index that already exists keeps whatever mode it was given, so a deliberately
@@ -845,13 +854,14 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> None:
             # so there is no meaningful window for it to be swapped.
             os.chmod(temporary, existing_mode)
         with handle:
-            yaml.safe_dump(index, handle, default_flow_style=False, sort_keys=True)
+            handle.write(payload.decode("utf-8"))
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temporary, index_file)
     except BaseException:
         temporary.unlink(missing_ok=True)
         raise
+    return digest
 
 
 def _existing_index_mode(index_file: Path) -> int | None:
@@ -925,14 +935,18 @@ def update_signal_index(
     """
     injections = (metadata.get("signal") or {}).get("injections") or []
     index_file = metadata_directory / "signal_index.yaml"
-    if not injections and not index_file.exists():
-        return
-
     lock_file = index_file.with_name(index_file.name + ".lock")
+    # `exists()` alone cannot decide this. A stale negative dentry -- the very fault the guard
+    # below exists for -- answers "no index" without contacting the server, and a batch that must
+    # *withdraw* its previous entries would then return having withdrawn nothing, leaving rows
+    # `find-signal --id` still trusts. If the sidecar records a digest, an index exists whether or
+    # not this client can currently see it, so take the lock and let the guard decide.
+    if not injections and not index_file.exists() and _recorded_digest(lock_file) is None:
+        return
     with _exclusive_index_lock(index_file):
         _require_fresh_index_read(index_file, lock_file)
-        _update_signal_index_locked(index_file, injections, metadata, metadata_file_name, encoding)
-        _record_digest(lock_file, _index_digest(index_file))
+        committed = _update_signal_index_locked(index_file, injections, metadata, metadata_file_name, encoding)
+        _record_digest(lock_file, committed)
 
 
 def _require_fresh_index_read(index_file: Path, lock_file: Path) -> None:
@@ -985,7 +999,7 @@ def _update_signal_index_locked(
     metadata: dict[str, Any],
     metadata_file_name: str,
     encoding: str,
-) -> None:
+) -> str:
     """Do the read-modify-write, with the caller holding the index lock.
 
     Split out so the critical section is a single named span: the read, the withdrawal and the
@@ -1034,7 +1048,7 @@ def _update_signal_index_locked(
         entry["batches"].append({"metadata": metadata_file_name, "frames": signal_frames})
 
     try:
-        _atomically_write_index(index_file, index)
+        return _atomically_write_index(index_file, index)
     except (OSError, yaml.YAMLError) as e:
         logger.error("Failed to save signal index: %s", e)
         raise
@@ -1743,14 +1757,27 @@ def execute_plan(  # noqa: PLR0915
                         list(pre_batch_state.keys()),
                     )
 
+                    # A retry meets whatever the failed attempt already wrote. Those outputs are
+                    # this batch's own uncheckpointed leftovers, not user data, so a retry must be
+                    # allowed to replace them -- exactly as `resuming` does for an interrupted
+                    # run. Without this the second attempt raises FileExistsError on its own
+                    # orphan and a transient failure becomes a hard one. Reachable in particular
+                    # since `update_signal_index` can now refuse a stale read, which happens
+                    # *after* the outputs are on disk.
+                    attempted = {"once": False}
+
                     def execute_batch(
                         _simulator=simulator,
                         _batch=batch,
                         _output_directory=output_directory,
                         _pre_batch_state=pre_batch_state,
                         _overwrite=batch_overwrite,
+                        _attempted=attempted,
                     ):
                         """Execute a single batch with state management."""
+                        if _attempted["once"]:
+                            _overwrite = True
+                        _attempted["once"] = True
                         set_batch_context = getattr(_simulator, "set_batch_context", None)
                         if callable(set_batch_context):
                             set_batch_context(

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import atexit
 import copy
 import errno
+import hashlib
 import json
 import logging
 import os
@@ -620,6 +621,16 @@ def _warn_unlocked_once() -> None:
     logger.warning("fcntl unavailable: the signal index is updated without a lock, so concurrent runs can race.")
 
 
+class StaleIndexReadError(RuntimeError):
+    """The index this process read is not the one the sidecar says is current.
+
+    Raised instead of writing, because writing is what discards the entries this process cannot
+    see. The usual cause is a client cache on a shared filesystem: the lock is held correctly and
+    the index is still read from a stale view, since acquiring the lock revalidates the sidecar
+    rather than the index.
+    """
+
+
 @contextmanager
 def _exclusive_index_lock(index_file: Path) -> Iterator[None]:
     """Hold an exclusive cross-process lock for the whole read-modify-write of the index.
@@ -719,6 +730,68 @@ def _align_lock_mode(lock_file: Path, index_file: Path) -> None:
     except (FileNotFoundError, PermissionError):
         return
     logger.debug("Widened %s from %s to %s to match the index.", lock_file, oct(current), oct(widened))
+
+
+def _index_digest(index_file: Path) -> str:
+    """Return a digest of the index's bytes, or the marker for "no index".
+
+    Bytes rather than the parsed mapping: the point is to detect that *this read* differs from
+    what the last writer committed, and a re-serialisation could mask a difference the reader
+    would then act on.
+
+    Args:
+        index_file: Path to ``signal_index.yaml``.
+
+    Returns:
+        Hex digest, or ``"absent"`` when the file does not exist.
+    """
+    try:
+        return hashlib.sha256(index_file.read_bytes()).hexdigest()
+    except FileNotFoundError:
+        return "absent"
+
+
+def _recorded_digest(lock_file: Path) -> str | None:
+    """Return the digest the sidecar records, or ``None`` when it records none.
+
+    ``None`` means an index predating this guard, not a mismatch.
+
+    Args:
+        lock_file: The sidecar beside the index.
+
+    Returns:
+        The recorded hex digest or ``"absent"`` marker, or ``None`` if unrecorded.
+    """
+    try:
+        recorded = lock_file.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+    return recorded or None
+
+
+def _record_digest(lock_file: Path, digest: str) -> None:
+    """Write the digest of the index just committed into the sidecar.
+
+    Written in place, deliberately: the sidecar keeps its inode so the lock and this record stay
+    on the file the lock made the filesystem revalidate. Replacing it by rename -- as the index
+    is -- would reintroduce the cached-dentry problem this exists to detect.
+
+    Written *after* the index, so a crash in between leaves the sidecar behind the index rather
+    than ahead of it. Behind is recoverable (the reader sees a digest for an older index and
+    refuses, which is loud); ahead would mean promising an index that was never committed.
+
+    Args:
+        lock_file: The sidecar beside the index.
+        digest: Digest of the index as committed.
+    """
+    try:
+        with lock_file.open("r+", encoding="utf-8") as handle:
+            handle.write(digest)
+            handle.truncate()
+            handle.flush()
+            os.fsync(handle.fileno())
+    except OSError as error:  # pragma: no cover - the lock path already proved it is writable
+        logger.warning("Could not record the index digest in %s: %s", lock_file, error)
 
 
 def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> None:
@@ -855,8 +928,55 @@ def update_signal_index(
     if not injections and not index_file.exists():
         return
 
+    lock_file = index_file.with_name(index_file.name + ".lock")
     with _exclusive_index_lock(index_file):
+        _require_fresh_index_read(index_file, lock_file)
         _update_signal_index_locked(index_file, injections, metadata, metadata_file_name, encoding)
+        _record_digest(lock_file, _index_digest(index_file))
+
+
+def _require_fresh_index_read(index_file: Path, lock_file: Path) -> None:
+    """Refuse to proceed when this process cannot see the index the sidecar says is current.
+
+    Holding the lock does not make the read trustworthy across hosts: acquiring it revalidates
+    the sidecar, not the index, so a client with a cached view reads an older index -- or none --
+    and writing then discards everything it could not see. Measured on a shared NFS home, where
+    the lock excluded correctly for 26.7 s and the update was lost anyway.
+
+    The comparison is against the sidecar because that is the file the lock *does* make the
+    filesystem revalidate, and it is written in place so it keeps its inode.
+
+    A sidecar with no digest predates this guard and is accepted with a warning: refusing would
+    break every in-flight run on upgrade, a certain cost against an uncertain one. That
+    acceptance should become a refusal once no index predates the release carrying this.
+
+    Args:
+        index_file: Path to ``signal_index.yaml``.
+        lock_file: The sidecar holding the digest of the last committed index.
+
+    Raises:
+        StaleIndexReadError: If the index this process reads is not the one last committed.
+    """
+    recorded = _recorded_digest(lock_file)
+    if recorded is None:
+        logger.warning(
+            "The signal index at %s has no digest recorded in %s, so this write cannot verify it "
+            "is reading the current index. Predates the staleness guard; accepted once.",
+            index_file,
+            lock_file.name,
+        )
+        return
+    seen = _index_digest(index_file)
+    if seen == recorded:
+        return
+    raise StaleIndexReadError(
+        f"This process reads {index_file} as {seen}, but {lock_file.name} records the last "
+        f"committed index as {recorded}, so the read is stale and writing would discard entries "
+        "this process cannot see. The usual cause is a filesystem cache on a shared mount: the "
+        "lock is held correctly, and the index is still read from an out-of-date view. Retry the "
+        "batch; if it persists, the writers are on different hosts and must be serialised "
+        "outside gwmock until they share a client cache."
+    )
 
 
 def _update_signal_index_locked(

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -472,6 +472,28 @@ def _build_output_records(
     return output_records
 
 
+class StaleIndexReadError(RuntimeError):
+    """The index this process read is not the one the sidecar says is current.
+
+    Raised instead of writing, because writing is what discards the entries this process cannot
+    see. The usual cause is a client cache on a shared filesystem: the lock is held correctly and
+    the index is still read from a stale view, since acquiring the lock revalidates the sidecar
+    rather than the index.
+    """
+
+
+class IndexDigestNotRecordedError(RuntimeError):
+    """The index was committed but its digest could not be recorded.
+
+    Distinct from :class:`StaleIndexReadError`: nothing is stale and no data is lost, but the
+    sidecar is now behind the index, and every later write refuses until it is re-baselined.
+    """
+
+
+#: Failures a backoff cannot help. Raised past the retry loop rather than attempted again.
+_NOT_WORTH_RETRYING = (StaleIndexReadError, IndexDigestNotRecordedError)
+
+
 def retry_with_backoff(
     func: Callable[..., Any],
     max_retries: int = 3,
@@ -501,6 +523,15 @@ def retry_with_backoff(
     for attempt in range(max_retries + 1):
         try:
             return func()
+        except _NOT_WORTH_RETRYING:
+            # Waiting changes nothing for these: a stale index read is a cache state, not a
+            # transient fault, and an unrecorded digest needs an operator. Retrying would also
+            # re-simulate the whole batch each time -- these are raised after the frames and
+            # metadata are already written -- so three attempts cost three full simulations and
+            # then fail anyway, with the second onwards tripping over the first attempt's own
+            # outputs. Fail now, loudly; a resumed run re-runs the batch because its checkpoint
+            # was never saved.
+            raise
         except Exception as e:  # pylint: disable=broad-exception-caught
             last_exception = e
             if attempt < max_retries:
@@ -619,16 +650,6 @@ def _warn_unlocked_once() -> None:
     by a global nobody re-checks.
     """
     logger.warning("fcntl unavailable: the signal index is updated without a lock, so concurrent runs can race.")
-
-
-class StaleIndexReadError(RuntimeError):
-    """The index this process read is not the one the sidecar says is current.
-
-    Raised instead of writing, because writing is what discards the entries this process cannot
-    see. The usual cause is a client cache on a shared filesystem: the lock is held correctly and
-    the index is still read from a stale view, since acquiring the lock revalidates the sidecar
-    rather than the index.
-    """
 
 
 @contextmanager
@@ -776,9 +797,14 @@ def _record_digest(lock_file: Path, digest: str) -> None:
     on the file the lock made the filesystem revalidate. Replacing it by rename -- as the index
     is -- would reintroduce the cached-dentry problem this exists to detect.
 
-    Written *after* the index, so a crash in between leaves the sidecar behind the index rather
-    than ahead of it. Behind is recoverable (the reader sees a digest for an older index and
-    refuses, which is loud); ahead would mean promising an index that was never committed.
+    Written *after* the index, so a failure in between leaves the sidecar behind rather than
+    ahead: ahead would promise an index that was never committed, which is silent. Behind is
+    loud — but **not self-correcting**, and an earlier version of this docstring wrongly called
+    it "recoverable". Nothing advances the recorded digest except this function, which runs only
+    after a successful update, which the guard is by then refusing; the directory wedges until
+    the sidecar is removed. That is why a failure here is raised rather than logged and dropped:
+    the operator learns at the point of the fault, with the index intact, instead of meeting a
+    permanent refusal on the next batch.
 
     Args:
         lock_file: The sidecar beside the index.
@@ -790,8 +816,18 @@ def _record_digest(lock_file: Path, digest: str) -> None:
             handle.truncate()
             handle.flush()
             os.fsync(handle.fileno())
-    except OSError as error:  # pragma: no cover - the lock path already proved it is writable
-        logger.warning("Could not record the index digest in %s: %s", lock_file, error)
+    except OSError as error:
+        # Being able to take the lock does not mean the write will land: fsync can still fail
+        # with EIO or ENOSPC. Swallowing it would leave the index committed and the sidecar
+        # behind, which is the permanent wedge described above -- discovered by whoever runs the
+        # next batch, with a message blaming a cache that is not the cause.
+        logger.error("Could not record the index digest in %s: %s", lock_file, error)
+        raise IndexDigestNotRecordedError(
+            f"The signal index was committed, but its digest could not be recorded in "
+            f"{lock_file.name} ({error}). The index itself is intact and correct. Until the "
+            f"digest is re-synced every later write will refuse as stale, so delete {lock_file.name} "
+            "to re-baseline it -- the sidecar holds only the digest and the lock, no data."
+        ) from error
 
 
 def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> str:
@@ -963,8 +999,11 @@ def _require_fresh_index_read(index_file: Path, lock_file: Path) -> None:
     filesystem revalidate, and it is written in place so it keeps its inode.
 
     A sidecar with no digest predates this guard and is accepted with a warning: refusing would
-    break every in-flight run on upgrade, a certain cost against an uncertain one. That
-    acceptance should become a refusal once no index predates the release carrying this.
+    break every in-flight run on upgrade, a certain cost against an uncertain one. The window is
+    one unprotected write *per writer that has not yet recorded a digest* -- so on a directory
+    shared by several hosts, each gets one pass before any of them records, and the original bug
+    is reachable for exactly those writes. That acceptance should become a refusal once no index
+    predates the release carrying this.
 
     Args:
         index_file: Path to ``signal_index.yaml``.
@@ -977,7 +1016,9 @@ def _require_fresh_index_read(index_file: Path, lock_file: Path) -> None:
     if recorded is None:
         logger.warning(
             "The signal index at %s has no digest recorded in %s, so this write cannot verify it "
-            "is reading the current index. Predates the staleness guard; accepted once.",
+            "is reading the current index. Predates the staleness guard; accepted until a digest "
+            "is recorded -- on a directory shared by several hosts each unprotected writer gets "
+            "one such pass, so the first post-upgrade write is the one to run from a single host.",
             index_file,
             lock_file.name,
         )
@@ -988,10 +1029,14 @@ def _require_fresh_index_read(index_file: Path, lock_file: Path) -> None:
     raise StaleIndexReadError(
         f"This process reads {index_file} as {seen}, but {lock_file.name} records the last "
         f"committed index as {recorded}, so the read is stale and writing would discard entries "
-        "this process cannot see. The usual cause is a filesystem cache on a shared mount: the "
-        "lock is held correctly, and the index is still read from an out-of-date view. Retry the "
-        "batch; if it persists, the writers are on different hosts and must be serialised "
-        "outside gwmock until they share a client cache."
+        "this process cannot see. Causes, in the order worth checking: (1) a filesystem cache on "
+        "a shared mount, where the lock is held correctly and the index is still read from an "
+        "out-of-date view -- retry, and if it persists the writers are on different hosts and "
+        "must be serialised outside gwmock; (2) the index was deleted or rebuilt by hand, which "
+        "is legitimate -- it is a rebuildable cache -- but leaves the sidecar describing an index "
+        f"that no longer exists; (3) a previous run could not record its digest. For (2) and (3) "
+        f"the recovery is to delete {lock_file.name}, which re-baselines the digest on the next "
+        "write and discards nothing: the sidecar holds only the digest and the lock."
     )
 
 
@@ -1759,27 +1804,14 @@ def execute_plan(  # noqa: PLR0915
                         list(pre_batch_state.keys()),
                     )
 
-                    # A retry meets whatever the failed attempt already wrote. Those outputs are
-                    # this batch's own uncheckpointed leftovers, not user data, so a retry must be
-                    # allowed to replace them -- exactly as `resuming` does for an interrupted
-                    # run. Without this the second attempt raises FileExistsError on its own
-                    # orphan and a transient failure becomes a hard one. Reachable in particular
-                    # since `update_signal_index` can now refuse a stale read, which happens
-                    # *after* the outputs are on disk.
-                    attempted = {"once": False}
-
                     def execute_batch(
                         _simulator=simulator,
                         _batch=batch,
                         _output_directory=output_directory,
                         _pre_batch_state=pre_batch_state,
                         _overwrite=batch_overwrite,
-                        _attempted=attempted,
                     ):
                         """Execute a single batch with state management."""
-                        if _attempted["once"]:
-                            _overwrite = True
-                        _attempted["once"] = True
                         set_batch_context = getattr(_simulator, "set_batch_context", None)
                         if callable(set_batch_context):
                             set_batch_context(

--- a/tests/cli/test_signal_index_concurrency.py
+++ b/tests/cli/test_signal_index_concurrency.py
@@ -346,15 +346,15 @@ def test_index_survives_a_write_that_fails_partway(tmp_path: Path, monkeypatch: 
     before = index_file.read_text()
     assert "7" in yaml.safe_load(before)
 
-    real_safe_dump = yaml.safe_dump
+    # Fail at the last possible moment -- the rename that publishes the new index. Anything that
+    # fails before it must leave the previous index untouched, which is the property being pinned.
+    # (An earlier version simulated this by making `yaml.safe_dump` fail while writing to a
+    # stream; the writer now serialises to bytes first, so that mock no longer intercepts
+    # anything and the test passed vacuously.)
+    def _fail_to_publish(source, destination):  # type: ignore[no-untyped-def]
+        raise OSError("no space left on device")
 
-    def _fail_after_writing_some(data, stream=None, **kwargs):  # type: ignore[no-untyped-def]
-        if stream is not None:
-            stream.write("partial: [")  # a prefix that is not valid YAML on its own
-            raise OSError("no space left on device")
-        return real_safe_dump(data, stream, **kwargs)
-
-    monkeypatch.setattr("gwmock.cli.simulate_utils.yaml.safe_dump", _fail_after_writing_some)
+    monkeypatch.setattr("gwmock.cli.simulate_utils.os.replace", _fail_to_publish)
     with pytest.raises(OSError, match="no space left on device"):
         update_signal_index(tmp_path, _metadata(8, 1), "orchestration-1.metadata.json")
     monkeypatch.undo()

--- a/tests/cli/test_signal_index_stale_read.py
+++ b/tests/cli/test_signal_index_stale_read.py
@@ -215,3 +215,39 @@ def test_an_ordinary_failure_is_still_retried(monkeypatch: pytest.MonkeyPatch) -
 
     assert retry_with_backoff(_transient, max_retries=3, initial_delay=0.0) == "ok"
     assert calls["n"] == 3, calls["n"]
+
+
+def test_the_recorded_digest_matches_the_bytes_on_disk(tmp_path: Path) -> None:
+    """The digest must describe the file as stored, byte for byte.
+
+    Hashing the serialised payload and then writing it through a text-mode handle would on any
+    platform that translates newlines: the digest would never match the file again, and every
+    update after the first would refuse. Comparing the recorded digest against a fresh hash of
+    the file on disk catches that regardless of platform.
+    """
+    for batch, event in enumerate((60, 61)):
+        update_signal_index(tmp_path, _metadata(event, batch), f"orchestration-{batch}.metadata.json")
+    on_disk = hashlib.sha256((tmp_path / "signal_index.yaml").read_bytes()).hexdigest()
+    recorded = (tmp_path / "signal_index.yaml.lock").read_text().strip()
+    assert recorded == on_disk, f"recorded {recorded[:12]} but the file hashes to {on_disk[:12]}"
+
+
+def test_an_unreadable_sidecar_does_not_disable_the_guard(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sidecar that exists but cannot be read must refuse, not fall through as "no digest".
+
+    Mapping every read error to "no digest recorded" would take the permissive legacy path on a
+    corrupt or unreadable sidecar -- silently turning the guard off exactly when something is
+    already wrong.
+    """
+    update_signal_index(tmp_path, _metadata(70, 0), "orchestration-0.metadata.json")
+    sidecar = tmp_path / "signal_index.yaml.lock"
+    real_read_text = Path.read_text
+
+    def _unreadable(self: Path, *args: Any, **kwargs: Any) -> str:
+        if self == sidecar:
+            raise OSError("input/output error")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _unreadable)
+    with pytest.raises(StaleIndexReadError, match="could not be read"):
+        update_signal_index(tmp_path, _metadata(71, 1), "orchestration-1.metadata.json")

--- a/tests/cli/test_signal_index_stale_read.py
+++ b/tests/cli/test_signal_index_stale_read.py
@@ -175,10 +175,10 @@ def test_a_withdrawing_batch_is_not_skipped_by_a_stale_existence_check(
 
     monkeypatch.setattr(Path, "exists", _index_looks_absent)
     empty = {"signal": {"injections": []}, "outputs": []}
-    with pytest.raises(StaleIndexReadError, match="stale"):
-        update_signal_index(tmp_path, empty, "orchestration-0.metadata.json")
+    update_signal_index(tmp_path, empty, "orchestration-0.metadata.json")
     monkeypatch.undo()
 
-    # Refused, so the entry it should have withdrawn is still there -- and still accurate,
-    # because nothing was written on a view that could not see it.
-    assert set(yaml.safe_load(index_file.read_text())) == {"50"}
+    # The claim is that the batch reached the locked section instead of returning early: its
+    # previous row is withdrawn. Asserting a raise here would be wrong -- this client can read the
+    # index perfectly well, only `exists()` was made to lie, so the guard is right not to fire.
+    assert yaml.safe_load(index_file.read_text()) == {}, "the withdrawing batch was skipped"

--- a/tests/cli/test_signal_index_stale_read.py
+++ b/tests/cli/test_signal_index_stale_read.py
@@ -278,7 +278,7 @@ def test_a_failure_to_record_the_digest_is_raised_not_swallowed(
     sidecar = tmp_path / "signal_index.yaml.lock"
 
     def _sidecar_write_fails(self: Path, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
-        if self == sidecar and "r+" in mode:
+        if self == sidecar and ("r+" in mode or "a+" in mode):
             raise OSError("input/output error")
         return real_open(self, mode, *args, **kwargs)
 
@@ -380,3 +380,19 @@ def test_an_unrelated_failure_during_handling_is_still_retried() -> None:
     # `from None` severs the cause but pytest still records context; the retry must proceed.
     assert retry_with_backoff(_fails_during_handling, max_retries=3, initial_delay=0.0) == "ok"
     assert calls["n"] == 3, calls["n"]
+
+
+def test_a_fresh_directory_does_not_warn_about_predating_the_guard(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The legacy warning must not fire where there is no legacy.
+
+    The lock creates the sidecar empty, and empty means "no digest recorded" -- so without this
+    the first write into every new metadata directory warns that an index which does not exist
+    predates the guard. A warning on every clean run is how the one that matters gets ignored.
+    """
+    with caplog.at_level("WARNING"):
+        update_signal_index(tmp_path, _metadata(100, 0), "orchestration-0.metadata.json")
+    assert not [r for r in caplog.records if "predates" in r.message.lower()], [r.message for r in caplog.records]
+    # ...and the digest is still recorded, so the guard is armed from the second write on.
+    assert (tmp_path / "signal_index.yaml.lock").read_text().strip()

--- a/tests/cli/test_signal_index_stale_read.py
+++ b/tests/cli/test_signal_index_stale_read.py
@@ -62,9 +62,17 @@ def test_a_stale_index_read_is_refused_not_believed(tmp_path: Path, monkeypatch:
     index_file = tmp_path / "signal_index.yaml"
     assert set(yaml.safe_load(index_file.read_text())) == {"1", "2"}
 
-    # Simulate the stale client: the reader sees the index as it was one update ago.
-    one_update_ago = yaml.safe_dump({"1": {"batches": [], "coa_time": 101.0}})
-    monkeypatch.setattr(Path, "read_text", lambda self, *a, **k: one_update_ago if self == index_file else "")
+    # Simulate the stale client: this process reads the index as it was one update ago. Patch
+    # ONLY the index's bytes -- an earlier version of this test patched Path.read_text globally
+    # and so blanked the sidecar too, which sent the guard down its "no digest recorded" branch
+    # and made the test pass for the wrong reason.
+    one_update_ago = yaml.safe_dump({"1": {"batches": [], "coa_time": 101.0}}).encode()
+    real_read_bytes = Path.read_bytes
+
+    def _stale_index_bytes(self: Path) -> bytes:
+        return one_update_ago if self == index_file else real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", _stale_index_bytes)
 
     with pytest.raises(StaleIndexReadError, match="stale"):
         update_signal_index(tmp_path, _metadata(3, 2), "orchestration-2.metadata.json")

--- a/tests/cli/test_signal_index_stale_read.py
+++ b/tests/cli/test_signal_index_stale_read.py
@@ -1,0 +1,116 @@
+# Copyright (C) 2026 Leuven Gravity Institute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+"""A writer must not build on an index read it cannot trust.
+
+Holding the lock is not enough when the writers are on different hosts. Measured on a shared NFS
+home: the lock excluded correctly -- the second writer blocked 26.7 s -- and the update was lost
+anyway, because acquiring the lock revalidates the *sidecar*, not ``signal_index.yaml``. The
+second writer read its client's cached view, found nothing, and wrote a file holding only its own
+event.
+
+The repair records, in the sidecar, a digest of the index that sidecar corresponds to. A writer
+that reads an index whose digest disagrees knows its read is stale before it acts on it. The
+digest lives in the sidecar rather than in the index because consumers iterate the index's keys
+as event ids (``find_signals``, ``_withdraw_batch``), so a bookkeeping key there would be read as
+an event.
+
+**These tests simulate the stale read locally** by feeding the reader an out-of-date view. The
+real fault needs two hosts and a cache, which no single-host test can produce -- that is the
+whole reason it survived #323's review. The cross-host harness lives outside the repo; what is
+pinned here is that a stale read is *detected* rather than silently believed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from gwmock.cli.simulate_utils import StaleIndexReadError, update_signal_index
+
+pytestmark = pytest.mark.unit
+
+
+def _metadata(event_id: int, batch: int) -> dict[str, Any]:
+    """One batch's metadata injecting a single distinct event."""
+    return {
+        "signal": {"injections": [{"event_id": event_id, "parameters": {"coa_time": 100.0 + event_id}}]},
+        "outputs": [{"kind": "signal", "path": f"signal/signal-{batch}.gwf"}],
+    }
+
+
+def test_a_stale_index_read_is_refused_not_believed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A reader whose index view predates the recorded digest must refuse to write.
+
+    This is the cross-host bug in miniature: the writer's entries are on the server, this reader
+    cannot see them, and writing anyway is what discards them.
+    """
+    update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+    update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
+    index_file = tmp_path / "signal_index.yaml"
+    assert set(yaml.safe_load(index_file.read_text())) == {"1", "2"}
+
+    # Simulate the stale client: the reader sees the index as it was one update ago.
+    one_update_ago = yaml.safe_dump({"1": {"batches": [], "coa_time": 101.0}})
+    monkeypatch.setattr(Path, "read_text", lambda self, *a, **k: one_update_ago if self == index_file else "")
+
+    with pytest.raises(StaleIndexReadError, match="stale"):
+        update_signal_index(tmp_path, _metadata(3, 2), "orchestration-2.metadata.json")
+
+    monkeypatch.undo()
+    # The refusal must leave the index exactly as it was -- refusing and corrupting is no better
+    # than believing the stale read.
+    assert set(yaml.safe_load(index_file.read_text())) == {"1", "2"}
+
+
+def test_an_index_that_matches_its_digest_is_accepted(tmp_path: Path) -> None:
+    """The guard must not fire on the ordinary path, or it is just an outage."""
+    for batch, event in enumerate((10, 11, 12)):
+        update_signal_index(tmp_path, _metadata(event, batch), f"orchestration-{batch}.metadata.json")
+    assert set(yaml.safe_load((tmp_path / "signal_index.yaml").read_text())) == {"10", "11", "12"}
+
+
+def test_an_index_predating_the_digest_is_accepted_with_a_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An index written before this feature has no digest to check, and must still be usable.
+
+    Refusing would break every in-flight run on upgrade -- a certain cost against an uncertain
+    one, the same trade #321 made for checkpoints without a config hash. It expires the same way:
+    once no index predates the release carrying this, the acceptance can become a refusal.
+    """
+    update_signal_index(tmp_path, _metadata(20, 0), "orchestration-0.metadata.json")
+    sidecar = tmp_path / "signal_index.yaml.lock"
+    sidecar.write_text("")  # as an older version left it: present, empty, no digest
+
+    with caplog.at_level("WARNING"):
+        update_signal_index(tmp_path, _metadata(21, 1), "orchestration-1.metadata.json")
+
+    assert set(yaml.safe_load((tmp_path / "signal_index.yaml").read_text())) == {"20", "21"}
+    assert any("no digest" in record.message.lower() for record in caplog.records), [r.message for r in caplog.records]
+
+
+def test_the_digest_survives_a_missing_index(tmp_path: Path) -> None:
+    """A sidecar promising an index that is gone is a divergence, not a fresh start.
+
+    Deleting the index by hand while the sidecar records a digest for it is indistinguishable, to
+    this client, from not being able to see it -- which is exactly the fault being guarded. Refuse
+    rather than silently starting over, and say how to proceed deliberately.
+    """
+    update_signal_index(tmp_path, _metadata(30, 0), "orchestration-0.metadata.json")
+    (tmp_path / "signal_index.yaml").unlink()
+
+    with pytest.raises(StaleIndexReadError, match="stale"):
+        update_signal_index(tmp_path, _metadata(31, 1), "orchestration-1.metadata.json")

--- a/tests/cli/test_signal_index_stale_read.py
+++ b/tests/cli/test_signal_index_stale_read.py
@@ -39,7 +39,7 @@ from typing import Any
 import pytest
 import yaml
 
-from gwmock.cli.simulate_utils import StaleIndexReadError, update_signal_index
+from gwmock.cli.simulate_utils import StaleIndexReadError, retry_with_backoff, update_signal_index
 
 pytestmark = pytest.mark.unit
 
@@ -182,3 +182,36 @@ def test_a_withdrawing_batch_is_not_skipped_by_a_stale_existence_check(
     # previous row is withdrawn. Asserting a raise here would be wrong -- this client can read the
     # index perfectly well, only `exists()` was made to lie, so the guard is right not to fire.
     assert yaml.safe_load(index_file.read_text()) == {}, "the withdrawing batch was skipped"
+
+
+def test_a_stale_read_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`retry_with_backoff` must let a stale read straight through.
+
+    Waiting changes nothing: a stale index read is a cache state, not a transient fault. Worse,
+    it is raised *after* the batch's frames and metadata are written, so each retry re-simulates
+    the whole batch and the second attempt trips over the first's outputs. Three attempts, three
+    full simulations, same failure.
+    """
+    calls = {"n": 0}
+
+    def _always_stale() -> None:
+        calls["n"] += 1
+        raise StaleIndexReadError("stale")
+
+    with pytest.raises(StaleIndexReadError):
+        retry_with_backoff(_always_stale, max_retries=3, initial_delay=0.0)
+    assert calls["n"] == 1, f"the stale read was attempted {calls['n']} times; it must not be retried"
+
+
+def test_an_ordinary_failure_is_still_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The no-retry rule must be narrow, or it silently disables the retry loop."""
+    calls = {"n": 0}
+
+    def _transient() -> str:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise OSError("transient")
+        return "ok"
+
+    assert retry_with_backoff(_transient, max_retries=3, initial_delay=0.0) == "ok"
+    assert calls["n"] == 3, calls["n"]

--- a/tests/cli/test_signal_index_stale_read.py
+++ b/tests/cli/test_signal_index_stale_read.py
@@ -356,3 +356,27 @@ def test_a_withdrawing_batch_survives_both_dentries_being_stale(
     monkeypatch.undo()
 
     assert yaml.safe_load(index_file.read_text()) == {}, "the withdrawal was skipped on a stale sidecar read"
+
+
+def test_an_unrelated_failure_during_handling_is_still_retried() -> None:
+    """Implicit context must not suppress retries.
+
+    ``__context__`` is set by any exception raised while another is being handled -- a cleanup or
+    logging failure, where the *new* exception is the real problem. Following it made an OSError
+    raised during handling of a stale read non-retryable, which is a different bug from the one
+    the chain walk prevents.
+    """
+    calls = {"n": 0}
+
+    def _fails_during_handling() -> str:
+        calls["n"] += 1
+        try:
+            raise StaleIndexReadError("stale")
+        except StaleIndexReadError:
+            if calls["n"] < 3:
+                raise OSError("transient cleanup failure") from None
+            return "ok"
+
+    # `from None` severs the cause but pytest still records context; the retry must proceed.
+    assert retry_with_backoff(_fails_during_handling, max_retries=3, initial_delay=0.0) == "ok"
+    assert calls["n"] == 3, calls["n"]

--- a/tests/cli/test_signal_index_stale_read.py
+++ b/tests/cli/test_signal_index_stale_read.py
@@ -32,6 +32,7 @@ pinned here is that a stale read is *detected* rather than silently believed.
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 from typing import Any
 
@@ -122,3 +123,62 @@ def test_the_digest_survives_a_missing_index(tmp_path: Path) -> None:
 
     with pytest.raises(StaleIndexReadError, match="stale"):
         update_signal_index(tmp_path, _metadata(31, 1), "orchestration-1.metadata.json")
+
+
+def test_the_recorded_digest_is_of_the_bytes_written_not_of_a_re_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The sidecar must record what was committed, not what this client can read back.
+
+    Re-reading the index to digest it runs through the very path that can be stale, so a client
+    with a stale view would record a digest *of that stale view* -- and the next client with the
+    same view would match it and overwrite silently. The guard would then certify the bug.
+    """
+    update_signal_index(tmp_path, _metadata(40, 0), "orchestration-0.metadata.json")
+    index_file = tmp_path / "signal_index.yaml"
+    sidecar = tmp_path / "signal_index.yaml.lock"
+    committed = index_file.read_bytes()
+
+    # From here this client reads the index stale -- as it was before the next update lands.
+    real_read_bytes = Path.read_bytes
+
+    def _stale_after_write(self: Path) -> bytes:
+        return committed if self == index_file else real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", _stale_after_write)
+    update_signal_index(tmp_path, _metadata(41, 1), "orchestration-1.metadata.json")
+    monkeypatch.undo()
+
+    truth = hashlib.sha256(index_file.read_bytes()).hexdigest()
+    stale = hashlib.sha256(committed).hexdigest()
+    recorded = sidecar.read_text().strip()
+    assert recorded != stale, "the sidecar recorded the digest of a stale re-read"
+    assert recorded == truth, f"recorded {recorded[:12]} but the committed index is {truth[:12]}"
+
+
+def test_a_withdrawing_batch_is_not_skipped_by_a_stale_existence_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A batch with no injections must still reach the guard when an index exists.
+
+    The early return asked ``index_file.exists()``, which a stale negative dentry answers without
+    contacting the server -- so a rerun that must *withdraw* its previous entries returned having
+    withdrawn nothing, leaving rows ``find-signal --id`` still trusts.
+    """
+    update_signal_index(tmp_path, _metadata(50, 0), "orchestration-0.metadata.json")
+    index_file = tmp_path / "signal_index.yaml"
+
+    real_exists = Path.exists
+
+    def _index_looks_absent(self: Path, **kwargs: Any) -> bool:
+        return False if self == index_file else real_exists(self, **kwargs)
+
+    monkeypatch.setattr(Path, "exists", _index_looks_absent)
+    empty = {"signal": {"injections": []}, "outputs": []}
+    with pytest.raises(StaleIndexReadError, match="stale"):
+        update_signal_index(tmp_path, empty, "orchestration-0.metadata.json")
+    monkeypatch.undo()
+
+    # Refused, so the entry it should have withdrawn is still there -- and still accurate,
+    # because nothing was written on a view that could not see it.
+    assert set(yaml.safe_load(index_file.read_text())) == {"50"}

--- a/tests/cli/test_signal_index_stale_read.py
+++ b/tests/cli/test_signal_index_stale_read.py
@@ -276,16 +276,13 @@ def test_a_failure_to_record_the_digest_is_raised_not_swallowed(
 
     real_open = Path.open
     sidecar = tmp_path / "signal_index.yaml.lock"
-    # The lock and the digest write both open the sidecar "a+", so the mode cannot tell them
-    # apart -- failing on the mode alone breaks the lock itself and every test in the file. The
-    # lock takes the first such open of each update; the digest write is the second.
-    writes = {"n": 0}
 
+    # Only the digest write opens the sidecar for writing at a position; the lock opens it "a+".
+    # Keying on that distinction failed the lock itself in an earlier version, which broke seven
+    # unrelated tests -- an injection wider than its target.
     def _sidecar_write_fails(self: Path, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
-        if self == sidecar and "a+" in mode:
-            writes["n"] += 1
-            if writes["n"] >= 2:
-                raise OSError("input/output error")
+        if self == sidecar and ("r+" in mode or mode == "w"):
+            raise OSError("input/output error")
         return real_open(self, mode, *args, **kwargs)
 
     monkeypatch.setattr(Path, "open", _sidecar_write_fails)

--- a/tests/cli/test_signal_index_stale_read.py
+++ b/tests/cli/test_signal_index_stale_read.py
@@ -276,10 +276,16 @@ def test_a_failure_to_record_the_digest_is_raised_not_swallowed(
 
     real_open = Path.open
     sidecar = tmp_path / "signal_index.yaml.lock"
+    # The lock and the digest write both open the sidecar "a+", so the mode cannot tell them
+    # apart -- failing on the mode alone breaks the lock itself and every test in the file. The
+    # lock takes the first such open of each update; the digest write is the second.
+    writes = {"n": 0}
 
     def _sidecar_write_fails(self: Path, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
-        if self == sidecar and ("r+" in mode or "a+" in mode):
-            raise OSError("input/output error")
+        if self == sidecar and "a+" in mode:
+            writes["n"] += 1
+            if writes["n"] >= 2:
+                raise OSError("input/output error")
         return real_open(self, mode, *args, **kwargs)
 
     monkeypatch.setattr(Path, "open", _sidecar_write_fails)

--- a/tests/cli/test_signal_index_stale_read.py
+++ b/tests/cli/test_signal_index_stale_read.py
@@ -32,6 +32,7 @@ pinned here is that a stale read is *detected* rather than silently believed.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 from pathlib import Path
 from typing import Any
@@ -39,7 +40,13 @@ from typing import Any
 import pytest
 import yaml
 
-from gwmock.cli.simulate_utils import StaleIndexReadError, retry_with_backoff, update_signal_index
+from gwmock.cli import simulate_utils
+from gwmock.cli.simulate_utils import (
+    IndexDigestNotRecordedError,
+    StaleIndexReadError,
+    retry_with_backoff,
+    update_signal_index,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -251,3 +258,101 @@ def test_an_unreadable_sidecar_does_not_disable_the_guard(tmp_path: Path, monkey
     monkeypatch.setattr(Path, "read_text", _unreadable)
     with pytest.raises(StaleIndexReadError, match="could not be read"):
         update_signal_index(tmp_path, _metadata(71, 1), "orchestration-1.metadata.json")
+
+
+def test_a_failure_to_record_the_digest_is_raised_not_swallowed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The blocker fix needs its own test: swallowing here wedges the directory silently.
+
+    Being able to take the lock does not mean the write lands -- fsync can still fail with EIO or
+    ENOSPC. Dropping that leaves the index committed and the sidecar behind, and every later
+    write refuses as stale with a message blaming a cache. Reverting to the old swallow passed
+    every other test in this file, which is why this one exists.
+    """
+    update_signal_index(tmp_path, _metadata(80, 0), "orchestration-0.metadata.json")
+    index_file = tmp_path / "signal_index.yaml"
+    committed = index_file.read_bytes()
+
+    real_open = Path.open
+    sidecar = tmp_path / "signal_index.yaml.lock"
+
+    def _sidecar_write_fails(self: Path, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
+        if self == sidecar and "r+" in mode:
+            raise OSError("input/output error")
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", _sidecar_write_fails)
+    with pytest.raises(IndexDigestNotRecordedError, match="could not be recorded"):
+        update_signal_index(tmp_path, _metadata(81, 1), "orchestration-1.metadata.json")
+    monkeypatch.undo()
+
+    # The index itself is committed and correct -- that is what makes the silent version so bad.
+    assert index_file.read_bytes() != committed
+    assert set(yaml.safe_load(index_file.read_text())) == {"80", "81"}
+
+
+def test_neither_guard_error_is_retried_even_when_wrapped() -> None:
+    """The no-retry rule must survive being re-raised from something else."""
+
+    def _attempts_before_giving_up(error: Exception) -> int:
+        calls = {"n": 0}
+
+        def _wrapped() -> None:
+            calls["n"] += 1
+            raise RuntimeError("wrapped") from error
+
+        with pytest.raises(RuntimeError):
+            retry_with_backoff(_wrapped, max_retries=3, initial_delay=0.0)
+        return calls["n"]
+
+    for error in (StaleIndexReadError("stale"), IndexDigestNotRecordedError("unrecorded")):
+        attempts = _attempts_before_giving_up(error)
+        assert attempts == 1, f"{type(error).__name__} wrapped was attempted {attempts} times"
+
+
+def test_a_withdrawing_batch_survives_both_dentries_being_stale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The no-op decision must not trust a sidecar read taken before the lock.
+
+    The sidecar is created by the same first write as the index, so a client that probed the
+    directory early caches a negative entry for *both*. Deciding to return early on that reading
+    skipped the withdrawal exactly as the original bug did -- reached through the sidecar instead
+    of the index.
+    """
+    update_signal_index(tmp_path, _metadata(90, 0), "orchestration-0.metadata.json")
+    index_file = tmp_path / "signal_index.yaml"
+    sidecar = tmp_path / "signal_index.yaml.lock"
+
+    real_exists = Path.exists
+    real_read_text = Path.read_text
+    unlocked = {"active": True}
+
+    def _both_look_absent(self: Path, **kwargs: Any) -> bool:
+        return False if (unlocked["active"] and self == index_file) else real_exists(self, **kwargs)
+
+    def _sidecar_looks_absent(self: Path, *args: Any, **kwargs: Any) -> str:
+        if unlocked["active"] and self == sidecar:
+            raise FileNotFoundError(sidecar)
+        return real_read_text(self, *args, **kwargs)
+
+    # The lock's own open("a+") revalidates the sidecar, so the staleness ends there -- which is
+    # precisely why the decision has to be made after it, not before.
+    real_lock = simulate_utils._exclusive_index_lock
+
+    @contextlib.contextmanager
+    def _lock_then_revalidate(path: Path):  # type: ignore[no-untyped-def]
+        with real_lock(path) as value:
+            unlocked["active"] = False
+            yield value
+
+    monkeypatch.setattr(Path, "exists", _both_look_absent)
+    monkeypatch.setattr(Path, "read_text", _sidecar_looks_absent)
+    monkeypatch.setattr(simulate_utils, "_exclusive_index_lock", _lock_then_revalidate)
+
+    empty = {"signal": {"injections": []}, "outputs": []}
+    update_signal_index(tmp_path, empty, "orchestration-0.metadata.json")
+    monkeypatch.undo()
+
+    assert yaml.safe_load(index_file.read_text()) == {}, "the withdrawal was skipped on a stale sidecar read"


### PR DESCRIPTION
## 📝 Summary

Tier: T2 (code semantics — silent data loss).

#323 serialised `update_signal_index` with an exclusive `flock` on a sidecar. Measured
afterwards on a shared NFS home, two hosts, one metadata directory: **the lock worked and the
update was still lost.** The second writer blocked 26.7 s, then wrote an index holding only its
own event.

Acquiring the lock revalidates the **sidecar**, not `signal_index.yaml`. The reader had a cached
negative dentry for the index, saw nothing, started from `{}`, and discarded the first writer's
entries under a correctly held lock. Structural rather than an oversight:
`_atomically_write_index` replaces the index by rename — the new inode a cached dentry will not
resolve to — and the sidecar was chosen precisely so the lock survives that rename.

**The repair detects; it does not prevent.** The sidecar records a sha256 of the index bytes it
corresponds to, and a writer whose read disagrees raises `StaleIndexReadError` instead of
writing. Two clients stale in the same way would still agree with each other. The claim is that
silent loss becomes a loud refusal, nothing more.

Also here, each forced by review:

- the digest is computed from the bytes serialised, never a re-read — re-reading runs through
  the very path that can be stale, so a stale client would have recorded *its own view* as
  authoritative and certified the next stale write;
- the temporary is written binary, so the hashed bytes are the stored bytes (a text handle
  translates newlines on Windows and the digest could never match again);
- the no-op decision happens inside the lock — the sidecar is created by the same first write as
  the index, so an early prober caches a negative entry for **both**;
- an unreadable sidecar refuses rather than taking the permissive "predates the guard" path;
- a failure to record the digest raises `IndexDigestNotRecordedError` instead of being swallowed:
  the index is committed and correct, but the sidecar is behind, and every later write then
  refuses until it is re-baselined;
- neither error is retried — a backoff cannot fix a cache state, and they are raised after the
  frames are written, so each retry re-simulated the batch and tripped over its own outputs.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

## 🧪 How Has This Been Tested?

- [x] **Unit tests:** `uv run pytest tests/cli/test_signal_index_stale_read.py` — 13 tests
      covering mismatch, match, no-digest, missing index, digest-vs-disk, unreadable sidecar, the
      unrecorded-digest raise, both-dentries-stale, and the retry rules.
- [x] **Full suite:** 1074 passed, 23 skipped.
- [x] **Mutation-tested**, each killed by the test that owns it: guard never raises; digest from
      a re-read; `exists()`-only early return; serialise after creating the temp; drop the
      mode-preserving chmod; and the no-retry rule in all three directions (never fires, always
      fires, follows `__context__` again).
- [x] **Cross-host, on the real fault** — writer `alma10`, reader `stadius-nc-5`, shared NFS,
      three fresh rounds with a settle before reading the truth: the fault reproduced in 2 of 3,
      the guard fired both times, **event 101 survived**, and the recorded digest matched a fresh
      hash of the index on disk in all three rounds. Before this change the identical scenario
      ended with event 101 gone.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation — the docstring's guarantee states
      what holds and what does not.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective.

## 📷 Screenshots (if applicable)

Not applicable.

## Known limits, stated deliberately

- **Detection, not prevention** — established by review against this branch's own cross-host
  data: the guard fired, so it observed the stale view rather than revalidating past it.
- **A sidecar with no digest is accepted with a warning**, so the original bug is reachable for
  one write per unrecorded writer on a pre-upgrade directory. Same trade as #321's None-hash; it
  should become a refusal once no index predates this release.
- **The sibling `index.yaml` still has all three original defects** — unlocked read-modify-write,
  in-place truncating write, unparsable→new. Reproduced at 4/20 concurrent trials, and invisible
  today only because nothing in production reads it. Tracked separately; not folded in here,
  since one work item is one PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signal-index update reliability by preventing stale or conflicting changes from overwriting newer data.
  * Preserved the last valid, readable index when an update fails during publication.
  * Added safer handling for empty and withdrawal-only updates.
  * Improved retry behavior so non-recoverable failures are not retried unnecessarily.
  * Added compatibility support and warnings for older index metadata formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->