### PR TITLE
chore(deps): floor gwmock-signal at 0.16.0 for the frame-of-date projection fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,14 @@ dependencies = [
   # rather than the one holding its coalescence. Below this the query is absent, placement falls back
   # to `coa_time`, and the start of any waveform landing near a boundary is cropped -- so this is a
   # floor the behaviour depends on, not a convenience.
-  "gwmock-signal>=0.15.0",
+  #
+  # Floored at 0.16.0 for a *correctness* fix rather than a feature: gwmock-signal #370 projects the
+  # source direction into the frame of date. Before it, `gha = GMST - right_ascension` mixed a J2000
+  # right ascension with an Earth rotation measured from the mean equinox of date, an inconsistency
+  # worth 0.43 degrees in right ascension by 2030. The fix cuts worst-case disagreement with
+  # `lalpulsar.Barycenter` from 1.774e-04 s to 8.686e-07 s across a 192-point sky/epoch grid. It
+  # changes continuous-wave output, which is why this bump carries regenerated e2e references.
+  "gwmock-signal>=0.16.0",
   "gwmock-noise>=0.10.1",
   "gwmock-pop>=0.11.5",
   "typer>=0.19.0",         # Literal-type CLI options; the SPEC 0 floor (0.13) predates them
@@ -41,7 +48,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-sgwb = ["gwmock-signal[sgwb]>=0.15.0"]
+sgwb = ["gwmock-signal[sgwb]>=0.16.0"]
 # The batched signal path. Without this extra `SignalAdapter.simulate_segments` and
 # `execution: batched` raise, because gwmock-signal's batched entry points need JAX and ripple,
 # which the base install omits.
@@ -51,16 +58,16 @@ sgwb = ["gwmock-signal[sgwb]>=0.15.0"]
 # it is the one the test suite exercises -- but it is not device execution, and nothing at runtime
 # distinguishes the two beyond `jax.devices()`. Use the `cuda` extra below for a GPU.
 #
-# 0.15.0 rather than 0.13.0 because that release floors `ripplegw>=0.3.1`, the first ripple
+# Floored above 0.13.0 because 0.15.0 floors `ripplegw>=0.3.1`, the first ripple
 # carrying the geocentre fix (GW-JAX-Team/ripple#141). Without it the continuous-wave path gets a
 # ripple that returns NaN for every sample at the geocentre, where these simulators generate. The
 # floor is deliberately *not* restated here as a `ripplegw` declaration: it belongs beside the
 # guard that raises on those NaNs, which lives in gwmock-signal, and stating a version in two
 # repositories is how the two drift.
-jax = ["gwmock-signal[jax]>=0.15.0"]
+jax = ["gwmock-signal[jax]>=0.16.0"]
 # The same path with an actual GPU backend. Linux x86_64 with a CUDA 12 driver only; there is no
 # macOS or Windows wheel, which is why this is separate from `jax` rather than folded into it.
-cuda = ["gwmock-signal[jax]>=0.15.0", "jax[cuda12]>=0.11.0"]
+cuda = ["gwmock-signal[jax]>=0.16.0", "jax[cuda12]>=0.11.0"]
 
 [dependency-groups]
 dev = [

--- a/tests/e2e/references/signal__cw__et_triangle_sardinia.json
+++ b/tests/e2e/references/signal__cw__et_triangle_sardinia.json
@@ -2,16 +2,16 @@
   "environment": {
     "astropy": "8.0.1",
     "astropy-iers-data": "0.2026.8.3.0.53.6",
-    "gwmock": "0.12.0.post28+148c143",
-    "gwmock-noise": "0.10.0",
-    "gwmock-pop": "0.11.4",
-    "gwmock-signal": "0.13.0",
+    "gwmock": "0.13.0.post23+6044248",
+    "gwmock-noise": "0.10.1",
+    "gwmock-pop": "0.11.5",
+    "gwmock-signal": "0.16.0",
     "jax": "0.11.0",
     "jaxlib": "0.11.0",
     "lalsuite": "7.26.15",
     "numpy": "2.5.1",
     "pyerfa": "2.0.1.5",
-    "ripplegw": "0.3.1.dev3",
+    "ripplegw": "0.3.1",
     "scipy": "1.18.0"
   },
   "fingerprint": {
@@ -22,64 +22,64 @@
   "label": "signal/cw/et_triangle_sardinia",
   "outputs": {
     "output/signal/E-ET1_SARD_STRAIN_CW-1419724816-8.gwf": {
-      "argmax": 653,
-      "content_hash": "sha256:ea1b528f43831819c90890bcde0b18ab8498a70e2bc005e3019c217b20bdae49",
-      "mean": -4.0779608509577994e-29,
+      "argmax": 1165,
+      "content_hash": "sha256:4f347f9919f1d6aae1b13f50b5f72e7331403b18df892c324641825ea975b54a",
+      "mean": -4.113951223045172e-29,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 8.669719437127463e-25,
-      "rms": 4.308881299526465e-25,
-      "signed_peak": 8.669719437127463e-25
+      "peak": 8.681129022047634e-25,
+      "rms": 4.318350442512096e-25,
+      "signed_peak": 8.681129022047634e-25
     },
     "output/signal/E-ET1_SARD_STRAIN_CW-1419724824-8.gwf": {
       "argmax": 141,
-      "content_hash": "sha256:8f2fccccec0f645ddd81bbc1c8ce57092d3029601811698b0923c35f3c133e26",
-      "mean": -3.806399163955231e-29,
+      "content_hash": "sha256:c0d058de74c0f6e752ad407dfa479f6b3a16f3dff4925ea139005de83bcd7d58",
+      "mean": -3.8454189171388483e-29,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 8.653649255856141e-25,
-      "rms": 4.308331956972266e-25,
-      "signed_peak": 8.653649255856141e-25
+      "peak": 8.6700946864139e-25,
+      "rms": 4.317823002304504e-25,
+      "signed_peak": 8.6700946864139e-25
     },
     "output/signal/E-ET2_SARD_STRAIN_CW-1419724816-8.gwf": {
       "argmax": 1827,
-      "content_hash": "sha256:4b305a855242b7aa97238344cfd48b4facd5b67189da6d1cb7b20091499d6325",
-      "mean": 6.386176818971265e-30,
+      "content_hash": "sha256:8fdd2a52c75712698a14d3aba78fd8b6559d8c24f4d1b1a58602acc6c142d71f",
+      "mean": 6.412414727277242e-30,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 6.402404321983363e-25,
-      "rms": 3.3166792911182656e-25,
-      "signed_peak": 6.402404321983363e-25
+      "peak": 6.403914071661634e-25,
+      "rms": 3.3269977853623663e-25,
+      "signed_peak": 6.403914071661634e-25
     },
     "output/signal/E-ET2_SARD_STRAIN_CW-1419724824-8.gwf": {
       "argmax": 1827,
-      "content_hash": "sha256:bbf453b1f63cd26437a9676cc9c4b51adbcf5e3471af2c6ec92877a12074a939",
-      "mean": 3.799044455510672e-30,
+      "content_hash": "sha256:c9318d91d43a91fbdc3ee6ff5f91fb42f7e34dcbb33dc8ca9e676243452b6a05",
+      "mean": 3.836043818123109e-30,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 6.435753627922695e-25,
-      "rms": 3.3159998152712577e-25,
-      "signed_peak": 6.435753627922695e-25
+      "peak": 6.439857730741399e-25,
+      "rms": 3.326297376071223e-25,
+      "signed_peak": 6.439857730741399e-25
     },
     "output/signal/E-ET3_SARD_STRAIN_CW-1419724816-8.gwf": {
       "argmax": 94,
-      "content_hash": "sha256:7c26177f46c63344d876507705ce17299e58543272d091ef24345179d59188bf",
-      "mean": 3.4639300076440884e-29,
+      "content_hash": "sha256:1243db03015d05f1366695e7105b9ba8e7ac264546298ccc9a73dc4f781987d5",
+      "mean": 3.497234354929469e-29,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 7.982557734013806e-25,
-      "rms": 4.2740235644150125e-25,
-      "signed_peak": 7.982557734013806e-25
+      "peak": 8.045951405148767e-25,
+      "rms": 4.300666384145504e-25,
+      "signed_peak": 8.045951405148767e-25
     },
     "output/signal/E-ET3_SARD_STRAIN_CW-1419724824-8.gwf": {
-      "argmax": 1644,
-      "content_hash": "sha256:c4f2334699de3a9f9bc130e41f727ffa98d3253e7cc36210e06aa56a3d88db8e",
-      "mean": 3.4513462422540224e-29,
+      "argmax": 1849,
+      "content_hash": "sha256:1977bca172c1733fd0786bb7260cc120526893abaa729c2f1a2a407b59b314a9",
+      "mean": 3.486630424899423e-29,
       "n": 2048,
       "nonzero": 2048,
-      "peak": 8.061702410942921e-25,
-      "rms": 4.2716628140774055e-25,
-      "signed_peak": 8.061702410942921e-25
+      "peak": 8.095211688518707e-25,
+      "rms": 4.2983132085753625e-25,
+      "signed_peak": 8.095211688518707e-25
     }
   }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -700,10 +700,10 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.16.0" },
     { name = "gwmock-noise", specifier = ">=0.10.1" },
     { name = "gwmock-pop", specifier = ">=0.11.5" },
-    { name = "gwmock-signal", specifier = ">=0.15.0" },
-    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'cuda'", specifier = ">=0.15.0" },
-    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'jax'", specifier = ">=0.15.0" },
-    { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", specifier = ">=0.15.0" },
+    { name = "gwmock-signal", specifier = ">=0.16.0" },
+    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'cuda'", specifier = ">=0.16.0" },
+    { name = "gwmock-signal", extras = ["jax"], marker = "extra == 'jax'", specifier = ">=0.16.0" },
+    { name = "gwmock-signal", extras = ["sgwb"], marker = "extra == 'sgwb'", specifier = ">=0.16.0" },
     { name = "h5py", specifier = ">=3.12.1" },
     { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda'", specifier = ">=0.11.0" },
     { name = "psutil", specifier = ">=6.1.0" },
@@ -768,7 +768,7 @@ wheels = [
 
 [[package]]
 name = "gwmock-signal"
-version = "0.15.0"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gwpy" },
@@ -776,9 +776,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/8e/4d8161a3d06de6a972f3507be3ae35a25aa1335d517df363f49498c013a0/gwmock_signal-0.15.0.tar.gz", hash = "sha256:9e90af755e80f1555a6bb8e6a66602cff34c77f9dfbdf5894b58a053c3d5c8f1", size = 445527, upload-time = "2026-08-04T09:40:44.488Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/70/ff393b7129e21a4f4db42b3a39e609d2282e49eaced5fdba075aea259349/gwmock_signal-0.16.0.tar.gz", hash = "sha256:e104115ba1b086c88a2998430b003f82138dcb23f628b5723206b61d78a8b695", size = 468969, upload-time = "2026-08-07T20:33:13.128Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/2b/1a42e19fc7f8c458e2c5a8e889559499111d0dfd5d963c34f816cc2828da/gwmock_signal-0.15.0-py3-none-any.whl", hash = "sha256:7d39b5c576c1d5ae2b63cb631f97cb209f024edde71fa45fcd1fa46e2c91be73", size = 165891, upload-time = "2026-08-04T09:40:43.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/af/0f1a648601c2cf6148a89b04e65a8561f0ef79e7f38fdc55c9885152cb83/gwmock_signal-0.16.0-py3-none-any.whl", hash = "sha256:a865f75ef7c15273d5f8f3a35aa09c63eb3d1b82fce70944cfeae87ab09a39db", size = 174367, upload-time = "2026-08-07T20:33:11.611Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 📝 Summary

Floors `gwmock-signal` at 0.16.0. **Not a routine bump** — 0.16.0 contains a projection
correctness fix that changes continuous-wave output, so it is split out from the placement work
that needed the floor (#332) rather than landing inside it. A later bisect of CW values should
arrive at this commit, not at a PR titled as a placement fix.

**The fix.** gwmock-signal
[#370](https://github.com/Leuven-Gravity-Institute/gwmock-signal/pull/370) projects the source
direction into the frame of date. Before it, the projection computed
`gha = GMST - right_ascension` using a **J2000** right ascension, while GMST measures the Earth's
rotation from the mean equinox **of date**. The two live in different frames, and the mismatch is
the precession accumulated since J2000 — 0.43° in right ascension by 2030. An inconsistency, not a
convention.

**Anchored outside gwmock-signal's own arithmetic.** The fix cuts worst-case disagreement with
`lalpulsar.Barycenter` from **1.774e-04 s to 8.686e-07 s** across a 192-point grid (3 detectors ×
4 right ascensions × 4 declinations × 4 epochs). The residue is nutation-scale — which LAL adds
separately and gwmock-signal does not model — so 8.7e-07 s is the size the omission predicts rather
than an unexplained leftover.

Both comments justifying the previous floor named 0.15.0 and are corrected.

## ✨ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 Refactoring (no functional changes, no API changes)

*(Closest available box. Strictly this is a dependency floor whose observable effect is a
corrected continuous-wave projection — no gwmock API changes, but the output does change; the
regenerated references below are that change made explicit.)*

## 🧪 How Has This Been Tested?

- [x] **e2e:** `uv run pytest -m e2e -k cw` → 6 passed against the regenerated references.
- [x] **Generated on the platform CI compares against** — Linux x86_64, Python 3.12 — not on the
      arm64 review machine. `argmax` is compared **exactly**, and a CW signal is near-sinusoidal, so
      its peak hops between nearly-equal maxima under a tiny amplitude change; references written
      elsewhere could fail on `argmax` alone.
- [x] **The two `argmax` moves recorded here (653 → 1165, 1644 → 1849) are identical to the ones CI
      observed**, and the regenerated peaks agree with CI's values to ~7 digits.
- [x] **Validated before regenerating, not after.** The CW check was confirmed *failing* on the
      generating host first. Had it passed there, the drift would have been CI-specific and
      regenerating from that host would have blessed the wrong numbers.
- [x] **Scope:** the file set, the fingerprint (`{Linux, x86_64, 3.12}`) and every other scenario's
      reference are unchanged; one file differs.
- [x] **Attribution proven, not assumed.** `main` with only these four pins bumped and no other
      change reproduces the same drift to ~13 significant digits, which is what established that
      #332's placement work was not responsible.

### Magnitude, and what is not anchored

The shifts are **peak 2.4e-04 to 7.9e-03** and **rms 2.2e-03 to 6.2e-03** relative. The correction
is 0.43° = 7.5e-03 rad and antenna patterns vary on radian scales, so a fractional amplitude change
of that order is what it predicts, with the smaller values where the pattern derivative is flatter.

**Not anchored:** where the new `argmax` lands. It is consistent with peak-hopping on a
near-sinusoid, but nothing here predicts the specific sample.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature
      works.

**On the unchecked box:** no documentation change. The corrected projection is described in
gwmock-signal's own release, and this repository's docs do not state the old convention anywhere I
could find — but I did not exhaustively verify that, so it is worth a reviewer's grep rather than my
assurance.
