### PR TITLE
fix(index): lock and atomically write the metadata index

### DIFF
--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -598,6 +598,20 @@ def update_metadata_index(
     The index maps data file names to their corresponding metadata files,
     enabling O(1) lookup to find metadata for a given data file.
 
+    Serialised and written atomically, for the reasons its sibling
+    :func:`update_signal_index` was: an unlocked read-modify-write let two runs sharing a
+    metadata directory lose one side's entries (measured at 4 losses in 20 concurrent trials),
+    and the in-place truncating write turned one interrupted dump into the loss of *every* entry,
+    because the loader above treats an unparsable index as "create a new index".
+
+    **Deliberately weaker than :func:`update_signal_index`: there is no staleness digest here.**
+    That guard's job is to refuse a write, and on a shared filesystem a client can hold a stale
+    view of this file just as it can of the signal index. Nothing in production reads
+    ``index.yaml`` today, so aborting a run over it would cost more than the entry it protects.
+    The residue is that a cross-host stale read can still drop an entry here silently. **Revisit
+    when something starts reading it** -- the guarantee this file offers is then the guarantee
+    that consumer inherits.
+
     Args:
         metadata_directory: Directory where metadata files are stored
         output_files: List of output data file Paths
@@ -605,31 +619,30 @@ def update_metadata_index(
         encoding: File encoding for reading/writing the index file
     """
     index_file = metadata_directory / "index.yaml"
-
-    # Load existing index or create new
-    if index_file.exists():
-        try:
-            with index_file.open(encoding=encoding) as f:
-                index = yaml.safe_load(f) or {}
-        except (OSError, yaml.YAMLError) as e:
-            logger.warning("Failed to load metadata index: %s. Creating new index.", e)
+    with _exclusive_index_lock(index_file):
+        # Load existing index or create new
+        if index_file.exists():
+            try:
+                with index_file.open(encoding=encoding) as f:
+                    index = yaml.safe_load(f) or {}
+            except (OSError, yaml.YAMLError) as e:
+                logger.warning("Failed to load metadata index: %s. Creating new index.", e)
+                index = {}
+        else:
             index = {}
-    else:
-        index = {}
 
-    # Add entries for all output files
-    for output_file in output_files:
-        index[output_file.name] = metadata_file_name
-        logger.debug("Index entry: %s -> %s", output_file.name, metadata_file_name)
+        # Add entries for all output files
+        for output_file in output_files:
+            index[output_file.name] = metadata_file_name
+            logger.debug("Index entry: %s -> %s", output_file.name, metadata_file_name)
 
-    # Save updated index
-    try:
-        with index_file.open("w") as f:
-            yaml.safe_dump(index, f, default_flow_style=False, sort_keys=True)
-        logger.debug("Updated metadata index: %s", index_file)
-    except (OSError, yaml.YAMLError) as e:
-        logger.error("Failed to save metadata index: %s", e)
-        raise
+        # Save updated index
+        try:
+            _atomically_write_index(index_file, index)
+            logger.debug("Updated metadata index: %s", index_file)
+        except (OSError, yaml.YAMLError) as e:
+            logger.error("Failed to save metadata index: %s", e)
+            raise
 
 
 def _withdraw_batch(index: dict[str, Any], metadata_file_name: str) -> dict[str, Any]:

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -605,12 +605,18 @@ def update_metadata_index(
     because the loader above treats an unparsable index as "create a new index".
 
     **Deliberately weaker than :func:`update_signal_index`: there is no staleness digest here.**
-    That guard's job is to refuse a write, and on a shared filesystem a client can hold a stale
-    view of this file just as it can of the signal index. Nothing in production reads
-    ``index.yaml`` today, so aborting a run over it would cost more than the entry it protects.
-    The residue is that a cross-host stale read can still drop an entry here silently. **Revisit
-    when something starts reading it** -- the guarantee this file offers is then the guarantee
-    that consumer inherits.
+    That guard's job is to refuse a write, and nothing in production reads ``index.yaml`` today,
+    so aborting a run over it would cost more than it protects.
+
+    **Be precise about what that costs, because it is not one entry.** On a shared filesystem a
+    client can hold a stale *negative* view of this path -- measured: ``exists()`` answers False
+    from a cached dentry, the loader starts from an empty mapping, and the write replaces the
+    file, so ``{data-0, data-1}`` became ``{data-2}``. The residue is **whole-index loss**, the
+    same catastrophic case the sibling's digest guard exists to catch, not a single dropped row.
+
+    **Revisit when a reader-writer appears from another process**, not merely when a reader
+    appears: a second reader alone is harmless, while a second *writer* on another host can
+    discard everything recorded so far.
 
     Args:
         metadata_directory: Directory where metadata files are stored

--- a/tests/cli/test_metadata_index_durability.py
+++ b/tests/cli/test_metadata_index_durability.py
@@ -22,8 +22,9 @@ nobody had looked at the file written on the line above.
 
 **Deliberately weaker than its sibling.** No staleness digest here: that guard's job is to refuse
 a write, and nothing in production reads ``index.yaml`` today, so aborting a run over it would
-cost more than the entry it protects. Cross-host staleness can still lose an entry here. If a
-real consumer appears, that decision should be revisited.
+cost more than it protects. The residue is **whole-index loss**, not one entry -- a stale
+negative dentry makes the loader start from an empty mapping and the write then replaces
+everything -- so the condition to revisit is a *reader-writer from another process*, not a reader.
 """
 
 from __future__ import annotations
@@ -160,7 +161,14 @@ def test_a_failed_write_leaves_the_previous_index_intact(tmp_path: Path, monkeyp
 
 
 def test_the_index_keeps_its_permissions(tmp_path: Path) -> None:
-    """Replacing by rename must not tighten the index, as it did for its sibling."""
+    """Replacing by rename must not tighten the index, as it did for its sibling.
+
+    **Not a discriminator for the atomic write.** This passes on the old in-place implementation
+    too, and for the same reason: ``open("w")`` truncates without touching the mode, so 0644 on
+    creation and a preserved 0664 hold either way. It guards the `mkstemp`-style regression that
+    bit the signal index (0600 on every replace), which is a property of the shared writer rather
+    than of this change. The race and failed-write tests are the ones that own this fix.
+    """
     previous = os.umask(0o022)
     try:
         update_metadata_index(tmp_path, [Path("data-0.gwf")], "orchestration-0.metadata.json")

--- a/tests/cli/test_metadata_index_durability.py
+++ b/tests/cli/test_metadata_index_durability.py
@@ -1,0 +1,166 @@
+# Copyright (C) 2026 Leuven Gravity Institute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+"""``index.yaml`` must survive concurrent writers and a failed write.
+
+The sibling of ``signal_index.yaml``, written by the same `save_batch_metadata` into the same
+metadata directory, and carrying the same two faults that file had before #323: an unlocked
+read-modify-write, and an in-place truncating write whose failure the loader then treats as
+"create a new index" -- discarding every entry rather than one.
+
+Found in review of the signal-index repair, by asking what a whole series of reviews had missed:
+nobody had looked at the file written on the line above.
+
+**Deliberately weaker than its sibling.** No staleness digest here: that guard's job is to refuse
+a write, and nothing in production reads ``index.yaml`` today, so aborting a run over it would
+cost more than the entry it protects. Cross-host staleness can still lose an entry here. If a
+real consumer appears, that decision should be revisited.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import time
+from multiprocessing.synchronize import Barrier
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from gwmock.cli.simulate_utils import update_metadata_index
+
+pytestmark = pytest.mark.unit
+
+_BARRIER_TIMEOUT_SECONDS = 2.0
+_LOCK_WAIT_EVIDENCE_SECONDS = 0.5
+_SCENARIO_ATTEMPTS = 3
+
+
+def _writer(directory: str, name: str, batch: int, ready: Barrier, barrier: Barrier, evidence: Any) -> None:
+    """Add one distinct entry, with the two writers rendezvousing inside the critical section.
+
+    The same shape as the signal-index race test, and for the same reason: a barrier placed
+    before the call only starts the processes together and leaves the overlap to the scheduler.
+    This one is armed on the read, and timed, because under the fix the second process is locked
+    out and can never arrive.
+    """
+    import gwmock.cli.simulate_utils as module
+
+    real_load = module.yaml.safe_load
+
+    def _rendezvous_then_load(stream: Any) -> Any:
+        loaded = real_load(stream)
+        try:
+            barrier.wait(timeout=_BARRIER_TIMEOUT_SECONDS)
+            evidence["rendezvous"] = True
+        except Exception:  # noqa: BLE001 - a broken barrier is the expected outcome under the fix
+            pass
+        return loaded
+
+    module.yaml.safe_load = _rendezvous_then_load
+
+    if module.fcntl is not None:
+        real_flock = module.fcntl.flock
+
+        def _timed_flock(descriptor: int, operation: int) -> Any:
+            if operation != module.fcntl.LOCK_EX:
+                return real_flock(descriptor, operation)
+            started = time.perf_counter()
+            result = real_flock(descriptor, operation)
+            evidence["lock_wait"] = max(evidence["lock_wait"], time.perf_counter() - started)
+            return result
+
+        module.fcntl.flock = _timed_flock
+
+    ready.wait(timeout=30)
+    update_metadata_index(Path(directory), [Path(name)], f"orchestration-{batch}.metadata.json")
+
+
+def test_two_processes_adding_entries_keep_both(tmp_path: Path) -> None:
+    """Neither writer's entry may be lost when both update the index at once.
+
+    Fails on the unfixed code: the read-modify-write is unlocked, so the second writer builds on
+    a pre-race read and its dump drops the first's entry. Measured at 4 losses in 20 trials
+    before the fix.
+    """
+    context = mp.get_context("fork")
+    manager = context.Manager()
+
+    for attempt in range(_SCENARIO_ATTEMPTS):
+        directory = tmp_path / f"attempt-{attempt}"
+        directory.mkdir()
+        ready = context.Barrier(2)
+        barrier = context.Barrier(2)
+        evidence = [manager.dict(rendezvous=False, lock_wait=0.0) for _ in range(2)]
+        processes = [
+            context.Process(target=_writer, args=(str(directory), name, batch, ready, barrier, evidence[batch]))
+            for batch, name in enumerate(("data-A.gwf", "data-B.gwf"))
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(timeout=60)
+        assert all(p.exitcode == 0 for p in processes), [p.exitcode for p in processes]
+
+        met = any(record["rendezvous"] for record in evidence)
+        waited = max(record["lock_wait"] for record in evidence)
+        if met or waited > _LOCK_WAIT_EVIDENCE_SECONDS:
+            break
+    else:
+        pytest.fail(
+            f"scenario did not run in {_SCENARIO_ATTEMPTS} attempts: rendezvous={met}, longest "
+            f"lock wait={waited:.3f}s -- the writers were serialised by scheduling rather than by "
+            "the lock, so nothing was exercised either way."
+        )
+
+    index = yaml.safe_load((directory / "index.yaml").read_text())
+    assert set(index) == {"data-A.gwf", "data-B.gwf"}, index
+
+
+def test_a_failed_write_leaves_the_previous_index_intact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A write that fails part-way must not discard the entries already recorded.
+
+    The in-place ``open("w")`` truncated first, and the loader treats an unparsable index as
+    "create a new index" -- so one interrupted write silently discarded every entry, not one.
+    """
+    update_metadata_index(tmp_path, [Path("data-0.gwf")], "orchestration-0.metadata.json")
+    index_file = tmp_path / "index.yaml"
+    assert set(yaml.safe_load(index_file.read_text())) == {"data-0.gwf"}
+
+    def _fail_to_publish(source: Any, destination: Any) -> None:
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr("gwmock.cli.simulate_utils.os.replace", _fail_to_publish)
+    with pytest.raises(OSError, match="no space left on device"):
+        update_metadata_index(tmp_path, [Path("data-1.gwf")], "orchestration-1.metadata.json")
+    monkeypatch.undo()
+
+    recovered = yaml.safe_load(index_file.read_text())
+    assert recovered is not None, "the index was truncated by the failed write"
+    assert set(recovered) == {"data-0.gwf"}, recovered
+    assert not list(tmp_path.glob("*.tmp")), list(tmp_path.glob("*.tmp"))
+
+
+def test_the_index_keeps_its_permissions(tmp_path: Path) -> None:
+    """Replacing by rename must not tighten the index, as it did for its sibling."""
+    previous = os.umask(0o022)
+    try:
+        update_metadata_index(tmp_path, [Path("data-0.gwf")], "orchestration-0.metadata.json")
+        index_file = tmp_path / "index.yaml"
+        assert oct(index_file.stat().st_mode & 0o777) == "0o644"
+        index_file.chmod(0o664)
+        update_metadata_index(tmp_path, [Path("data-1.gwf")], "orchestration-1.metadata.json")
+        assert oct(index_file.stat().st_mode & 0o777) == "0o664"
+    finally:
+        os.umask(previous)

--- a/tests/cli/test_metadata_index_durability.py
+++ b/tests/cli/test_metadata_index_durability.py
@@ -28,8 +28,10 @@ real consumer appears, that decision should be revisited.
 
 from __future__ import annotations
 
+import contextlib
 import multiprocessing as mp
 import os
+import threading
 import time
 from multiprocessing.synchronize import Barrier
 from pathlib import Path
@@ -61,11 +63,11 @@ def _writer(directory: str, name: str, batch: int, ready: Barrier, barrier: Barr
 
     def _rendezvous_then_load(stream: Any) -> Any:
         loaded = real_load(stream)
-        try:
+        # A broken barrier is the expected outcome under the fix: the other process is blocked on
+        # the lock and cannot arrive, which is the point.
+        with contextlib.suppress(threading.BrokenBarrierError):
             barrier.wait(timeout=_BARRIER_TIMEOUT_SECONDS)
             evidence["rendezvous"] = True
-        except Exception:  # noqa: BLE001 - a broken barrier is the expected outcome under the fix
-            pass
         return loaded
 
     module.yaml.safe_load = _rendezvous_then_load
@@ -100,6 +102,11 @@ def test_two_processes_adding_entries_keep_both(tmp_path: Path) -> None:
     for attempt in range(_SCENARIO_ATTEMPTS):
         directory = tmp_path / f"attempt-{attempt}"
         directory.mkdir()
+        # Seed the index first. The rendezvous is armed on the load, and the load only happens
+        # when the index already exists -- against a fresh directory neither writer would take
+        # that path, so nothing would overlap and the run would prove nothing. Seeding also makes
+        # the lost update visible: an entry that was there before the race must still be there.
+        update_metadata_index(directory, [Path("data-seed.gwf")], "orchestration-seed.metadata.json")
         ready = context.Barrier(2)
         barrier = context.Barrier(2)
         evidence = [manager.dict(rendezvous=False, lock_wait=0.0) for _ in range(2)]
@@ -125,7 +132,7 @@ def test_two_processes_adding_entries_keep_both(tmp_path: Path) -> None:
         )
 
     index = yaml.safe_load((directory / "index.yaml").read_text())
-    assert set(index) == {"data-A.gwf", "data-B.gwf"}, index
+    assert set(index) == {"data-seed.gwf", "data-A.gwf", "data-B.gwf"}, index
 
 
 def test_a_failed_write_leaves_the_previous_index_intact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## 📝 Summary

Tier: T2 (code semantics — silent data loss).

`update_metadata_index` writes `index.yaml` with two of the three faults `signal_index.yaml` had
before #323, from the same caller (`save_batch_metadata`) into the same metadata directory:

- an **unlocked read-modify-write** — two runs sharing a directory lose one side's entries.
  Measured during review at **4 losses in 20 concurrent trials**;
- an **in-place truncating write**, whose failure the loader above then reads as "create a new
  index" — so one interrupted dump discards *every* entry, not one.

Found at the end of the signal-index repair by asking what several rounds of review had missed:
nobody had looked at the file written on the line above.

The fix reuses the helpers the signal index already has — both take the index path — so this is
wiring rather than new invention: the update runs under the same exclusive `flock` on a sidecar,
and the result is renamed into place instead of truncating.

**No staleness digest here, deliberately.** That guard's job is to refuse a write, and nothing in
production reads `index.yaml` today, so aborting a run over it would cost more than it protects.
The residue is stated precisely in the docstring, because it is worse than it first sounds: a
stale negative dentry makes the loader start from an empty mapping, so a cross-host stale write
replaces the **whole index**, not one row. Measured: `{data-0, data-1}` became `{data-2}`. The
condition to revisit is therefore a **reader-writer from another process**, not merely a reader.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

## 🧪 How Has This Been Tested?

- [x] **Unit tests:** `uv run pytest tests/cli/test_metadata_index_durability.py` — 3 tests. Two
      were written first and **confirmed failing against the unfixed implementation**; the third
      guards mode preservation.
- [x] **Full suite:** 1078 passed, 23 skipped.
- [x] **Mutation-tested**, each killed by the test that owns it and nothing else: drop the lock →
      the race test; write in place → the failed-write test.
- [x] The race test carries the validity check from the signal-index work: it refuses to pass a
      run the *scheduler* serialised rather than the lock. That check earned its place
      immediately — an earlier version armed its rendezvous on `yaml.safe_load`, which only fires
      when the index already exists, so against a fresh directory nothing overlapped. It reported
      "scenario did not run" instead of passing green. The index is now seeded first.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation — the docstring states the
      guarantee, the residue and the revisit condition.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective.

## 📷 Screenshots (if applicable)

Not applicable.

## Known limits

- **Two files in one directory now carry different guarantees.** Deliberate, reviewed, and
  recorded in the docstring rather than only in this description.
- **The permissions test does not discriminate this change** — it passes on the in-place
  implementation for the same reason, and guards the shared writer's mode behaviour. Said so in
  its docstring so nobody mistakes it for coverage of atomic-vs-in-place.
- **`save_batch_metadata` now takes two locks per batch**, sequentially and never nested;
  measured at ~3.3 ms per update, dominated by the atomic write's `fsync` rather than the lock.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata index updates to safely handle concurrent changes.
  * Prevented interrupted or failed writes from corrupting or replacing existing index data.
  * Preserved file permissions when updating the metadata index.

* **Tests**
  * Added coverage for concurrent updates, failed writes, temporary-file cleanup, and permission preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->