### PR TITLE
fix(placement): stop claiming events whose waveform ended before the segment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,18 +22,23 @@ classifiers = [
 requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = [
-  # 0.15.0 is the first release exposing `CBCSimulator.pre_coalescence_duration`, which segment
-  # placement asks before generating so an event is claimed by the segment its *waveform* starts in
-  # rather than the one holding its coalescence. Below this the query is absent, placement falls back
-  # to `coa_time`, and the start of any waveform landing near a boundary is cropped -- so this is a
-  # floor the behaviour depends on, not a convenience.
+  # Two floors, both behavioural rather than conveniences.
   #
-  # Floored at 0.16.0 for a *correctness* fix rather than a feature: gwmock-signal #370 projects the
-  # source direction into the frame of date. Before it, `gha = GMST - right_ascension` mixed a J2000
-  # right ascension with an Earth rotation measured from the mean equinox of date, an inconsistency
-  # worth 0.43 degrees in right ascension by 2030. The fix cuts worst-case disagreement with
-  # `lalpulsar.Barycenter` from 1.774e-04 s to 8.686e-07 s across a 192-point sky/epoch grid. It
-  # changes continuous-wave output, which is why this bump carries regenerated e2e references.
+  # 0.15.0 first exposed `CBCSimulator.pre_coalescence_duration`, which segment placement asks
+  # before generating so an event is claimed by the segment its *waveform* starts in rather than the
+  # one holding its coalescence. Below it the query is absent, placement falls back to `coa_time`,
+  # and the start of any waveform landing near a boundary is cropped.
+  #
+  # 0.16.0 adds the other half, `post_coalescence_duration`. Without the tail, a run whose
+  # start-time is later than its population's first event cannot tell that the earlier events are
+  # finished, so it claims every one of them into its first segment and discards the samples; the
+  # batch then grows with the distance from the catalogue start until the preflight refuses it.
+  #
+  # 0.16.0 also carries a projection *correctness* fix (gwmock-signal #370): the source direction is
+  # projected into the frame of date, where before `gha = GMST - right_ascension` mixed a J2000 right
+  # ascension with an Earth rotation measured from the mean equinox of date -- 0.43 degrees in right
+  # ascension by 2030. It changes continuous-wave output, which is why the bump landed with
+  # regenerated e2e references rather than inside this change.
   "gwmock-signal>=0.16.0",
   "gwmock-noise>=0.10.1",
   "gwmock-pop>=0.11.5",

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -155,6 +155,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         # malformed row fails only its own query and its cause differs from a whole-catalogue one --
         # collapsing both into one warning would name the wrong cause for everything after it.
         self._pre_coalescence_query_failures: set[str] = set()
+        self._post_coalescence_query_failures: set[str] = set()
         # Consumption order, as positions into `_population_events`. Established lazily by
         # `_placement_order`, because it costs one query per event and the continuous-wave and
         # stochastic paths never consume the catalogue this way.
@@ -549,6 +550,11 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             # place in the loaded catalogue rather than by the order generation happened to take.
             event_id = int(order[int(self.population_index)])
             parameters = dict(self._population_events[event_id])
+            if self._event_ended_before_segment_start(parameters):
+                # Consumed without being generated, the same as in `_events_for_this_segment`, and
+                # stepped over rather than breaking so the events behind it are still reached.
+                self.population_index = cast(int, self.population_index) + 1
+                continue
             if not self._event_starts_before_segment_end(parameters):
                 break
             strain = self.signal_adapter.simulate(
@@ -686,6 +692,99 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         start_time_value = float(coa_time) if lead is None else float(coa_time) - float(lead)
         return start_time_value < end_time_value
 
+    def _event_ended_before_segment_start(self, parameters: Mapping[str, Any]) -> bool:
+        """Return whether this event's waveform has finished before the current segment begins.
+
+        The lower bound, and the reason it exists: :meth:`_event_starts_before_segment_end` is
+        one-sided. In a sequential run that is invisible, because the earlier segments have already
+        consumed the earlier events. In a run whose ``start-time`` is later than its population's
+        first event -- resuming a campaign mid-catalogue, or slicing a long population into per-day
+        jobs -- nothing has consumed them, every one satisfies the upper bound, and the first
+        segment claims the whole back catalogue. Measured on the shipped ET config: 126 events
+        batched for a segment containing 13, refused by the preflight at an estimated 12.5 GiB.
+
+        **This must not be folded into the upper-bound predicate.** Both loops ``break`` on the
+        first event that does not belong, and ``population_index`` means "every event before this
+        one is consumed". An early event answering "does not belong" would stop the walk at
+        position 0, consume nothing, and repeat that on every following segment -- the run would
+        stall permanently, which is worse than the over-batching being fixed. A finished event is
+        *stepped over and consumed*, which is what the callers do with this answer.
+
+        ``None`` means *unknown*, and unknown claims the event. The tail is a fixed fraction of the
+        buffer rather than a physical ringdown -- 0.4 s for a 4 s binary-black-hole buffer, 25.6 s
+        for a 256 s binary-neutron-star one -- so an event coalescing seconds before the segment
+        may still be producing signal inside it. Reading an unknown tail as zero would conclude
+        every such event finished at ``coa_time`` and discard it, silently and for a whole backend
+        at a time; claiming it merely generates a waveform injection then crops.
+
+        Args:
+            parameters: The candidate event's source parameters.
+
+        Returns:
+            Whether the event's content is wholly behind this segment. Events without a
+            ``coa_time``, and events whose tail is unknown, are never reported as finished.
+        """
+        coa_time = parameters.get("coa_time")
+        if coa_time is None:
+            return False
+        tail = self._post_coalescence_duration(parameters)
+        if tail is None:
+            return False
+        start_time_value = float(getattr(self.start_time, "value", self.start_time))
+        # Strict, so an event ending exactly on the boundary is claimed: its final sample lands on
+        # the segment's first sample. The upper bound is strict at its own end for the same reason.
+        return float(coa_time) + float(tail) < start_time_value
+
+    def _post_coalescence_duration(self, parameters: Mapping[str, Any]) -> float | None:
+        """Return the event's waveform tail in seconds, or ``None`` when it cannot be established.
+
+        The complement of :meth:`_pre_coalescence_duration`, with the same swallow-and-report
+        handling and for the same reason: this query decides *placement*, and letting it fail a run
+        would turn an incomplete catalogue column into a crash in an unrelated part of the loop.
+
+        The fallback differs from the pre side's in what it costs. There, an unknown lead falls
+        back to the ``coa_time`` rule and the loss is reported per signal. Here, an unknown tail
+        means the event is claimed and generated -- work that may be discarded, which is exactly
+        today's behaviour and the thing being improved. Failing safe here is failing *slow*, not
+        failing wrong.
+
+        Args:
+            parameters: The candidate event's source parameters.
+
+        Returns:
+            Seconds after ``coa_time`` at which the waveform ends, or ``None`` for unknown.
+        """
+        if self.signal_adapter is None:
+            return None
+        query = getattr(self.signal_adapter, "post_coalescence_duration", None)
+        if query is None:
+            # An adapter predating gwmock-signal 0.16, or a caller's own stand-in. Unknown rather
+            # than an error: the packaging metadata requires a version that has it, so this is the
+            # duck-typed path, and the conservative answer keeps such a caller working unchanged.
+            return None
+        try:
+            return query(
+                parameters,
+                sampling_frequency=float(self.sampling_frequency.value),
+                minimum_frequency=self.minimum_frequency,
+                waveform_arguments=self.waveform_arguments,
+                waveform_options=self.waveform_options,
+            )
+        except Exception as exc:
+            # Deliberately broad, deduplicated by reason rather than by a flag -- see
+            # `_pre_coalescence_duration` for why a flag mislabels a second, different failure.
+            reason = f"{type(exc).__name__}: {exc}"
+            if reason not in self._post_coalescence_query_failures:
+                self._post_coalescence_query_failures.add(reason)
+                logger.warning(
+                    "Cannot establish how long after coalescence a waveform ends (%s). Affected "
+                    "events are claimed by every segment their coalescence precedes, so a run "
+                    "starting later than its population's first event may batch events whose "
+                    "signal it then crops.",
+                    reason,
+                )
+            return None
+
     def _pre_coalescence_duration(self, parameters: Mapping[str, Any]) -> float | None:
         """Return the event's waveform lead in seconds, or ``None`` when it cannot be established.
 
@@ -759,14 +858,34 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         # restores pre-batch state, so this is about direct library callers rather than the runner.
         order = self._placement_order()
         position = int(self.population_index)
+        skipped = 0
         while position < len(order):
             event_id = int(order[position])
             parameters = dict(self._population_events[event_id])
+            if self._event_ended_before_segment_start(parameters):
+                skipped += 1
+                position += 1
+                continue
             if not self._event_starts_before_segment_end(parameters):
                 break
             event_ids.append(event_id)
             events.append(parameters)
             position += 1
+
+        # Skipped events are advanced past here rather than in `_commit_consumed_events`, and this
+        # is the one exception to the read-without-advancing rule above. It is safe because nothing
+        # further can fail for them: a skipped event is not generated, so there is no later step
+        # whose failure would need the index rolled back. Deferring them to the commit would lose
+        # them outright -- `_simulate_batched_segment` returns early when the batch is empty, which
+        # is exactly the case where every event in front of the index was skipped, so the commit
+        # never runs and the next segment reconsiders the same events.
+        if skipped:
+            self.population_index = cast(int, self.population_index) + skipped
+            logger.info(
+                "Skipped %d event(s) whose waveform ends before this segment starts; they belong "
+                "to no segment this run writes.",
+                skipped,
+            )
         return event_ids, events
 
     def _commit_consumed_events(self, event_ids: list[int]) -> None:

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -156,6 +156,9 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         # collapsing both into one warning would name the wrong cause for everything after it.
         self._pre_coalescence_query_failures: set[str] = set()
         self._post_coalescence_query_failures: set[str] = set()
+        #: How far the last batched walk traversed, set by `_events_for_this_segment` and consumed
+        #: by `_commit_consumed_events`. `None` means no walk has happened since the last commit.
+        self._traversed_this_batch: int | None = None
         # Consumption order, as positions into `_population_events`. Established lazily by
         # `_placement_order`, because it costs one query per event and the continuous-wave and
         # stochastic paths never consume the catalogue this way.
@@ -756,14 +759,16 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         """
         if self.signal_adapter is None:
             return None
-        query = getattr(self.signal_adapter, "post_coalescence_duration", None)
-        if query is None:
-            # An adapter predating gwmock-signal 0.16, or a caller's own stand-in. Unknown rather
-            # than an error: the packaging metadata requires a version that has it, so this is the
-            # duck-typed path, and the conservative answer keeps such a caller working unchanged.
-            return None
+        # Called directly, exactly as the pre side calls its own query, and deliberately *not*
+        # behind a `getattr` guard. A guard here returns `None` for an adapter without the method
+        # and says nothing, which is precisely how this change shipped as a silent no-op: the
+        # orchestrator's own `SignalAdapter` had no `post_coalescence_duration`, every tail came
+        # back unknown, and the whole lower bound was dead in production while the stub-driven
+        # tests passed. Letting the `AttributeError` fall into the handler below produces the same
+        # conservative `None` *and* warns once, which is the codebase's stated rule: the fallback
+        # is the previous behaviour, and its cost is reported rather than silent.
         try:
-            return query(
+            return self.signal_adapter.post_coalescence_duration(
                 parameters,
                 sampling_frequency=float(self.sampling_frequency.value),
                 minimum_frequency=self.minimum_frequency,
@@ -830,12 +835,19 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             return None
 
     def _events_for_this_segment(self) -> tuple[list[int], list[dict[str, Any]]]:
-        """Return the population events belonging to the current segment, without consuming them.
+        """Return the population events to generate for the current segment.
 
         Stops on :meth:`_event_starts_before_segment_end`, the same boundary the per-event loop
         applies. That matters for resume: ``population_index`` is checkpointed state, so a run
-        switched between modes must not skip or repeat events. The index advances only in
-        :meth:`_commit_consumed_events`, once generation has succeeded.
+        switched between modes must not skip or repeat events.
+
+        Events the walk *steps over* -- those :meth:`_event_ended_before_segment_start` reports as
+        finished -- are consumed without being returned, so the count of events generated is not
+        the distance the index must advance. The walk records that distance in
+        ``_traversed_this_batch`` for :meth:`_commit_consumed_events`, which still does the
+        advancing once generation has succeeded. The single exception is a batch in which
+        *everything* was skipped: it advances here, because the caller returns early on an empty
+        batch and never reaches the commit.
 
         One difference, stated rather than glossed: the per-event loop also breaks when a *generated*
         strain starts at or after ``end_time``, a condition that cannot be evaluated before
@@ -872,20 +884,30 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             events.append(parameters)
             position += 1
 
-        # Skipped events are advanced past here rather than in `_commit_consumed_events`, and this
-        # is the one exception to the read-without-advancing rule above. It is safe because nothing
-        # further can fail for them: a skipped event is not generated, so there is no later step
-        # whose failure would need the index rolled back. Deferring them to the commit would lose
-        # them outright -- `_simulate_batched_segment` returns early when the batch is empty, which
-        # is exactly the case where every event in front of the index was skipped, so the commit
-        # never runs and the next segment reconsiders the same events.
         if skipped:
-            self.population_index = cast(int, self.population_index) + skipped
             logger.info(
                 "Skipped %d event(s) whose waveform ends before this segment starts; they belong "
                 "to no segment this run writes.",
                 skipped,
             )
+
+        # How far the walk got, which is what consumption has to advance by -- not the number of
+        # events generated. Skipped and claimed events interleave: consumption is ordered by
+        # waveform *start* while skipping is decided by waveform *end*, so a long event starting
+        # early and overlapping the segment can be followed by a short one that starts later and
+        # already finished. Advancing by the skip count alone would leave the index pointing past a
+        # claimed event that had not been generated yet, and a direct caller retrying after a
+        # generation failure would never generate it -- silently dropping a real event, which is
+        # worse than the wasted work this change removes.
+        self._traversed_this_batch = position - int(self.population_index)
+
+        # The all-skipped batch is the one case that must advance here. Nothing can fail for events
+        # that are never generated, and `_simulate_batched_segment` returns early on an empty
+        # batch, so the commit never runs -- the next segment would reconsider the same events, and
+        # every segment after it too.
+        if not event_ids and skipped:
+            self.population_index = cast(int, self.population_index) + skipped
+            self._traversed_this_batch = 0
         return event_ids, events
 
     def _commit_consumed_events(self, event_ids: list[int]) -> None:
@@ -894,11 +916,21 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         Advances by *count*, not to ``max(event_ids) + 1``: the ids are catalogue positions and
         consumption follows :meth:`_placement_order`, so they need not be contiguous or ascending.
 
+        The count is how far the walk *traversed*, not how many events it generated. Those differ
+        once events can be skipped: a skipped event sitting between two claimed ones is consumed
+        without being generated, and advancing by the generated count alone would leave the index
+        short, so the next segment would re-walk -- and re-generate -- events already written.
+        ``_traversed_this_batch`` is set by :meth:`_events_for_this_segment` and falls back to the
+        generated count for any caller that commits without having walked.
+
         Args:
             event_ids: Catalogue positions of the events this batch generated.
         """
         if event_ids:
-            self.population_index = cast(int, self.population_index) + len(event_ids)
+            traversed = self._traversed_this_batch
+            advance = len(event_ids) if traversed is None else traversed
+            self.population_index = cast(int, self.population_index) + advance
+        self._traversed_this_batch = None
 
     def _segment_injections(self) -> list[dict[str, Any]]:
         """Return one record per signal present in the segment just built.

--- a/src/gwmock/signal/adapter.py
+++ b/src/gwmock/signal/adapter.py
@@ -700,6 +700,61 @@ class SignalAdapter:
                 minimum_frequency=minimum_frequency,
             )
 
+    def post_coalescence_duration(
+        self,
+        parameters: Mapping[str, Any],
+        *,
+        sampling_frequency: float,
+        minimum_frequency: float,
+        waveform_arguments: Mapping[str, Any] | None = None,
+        waveform_options: Mapping[str, Any] | None = None,
+    ) -> float | None:
+        """Return how long after ``coa_time`` this event's waveform ends, in seconds.
+
+        The complement of :meth:`pre_coalescence_duration`, and the reason it exists: knowing only
+        where a buffer *starts* tells a caller that an event begins before a segment, never that it
+        has finished before one. Without the tail, a run whose ``start-time`` is later than its
+        population's first event cannot tell that the earlier events are behind it, and claims
+        every one of them into its first segment.
+
+        Args:
+            parameters: Per-event source parameters, as :meth:`simulate` takes them.
+            sampling_frequency: Sample rate in Hz.
+            minimum_frequency: Low-frequency cutoff in Hz.
+            waveform_arguments: Fixed waveform parameters, as :meth:`simulate` takes them.
+            waveform_options: Extra waveform options, as :meth:`simulate` takes them.
+
+        Returns:
+            Seconds between coalescence and one sample past the buffer's end, positive; or ``None``
+            when the answer is *unknown* -- a backend that cannot say (PyCBC), a source type with no
+            coalescence, or an installed gwmock-signal predating the query. Never read ``None`` as
+            zero: zero claims the waveform stops at coalescence, and acting on it discards an event
+            whose tail still reaches into the segment. The tail is a fraction of the buffer rather
+            than a physical ringdown, so it is 0.4 s for a 4 s binary-black-hole buffer and 25.6 s
+            for a 256 s binary-neutron-star one.
+        """
+        query = getattr(self._backend, "post_coalescence_duration", None)
+        if query is None:
+            return None
+        backend_parameters = self._backend_parameters(parameters, waveform_arguments, waveform_options)
+        try:
+            return query(
+                backend_parameters,
+                sampling_frequency=sampling_frequency,
+                minimum_frequency=minimum_frequency,
+            )
+        except ValueError as exc:
+            # As on the pre side: a population column the backend does not know must not be what
+            # decides whether an event is placed. Anything else propagates.
+            filtered = self._without_unsupported(exc, backend_parameters)
+            if filtered is None:
+                raise
+            return query(
+                filtered,
+                sampling_frequency=sampling_frequency,
+                minimum_frequency=minimum_frequency,
+            )
+
     def simulate_stack(
         self,
         parameters: Mapping[str, Any],

--- a/tests/cli/test_events_ending_before_the_segment.py
+++ b/tests/cli/test_events_ending_before_the_segment.py
@@ -302,6 +302,64 @@ class TestTheRealAdapterAnswers:
         assert tail > 0.0
 
 
+class TestAgainstRealGeneration:
+    """The predicted tail has to be the tail generation actually produces.
+
+    The post-side mirror of ``test_the_predicted_lead_matches_the_generated_buffer``, and named by a
+    reviewer as the single most valuable test missing from this change. Every other test here asks
+    whether the query *answers*; this one asks whether the answer is *true*. The direction matters:
+    a tail shorter than generation produces means an event is skipped while it is still contributing
+    signal to the segment -- deleting real data, which is the one outcome strictly worse than the
+    wasted work this change removes. It held when the reviewer probed it by hand; nothing pinned it,
+    so a regression in the adapter's parameter merge or the backend's arithmetic would pass the
+    whole suite.
+    """
+
+    def test_the_predicted_tail_matches_the_generated_buffer(self, tmp_path):
+        """Measured on the produced ``TimeSeries``, not recomputed from the same formula."""
+        orchestrator = _orchestrator(tmp_path)
+        adapter = orchestrator.signal_adapter
+        assert adapter is not None
+        coa_time = _START + 8.0
+        parameters = {**_COMPLETE_EVENT, "coa_time": coa_time}
+
+        predicted = adapter.post_coalescence_duration(
+            parameters,
+            sampling_frequency=_SAMPLING_FREQUENCY,
+            minimum_frequency=30.0,
+        )
+        strain = adapter.simulate(parameters, sampling_frequency=_SAMPLING_FREQUENCY, minimum_frequency=30.0)
+        # `end_time` is the series' own accessor rather than arithmetic on the array, so the test
+        # cannot disagree with the object about where the buffer ends.
+        measured = float(strain.end_time.value) - coa_time
+
+        assert predicted is not None, "LAL can answer this; a None here would disable the fix silently"
+        assert predicted == pytest.approx(measured, abs=0.5 / _SAMPLING_FREQUENCY), (
+            f"predicted tail {predicted} s but generation ends {measured} s after coalescence"
+        )
+
+    def test_the_two_sides_account_for_the_whole_generated_buffer(self, tmp_path):
+        """Lead plus tail is the buffer, checked against the buffer that was generated.
+
+        Catches a drift that splits the buffer wrongly while keeping each side self-consistent --
+        the failure the two separate agreement tests can each miss on their own.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        adapter = orchestrator.signal_adapter
+        assert adapter is not None
+        parameters = {**_COMPLETE_EVENT, "coa_time": _START + 8.0}
+        kwargs = {"sampling_frequency": _SAMPLING_FREQUENCY, "minimum_frequency": 30.0}
+
+        lead = adapter.pre_coalescence_duration(parameters, **kwargs)
+        tail = adapter.post_coalescence_duration(parameters, **kwargs)
+        strain = adapter.simulate(parameters, **kwargs)
+        generated = float(strain.duration.value)
+
+        assert lead is not None
+        assert tail is not None
+        assert lead + tail == pytest.approx(generated, abs=1.0 / _SAMPLING_FREQUENCY)
+
+
 class TestADegradedAdapterIsReported:
     """An adapter that cannot answer must say so once, not disappear into a silent fallback."""
 
@@ -334,6 +392,34 @@ class TestADegradedAdapterIsReported:
         assert any("after coalescence" in record.message for record in caplog.records), (
             "the adapter could not answer and the run was told nothing"
         )
+
+    def test_the_warning_is_not_repeated_once_per_event(self, tmp_path, caplog):
+        """Deduplicated by reason across a whole walk, not merely on a single call.
+
+        A catalogue the query cannot read fails identically for every row, and one message is right
+        for it -- a per-event warning would bury the run's real output. Asserted over a walk rather
+        than two direct calls, because the walk is where the repetition would actually happen.
+        """
+
+        class _AdapterWithoutTheQuery:
+            detector_names = ("E1",)
+
+            def pre_coalescence_duration(self, parameters, **_):
+                del parameters
+                return 3.6
+
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _AdapterWithoutTheQuery()
+        start = _start_time(orchestrator)
+        _install_events(orchestrator, [start - 900.0, start - 800.0, start + 2.0, start + 6.0])
+
+        with caplog.at_level("WARNING"):
+            _, events = orchestrator._events_for_this_segment()
+
+        warnings = [r for r in caplog.records if "after coalescence" in r.message]
+        assert len(warnings) == 1, f"warned {len(warnings)} times across a {len(events)}-event walk"
+        # And the degraded query must not have dropped anything: unknown claims.
+        assert len(events) == 4
 
 
 class TestTheIndexSurvivesInterleavedSkips:

--- a/tests/cli/test_events_ending_before_the_segment.py
+++ b/tests/cli/test_events_ending_before_the_segment.py
@@ -1,0 +1,345 @@
+"""Events whose waveform has finished before the segment starts, and the batch they inflate.
+
+The companion to :mod:`tests.cli.test_inspiral_segment_placement`, from the other side. That
+module pins the *upper* bound: a segment claims an event whose waveform starts before the segment
+ends, so an inspiral is not cropped. The rule has no lower bound, and the omission is invisible in
+a sequential run -- earlier segments have already consumed the earlier events, so the walk starts
+past them.
+
+It is not invisible in a run whose ``start-time`` is later than its population's first event.
+Nothing has consumed those events, every one of them satisfies "starts before this segment ends",
+and the first segment claims the entire back catalogue. **Measured on the shipped ET config:** a
+run starting 53 ks into the catalogue batched 126 events where the segment contains 13, estimated
+12.5 GiB, and was refused by the preflight; at 41 ks it batched 98 for 16; at 4 ks, 19 for 8. The
+batch tracks the offset rather than the local event density. Their samples are then cropped as
+out-of-segment, so the work is generated and discarded.
+
+Resuming a campaign mid-catalogue, or slicing a long population into per-day jobs, is exactly this.
+
+**Why the fix cannot be another clause in the same predicate.** Both loops ``break`` on the first
+event that does not belong, and ``population_index`` -- checkpointed state meaning "every event
+before this one is consumed" -- advances by the count of events consumed. An early event answering
+"does not belong" would therefore stop the walk at position 0 and consume nothing, and it would do
+so again on every following segment: the run would stall permanently rather than over-batch. An
+event that has finished must be *skipped and consumed*, which is a different operation from the
+one the upper bound performs, and ``test_a_finished_event_does_not_stop_the_walk`` is what pins
+the difference.
+
+``None`` from the query means unknown, and unknown must claim. The query exists to let a caller
+*prove* an event is finished; on no answer the conservative branch is the one that generates the
+event and lets injection crop it, because the alternative silently deletes signal.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gwmock.cli.utils.config import Config
+
+_POPULATION_CSV = Path(__file__).resolve().parents[2] / "examples" / "signal" / "bbh_population.csv"
+_START = 1577491296.0
+_SAMPLING_FREQUENCY = 1024.0
+_SEGMENT_DURATION = 16.0
+
+#: A complete BBH parameter set, so a real query could answer; these tests supply the answer
+#: through the stub, but an underspecified event would exercise the unknown path by accident.
+_COMPLETE_EVENT: dict[str, Any] = {
+    "detector_frame_mass_1": 30.0,
+    "detector_frame_mass_2": 25.0,
+    "distance": 400.0,
+    "right_ascension": 1.0,
+    "declination": 0.5,
+    "polarization_angle": 0.2,
+    "inclination": 0.3,
+}
+
+
+def _config(working_directory: Path, execution: str) -> dict[str, Any]:
+    """Return a one-segment BBH config, matching the placement module's fixture.
+
+    No ``waveform-backend`` key, so constructing the orchestrator does not instantiate a backend
+    needing the ``[jax]`` extra.
+    """
+    return {
+        "globals": {
+            "simulator-arguments": {
+                "sampling-frequency": _SAMPLING_FREQUENCY,
+                "duration": _SEGMENT_DURATION,
+                "total-duration": _SEGMENT_DURATION,
+                "start-time": _START,
+                "seed": 20260807,
+            },
+            "working-directory": str(working_directory),
+            "output-directory": "output",
+            "metadata-directory": "metadata",
+        },
+        "orchestration": {
+            "population": {
+                "backend": "FilePopulationLoader",
+                "source-type": "bbh",
+                "n-samples": 1,
+                "arguments": {"path": str(_POPULATION_CSV)},
+            },
+            "signal": {
+                "source-type": "bbh",
+                "waveform-model": "IMRPhenomD",
+                "execution": execution,
+                "minimum-frequency": 30,
+                "detectors": ["ET-Triangle-Sardinia"],
+                "output": {
+                    "output_directory": "signal",
+                    "file_name": "sig-{{ detectors }}.gwf",
+                    "arguments": {"channel": "{{ detectors }}:STRAIN"},
+                },
+            },
+        },
+    }
+
+
+def _orchestrator(working_directory: Path, execution: str = "batched"):
+    from gwmock.cli.adapter_orchestration import AdapterOrchestrator
+
+    working_directory.mkdir(parents=True, exist_ok=True)
+    config = Config.model_validate(_config(working_directory, execution))
+    return AdapterOrchestrator.from_config(
+        config.orchestration,
+        global_simulator_arguments=dict(config.globals.simulator_arguments),
+    )
+
+
+class _StubAdapter:
+    """A signal adapter answering both placement queries however the test needs.
+
+    Both sides are supplied, because a test that fixed only the tail would let the lead default to
+    something the sort key also depends on, and the two together decide which events the walk even
+    reaches.
+    """
+
+    def __init__(self, lead: float | None = 0.0, tail: float | None = 0.0) -> None:
+        self._lead = lead
+        self._tail = tail
+        self.detector_names = ("E1",)
+        #: Every event handed to :meth:`simulate`, so a test can assert what was *generated* rather
+        #: than what a predicate said. The two are not the same thing, which is the whole reason
+        #: this list exists -- see ``test_the_per_event_loop_steps_over_finished_events``.
+        self.simulated: list[float] = []
+
+    def simulate(self, parameters: Mapping[str, Any], **_: Any):
+        """Return a one-sample segment-length strain, recording that the event was generated."""
+        import numpy as np
+
+        from gwmock.data.time_series.time_series import TimeSeries
+
+        self.simulated.append(float(parameters["coa_time"]))
+        return TimeSeries(
+            np.zeros((1, int(_SAMPLING_FREQUENCY * _SEGMENT_DURATION))),
+            start_time=float(parameters["coa_time"]),
+            sampling_frequency=_SAMPLING_FREQUENCY,
+        )
+
+    def pre_coalescence_duration(self, parameters: Mapping[str, Any], **_: Any) -> float | None:
+        del parameters
+        return self._lead
+
+    def post_coalescence_duration(self, parameters: Mapping[str, Any], **_: Any) -> float | None:
+        del parameters
+        return self._tail
+
+
+def _install_events(orchestrator, coa_times: list[float]) -> None:
+    """Give the orchestrator a synthetic catalogue and drop the cached placement order.
+
+    The order is cached on first use and keyed by the events present when it was built, so a test
+    replacing the catalogue afterwards would otherwise walk positions that no longer exist.
+    """
+    orchestrator._population_events = [{**_COMPLETE_EVENT, "coa_time": t} for t in coa_times]
+    orchestrator._placement_order_cache = None
+    orchestrator.population_index = 0
+
+
+def _start_time(orchestrator) -> float:
+    return float(getattr(orchestrator.start_time, "value", orchestrator.start_time))
+
+
+class TestTheBatchDoesNotGrowWithTheOffset:
+    """The defect: a run starting after its population's first event batches all of them."""
+
+    def test_the_batch_holds_the_events_in_the_window_not_the_ones_before_it(self, tmp_path):
+        """The measured failure, reduced to its shape.
+
+        Ten events sit wholly before the segment -- each finishing, with its 0.4 s tail, well
+        before the segment starts -- and three fall inside it. A run whose ``start-time`` skipped
+        the first ten claims all thirteen, generates ten waveforms whose samples are then cropped
+        as out-of-segment, and sizes its batch from the offset rather than from the segment.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(lead=3.6, tail=0.4)
+        start = _start_time(orchestrator)
+        before = [start - 3600.0 + 60.0 * i for i in range(10)]
+        inside = [start + 1.0, start + 5.0, start + 9.0]
+        _install_events(orchestrator, before + inside)
+
+        event_ids, events = orchestrator._events_for_this_segment()
+
+        assert len(events) == 3, f"batched {len(events)} events for a segment containing 3"
+        assert sorted(event_ids) == [10, 11, 12]
+
+    def test_the_batch_tracks_the_segment_not_the_distance_from_the_catalogue_start(self, tmp_path):
+        """Doubling the offset must not change the batch.
+
+        This is the property the measurement actually showed violated -- 126, then 98, then 19 for
+        the same kind of segment -- and it is the one a caller relies on when slicing a population
+        into per-day jobs. A test fixing a single offset would pass against a fix that merely
+        shifted the over-claiming.
+        """
+        counts = []
+        for offset in (600.0, 1200.0, 2400.0):
+            orchestrator = _orchestrator(tmp_path / f"offset_{int(offset)}")
+            orchestrator.signal_adapter = _StubAdapter(lead=3.6, tail=0.4)
+            start = _start_time(orchestrator)
+            n_before = int(offset / 60.0)
+            before = [start - offset + 60.0 * i for i in range(n_before)]
+            _install_events(orchestrator, [*before, start + 1.0, start + 5.0])
+            counts.append(len(orchestrator._events_for_this_segment()[1]))
+
+        assert counts == [2, 2, 2], f"batch grew with the offset: {counts}"
+
+    def test_a_finished_event_does_not_stop_the_walk(self, tmp_path):
+        """Skipped, not refused -- the distinction the loops' ``break`` makes load-bearing.
+
+        If a finished event answered the boundary question with "does not belong", the walk would
+        stop at position 0 and consume nothing, on this segment and on every one after it. The run
+        would stall rather than over-batch, which is a worse failure than the one being fixed. So
+        the events *behind* the finished one must still be claimed.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(lead=3.6, tail=0.4)
+        start = _start_time(orchestrator)
+        _install_events(orchestrator, [start - 1000.0, start + 2.0, start + 6.0])
+
+        event_ids, events = orchestrator._events_for_this_segment()
+
+        assert len(events) == 2, "the walk stopped at the finished event instead of stepping over it"
+        assert sorted(event_ids) == [1, 2]
+
+    def test_a_skipped_event_is_consumed_so_the_next_segment_does_not_reconsider_it(self, tmp_path):
+        """``population_index`` means every event before it is consumed; skipping must keep that.
+
+        Advancing only by the events *generated* would leave the finished ones in front of the
+        index forever: every later segment would re-examine and re-skip them, and a resumed run
+        would restart inside a prefix it had already dealt with. The count is what resume depends
+        on, so it is asserted rather than the ids.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(lead=3.6, tail=0.4)
+        start = _start_time(orchestrator)
+        _install_events(orchestrator, [start - 900.0, start - 800.0, start + 2.0])
+
+        event_ids, _ = orchestrator._events_for_this_segment()
+        orchestrator._commit_consumed_events(event_ids)
+
+        assert orchestrator.population_index == 3, (
+            f"index advanced to {orchestrator.population_index}; the two skipped events are still "
+            "in front of it and will be reconsidered by the next segment"
+        )
+
+
+class TestUnknownStillClaims:
+    """Unknown is not zero, and on this side reading it as zero deletes signal."""
+
+    def test_an_event_whose_tail_is_unknown_is_claimed(self, tmp_path):
+        """A backend that cannot say where its buffer ends must not have events dropped for it.
+
+        PyCBC answers ``None`` by design, as does any custom-registered model. Reading that as a
+        zero-length tail would conclude every such event finished at ``coa_time`` and discard the
+        ones sitting before the segment -- silently, and for a whole backend at a time.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(lead=3.6, tail=None)
+        start = _start_time(orchestrator)
+        _install_events(orchestrator, [start - 1000.0, start + 2.0])
+
+        _, events = orchestrator._events_for_this_segment()
+
+        assert len(events) == 2, "an event with an unknown tail was dropped; unknown is not zero"
+
+    def test_an_event_still_ringing_into_the_segment_is_claimed(self, tmp_path):
+        """The tail is a fixed fraction of the buffer, so for a BNS it is tens of seconds.
+
+        Measured on the shipped backends: 0.4 s for a 4 s BBH buffer, **25.6 s** for a 256 s BNS
+        buffer. An event coalescing 10 s before the segment is therefore still producing signal
+        inside it, and a lower bound written against a millisecond intuition would delete it.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(lead=100.0, tail=25.6)
+        start = _start_time(orchestrator)
+        _install_events(orchestrator, [start - 10.0, start + 2.0])
+
+        _, events = orchestrator._events_for_this_segment()
+
+        assert len(events) == 2, "an event whose ringdown reaches into the segment was dropped"
+
+    def test_the_boundary_is_inclusive_the_way_the_upper_one_is(self, tmp_path):
+        """An event ending exactly at the segment start contributes its final sample.
+
+        Pinned because the off-by-one here is silent: it drops one event at one boundary, in a run
+        that otherwise looks correct.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(lead=3.6, tail=2.0)
+        start = _start_time(orchestrator)
+        _install_events(orchestrator, [start - 2.0, start + 2.0])
+
+        _, events = orchestrator._events_for_this_segment()
+
+        assert len(events) == 2, "the event ending exactly at the segment start was dropped"
+
+
+class TestBothLoopsAgree:
+    """Per-event and batched must place identically, or resume skips or repeats events."""
+
+    @pytest.mark.parametrize("execution", ["per-event", "batched"])
+    def test_the_two_modes_claim_the_same_events(self, tmp_path, execution):
+        """``population_index`` is checkpointed, so a run switched between modes must not disagree.
+
+        Asserted through the shared predicate rather than by generating, because the per-event loop
+        generates as it walks and this is a placement question.
+        """
+        orchestrator = _orchestrator(tmp_path / execution, execution=execution)
+        orchestrator.signal_adapter = _StubAdapter(lead=3.6, tail=0.4)
+        start = _start_time(orchestrator)
+        _install_events(orchestrator, [start - 1000.0, start - 500.0, start + 2.0, start + 6.0])
+
+        finished = [
+            orchestrator._event_ended_before_segment_start(dict(orchestrator._population_events[i])) for i in range(4)
+        ]
+
+        assert finished == [True, True, False, False]
+
+    def test_the_per_event_loop_steps_over_finished_events(self, tmp_path):
+        """Asserted on what the loop *generated*, not on what the predicate returned.
+
+        This test exists because the first version of this module did not have it, and a mutation
+        deleting the per-event loop's lower bound outright survived the whole suite: every other
+        test here reaches the rule through ``_events_for_this_segment`` or by calling the predicate
+        directly, so the per-event walk -- the default execution mode -- was unpinned while looking
+        covered. Both loops share the predicate but apply it separately, and ``population_index``
+        is checkpointed state, so a mode that keeps generating finished events also breaks resume
+        for a run switched between modes.
+        """
+        orchestrator = _orchestrator(tmp_path, execution="per-event")
+        adapter = _StubAdapter(lead=3.6, tail=0.4)
+        orchestrator.signal_adapter = adapter
+        start = _start_time(orchestrator)
+        _install_events(orchestrator, [start - 1000.0, start - 500.0, start + 2.0])
+
+        orchestrator._simulate()
+
+        assert adapter.simulated == [start + 2.0], (
+            f"generated {len(adapter.simulated)} event(s); the finished ones were not stepped over"
+        )
+        assert orchestrator.population_index == 3

--- a/tests/cli/test_events_ending_before_the_segment.py
+++ b/tests/cli/test_events_ending_before_the_segment.py
@@ -248,6 +248,174 @@ class TestTheBatchDoesNotGrowWithTheOffset:
         )
 
 
+class TestTheRealAdapterAnswers:
+    """No stub. The one test here that would have caught the fix being inert in production.
+
+    Every other test in this module supplies a ``_StubAdapter`` that defines
+    ``post_coalescence_duration``, so all of them passed while the *real* ``SignalAdapter`` had no
+    such method at all: the orchestrator's ``getattr`` guard returned ``None`` for every event, the
+    tail was always unknown, and the lower bound never fired in any real run. A reviewer found it
+    by instantiating an ordinary orchestrator and looking; the suite could not, because the suite
+    only ever asked a stand-in that was built to answer.
+    """
+
+    def test_the_orchestrators_own_adapter_exposes_the_query(self, tmp_path):
+        """The wiring, asserted on the object a run actually holds."""
+        orchestrator = _orchestrator(tmp_path)
+
+        assert hasattr(orchestrator.signal_adapter, "post_coalescence_duration"), (
+            "the adapter a real run holds cannot answer the tail query, so the lower bound is dead "
+            "code behind the orchestrator's getattr guard"
+        )
+
+    def test_the_real_adapter_returns_a_usable_tail(self, tmp_path):
+        """Present is not the same as answering, so the value is checked too.
+
+        A method returning ``None`` for a complete binary-black-hole event would satisfy the
+        `hasattr` test above while leaving the behaviour exactly as broken. The magnitude is pinned
+        loosely -- the point is that it is a real positive number from the installed backend, not
+        that it equals a figure recomputed here.
+        """
+        orchestrator = _orchestrator(tmp_path)
+
+        tail = orchestrator.signal_adapter.post_coalescence_duration(
+            {**_COMPLETE_EVENT, "coa_time": _START + 4.0},
+            sampling_frequency=_SAMPLING_FREQUENCY,
+            minimum_frequency=30.0,
+        )
+
+        assert tail is not None, "the installed gwmock-signal did not answer the tail query"
+        assert 0.0 < tail < 10.0, f"implausible tail for a 30+25 binary at 30 Hz: {tail} s"
+
+    def test_the_orchestrator_reaches_the_query_through_its_own_adapter(self, tmp_path):
+        """End to end through the private helper, with nothing substituted.
+
+        Closes the last gap between "the adapter has the method" and "the orchestrator calls it":
+        the two are wired by name, and a rename on either side would leave both tests above
+        passing.
+        """
+        orchestrator = _orchestrator(tmp_path)
+
+        tail = orchestrator._post_coalescence_duration({**_COMPLETE_EVENT, "coa_time": _START + 4.0})
+
+        assert tail is not None
+        assert tail > 0.0
+
+
+class TestADegradedAdapterIsReported:
+    """An adapter that cannot answer must say so once, not disappear into a silent fallback."""
+
+    def test_an_adapter_without_the_query_warns_rather_than_going_quiet(self, tmp_path, caplog):
+        """Why the query is called directly instead of behind a ``getattr`` guard.
+
+        The guard was how this change shipped as a no-op: the real ``SignalAdapter`` had no tail
+        method, the guard returned ``None`` for every event, and nothing in a run said anything.
+        Calling directly puts the ``AttributeError`` into the same handler the pre side uses, which
+        warns once and falls back -- the codebase's own rule that a fallback's cost is reported
+        rather than silent. Restoring the guard is invisible to every other test in this module,
+        because with the adapter fixed the two are behaviourally identical; this is the one test
+        that can tell them apart.
+        """
+
+        class _AdapterWithoutTheQuery:
+            detector_names = ("E1",)
+
+            def pre_coalescence_duration(self, parameters, **_):
+                del parameters
+                return 3.6
+
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _AdapterWithoutTheQuery()
+
+        with caplog.at_level("WARNING"):
+            tail = orchestrator._post_coalescence_duration({**_COMPLETE_EVENT, "coa_time": _START})
+
+        assert tail is None
+        assert any("after coalescence" in record.message for record in caplog.records), (
+            "the adapter could not answer and the run was told nothing"
+        )
+
+
+class TestTheIndexSurvivesInterleavedSkips:
+    """Skipped and claimed events interleave, so the index cannot be advanced by either count alone.
+
+    Consumption is ordered by waveform *start*; skipping is decided by waveform *end*. A long event
+    starting early and overlapping the segment can therefore be followed by a short one that starts
+    later and has already finished. Found by a reviewer, who built the case below by hand.
+    """
+
+    def test_a_claimed_event_is_not_left_behind_the_index_when_generation_fails(self, tmp_path):
+        """The one that silently drops a real event.
+
+        Event A starts early, ends inside the segment, and must be generated. Event B starts later
+        and is already finished, so it is skipped. Advancing by the skip count alone moves the index
+        past A -- and if generation then fails and a direct library caller retries on the same
+        orchestrator, A is behind the index and is never generated at all. Wasted work is the bug
+        being fixed here; losing a real event would be a worse one introduced by the fix.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        start = _start_time(orchestrator)
+        orchestrator.signal_adapter = _StubAdapter()
+        # The leads must differ, or the case does not exist. Consumption is ordered by waveform
+        # start, so giving both events the same lead puts the finished one first and the skips are
+        # a prefix after all -- the first version of this test did exactly that and passed against
+        # the unsafe code. A starts earliest *and* overlaps; B starts later and has already ended.
+        #   A: coa S+20, lead 100 -> starts S-80, ends S+520   claimed, walked first
+        #   B: coa S-40, lead  10 -> starts S-50, ends S-39    skipped, walked second
+        leads = {start + 20.0: 100.0, start - 40.0: 10.0}
+        tails = {start + 20.0: 500.0, start - 40.0: 1.0}
+        orchestrator.signal_adapter.pre_coalescence_duration = lambda parameters, **_: leads[
+            float(parameters["coa_time"])
+        ]
+        orchestrator.signal_adapter.post_coalescence_duration = lambda parameters, **_: tails[
+            float(parameters["coa_time"])
+        ]
+        orchestrator._population_events = [
+            {**_COMPLETE_EVENT, "coa_time": start + 20.0},
+            {**_COMPLETE_EVENT, "coa_time": start - 40.0},
+        ]
+        orchestrator._placement_order_cache = None
+        orchestrator.population_index = 0
+
+        # The order the walk will take, asserted rather than assumed: if a future change to the
+        # placement key made the skipped event sort first again, this test would silently stop
+        # covering the interleaving it exists for.
+        order = orchestrator._placement_order()
+        assert order == (0, 1), f"the interleaving this test needs does not exist in order {order}"
+
+        event_ids, events = orchestrator._events_for_this_segment()
+
+        assert len(events) == 1, "expected only the overlapping event to be claimed"
+        # Generation has NOT happened, so nothing may have been committed for the claimed event.
+        # Only the walk's own bookkeeping may have moved, and it must not have stepped past A.
+        remaining = orchestrator._placement_order()[int(orchestrator.population_index) :]
+        assert event_ids[0] in remaining, (
+            "the claimed event is behind population_index before its generation succeeded; a "
+            "retry would never generate it"
+        )
+
+    def test_an_all_skipped_batch_advances_through_the_real_entry_point(self, tmp_path):
+        """The case that justifies advancing inside the walk, exercised through the caller.
+
+        The other index test drives `_events_for_this_segment` and `_commit_consumed_events`
+        directly, which is exactly the path that cannot show this: `_simulate_batched_segment`
+        returns early on an empty batch and never commits, so if the walk did not advance, the next
+        segment would reconsider the same finished events -- and so would every segment after it.
+        """
+        orchestrator = _orchestrator(tmp_path)
+        orchestrator.signal_adapter = _StubAdapter(lead=3.6, tail=0.4)
+        start = _start_time(orchestrator)
+        _install_events(orchestrator, [start - 900.0, start - 800.0, start - 700.0])
+
+        chunks = orchestrator._simulate_batched_segment()
+
+        assert len(chunks) == 0
+        assert orchestrator.population_index == 3, (
+            f"index is {orchestrator.population_index}; the finished events would be walked again "
+            "by every following segment"
+        )
+
+
 class TestUnknownStillClaims:
     """Unknown is not zero, and on this side reading it as zero deletes signal."""
 

--- a/tests/signal/test_adapter.py
+++ b/tests/signal/test_adapter.py
@@ -444,3 +444,74 @@ class TestWaveformOptions:
             waveform_options={},
         )
         assert "waveform_arguments" not in backend.received_params[0]
+
+
+class TailQueryingBackend:
+    """Backend answering the tail query, rejecting unsupported parameters on the first call.
+
+    Deliberately separate from :class:`FailingBackend`: that one fails inside ``simulate``, and the
+    point here is the *query*, which runs before any generation and has its own retry.
+    """
+
+    def __init__(self, *, waveform_model: str = "IMRPhenomD", backend_label: str = "LAL") -> None:
+        self.waveform_model = waveform_model
+        self.backend_label = backend_label
+        self.required_params = frozenset({"coa_time"})
+        self.query_calls: list[dict] = []
+
+    def post_coalescence_duration(self, params, *, sampling_frequency, minimum_frequency):
+        del sampling_frequency, minimum_frequency
+        self.query_calls.append(dict(params))
+        if "redshift" in params:
+            raise ValueError(f"Unsupported {self.backend_label} waveform parameters: redshift")
+        return 0.4
+
+
+class TestPostCoalescenceDurationThroughTheAdapter:
+    """The tail query's own parameter handling, which generation's tests do not cover.
+
+    Both cases were named by a reviewer as residual risk after the round-2 fixes: the query is the
+    thing that decides *placement*, so if it and generation disagree about what reaches the
+    backend, the number describes a waveform the run will not produce.
+    """
+
+    def test_a_population_column_the_backend_rejects_does_not_lose_the_answer(self):
+        """Catch-parse-retry on the query, mirroring what generation already does.
+
+        Without it a catalogue carrying an extra column -- ``redshift`` is the usual one -- makes
+        every tail unknown, and the placement rule silently degrades to the behaviour it replaced.
+        """
+        backend = TailQueryingBackend()
+        adapter = _make_adapter_with_backend(backend)
+
+        tail = adapter.post_coalescence_duration(
+            {"mass_1": 30.0, "coa_time": 0.0, "redshift": 0.1},
+            sampling_frequency=1024.0,
+            minimum_frequency=20.0,
+        )
+
+        assert tail == 0.4
+        assert len(backend.query_calls) == 2, "the query was not retried without the rejected column"
+        assert "redshift" not in backend.query_calls[1]
+
+    def test_waveform_arguments_and_options_reach_the_query(self):
+        """The query must see the same merged mapping generation sees.
+
+        A query answering from defaults while generation runs with a pinned ``segment_duration`` or
+        a non-default ``ringdown_fraction`` would size a different buffer than the one produced,
+        and the placement decision would be made about a waveform that does not exist.
+        """
+        backend = TailQueryingBackend()
+        adapter = _make_adapter_with_backend(backend)
+
+        adapter.post_coalescence_duration(
+            {"mass_1": 30.0, "coa_time": 0.0},
+            sampling_frequency=1024.0,
+            minimum_frequency=20.0,
+            waveform_arguments={"reference_frequency": 50.0},
+            waveform_options={"ModeArray": [(2, 2)]},
+        )
+
+        received = backend.query_calls[0]
+        assert received["reference_frequency"] == 50.0
+        assert "waveform_arguments" in received


### PR DESCRIPTION
## 📝 Summary

`_event_starts_before_segment_end` had no lower bound. In a sequential run that is invisible,
because earlier segments have already consumed the earlier events. It is not invisible in a run
whose `start-time` is later than its population's first event: nothing has consumed those events,
every one of them satisfies "starts before this segment ends", and the first segment claims the
entire back catalogue.

**Measured on the shipped ET config:** a run starting 53 ks into the catalogue batched **126
events for a segment containing 13**, estimated 12.5 GiB, and was refused by the preflight; at
41 ks it batched 98 for 16; at 4 ks, 19 for 8. The batch tracks the distance from the catalogue
start rather than the local event density, and the extra events' samples are then cropped as
out-of-segment — generated and discarded. Resuming a campaign mid-catalogue, or slicing a long
population into per-day jobs, is exactly this.

This adds the missing bound, using `post_coalescence_duration` from gwmock-signal 0.16.0:

- `AdapterOrchestrator._event_ended_before_segment_start` — `coa_time + tail < segment_start`,
  strict, so an event ending exactly on the boundary keeps its final sample.
- `SignalAdapter.post_coalescence_duration` — the wrapper the orchestrator actually talks to,
  mirroring `pre_coalescence_duration` including its unsupported-parameter retry.
- Both consumption loops **step over and consume** a finished event.
- Dependency floor moved to `>=0.16.0` in all four places, with `uv.lock`. The two comments
  justifying the old floor had become false and are rewritten.

**`None` means unknown and claims the event.** The tail is a fixed fraction of the buffer rather
than a physical ringdown — 0.4 s for a 4 s BBH buffer, 25.6 s for a 256 s BNS one — so an event
coalescing before the segment may still be producing signal inside it. Reading unknown as zero
would discard those silently, and for a whole backend at a time.

### Two design points worth stating

**The bound is not another clause in the existing predicate.** Both loops `break` on the first
event that does not belong, and `population_index` means "every event before this one is consumed".
An early event answering *does not belong* would stop the walk at position 0 and repeat that on
every following segment — the run would **stall permanently**, which is worse than the
over-batching being fixed.

**The index advances by the walk's traversal, not by the skip count.** Skips are not a prefix:
consumption is ordered by waveform *start* while skipping is decided by waveform *end*, so a long
overlapping event can be followed by a short finished one. Advancing by skips leaves the claimed
event behind the index, and a direct library caller retrying after a generation failure would never
generate it. Only the all-skipped batch advances inside the walk, because the caller returns early
on an empty batch and never reaches the commit.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** `uv run pytest` → **1099 passed, 23 skipped** on the review machine.
- [x] **Regression first.** Five tests were run against the unfixed tree and confirmed failing
      there *for the right reason* — 13 batched where 3 belong, and 12/22/42 growing with the
      offset, reproducing the measured shape rather than erroring.
- [x] **Checked against generation, not against another prediction.** The predicted tail is
      compared with where the produced `TimeSeries` actually ends, and lead + tail against its
      duration. Inflating the tail by 5% fails both and nothing else.
- [x] **Three tests use the real adapter** with nothing substituted — see below for why that
      matters more than the count suggests.
- [x] **Fifteen mutations across three rounds, all killed**, each by the test that owns it:
      unknown-as-zero, skip-as-break, index-not-advanced, `<`→`<=`, per-event loop left one-sided,
      no-`coa_time`-as-finished, adapter method removed, adapter answering `None`,
      commit-by-generated-count, walk-advancing-by-skips, guard restored, post-side retry removed,
      query bypassing the parameter merge, tail inflated 5%.

### What review caught that the tests did not

**The first version of this change was a no-op in production while fifteen tests passed.** Both
independent reviewers found it in the same round. `signal_adapter` is this package's own
`SignalAdapter`, not gwmock-signal's `CBCSimulator`, and it had only `pre_coalescence_duration`; a
`getattr` guard turned every tail into "unknown" and the bound never fired. Every test supplied a
stub built to answer, so the stub *was* the bug's disguise. The guard is gone — the query is called
directly, so a missing method warns once through the existing handler instead of vanishing, which
is this codebase's own rule about fallbacks having reported costs.

Round 2 found no logic defects and closed coverage gaps instead: the query-versus-generation
agreement test above, the post-side retry, the parameter merge, and warn-once dedup across a walk.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature
      works.

**On the unchecked box, and one gap left open deliberately.**

No user-guide coverage for the tail. A reviewer checked and the *pre* side has none either, so this
is symmetric with existing precedent rather than a new hole; a short note is warranted and is
tracked separately.

**The ripple batched path never exercises a skip end to end.** The real-adapter tests use the
default LAL backend and the bundled population has its one event inside the segment, so index
agreement between the two execution modes is validated with *zero skips*. Closing it needs the
`[jax]` extra and belongs in the `test-jax` cells; it is tracked. Related, pre-existing, and shared
with the pre side: in a batched config with no `waveform-backend` key, the adapter holds LAL while
`simulate_cbc_batch` generates with ripple (4.0 s vs 3.125 s buffers for the same 30+25 binary).
LAL's tail is the larger, so it errs toward claiming — wasted work, not dropped signal — and the
shipped batched example sets ripple explicitly. Safe today, but by asymmetry rather than by design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved event placement by skipping waveforms that finish before a segment begins.
  * Added waveform tail-duration detection to support more accurate event processing.
  * Added fallback handling when tail duration cannot be determined, with deduplicated warnings.

* **Bug Fixes**
  * Preserved catalogue indexing and traversal across skipped events, failed generations, and empty batches.
  * Improved consistency between batched and per-event processing.
  * Updated the minimum supported signal package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->