### PR TITLE
fix(placement): answer placement with the backend that generates the buffer

### DIFF
--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -805,28 +805,25 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         if getattr(self, "_substituted_waveform_backend", None) is not None:
             self._substituted_waveform_backend = None
 
-    def _require_placement_backend(self) -> None:
-        """Refuse to answer a placement question the run cannot answer correctly.
+    def _placement_backend_can_answer(self) -> bool:
+        """Whether the tail query describes the buffer this run will actually generate.
 
         A batched config with no ``waveform-backend`` needs ripple, because that is what it
-        generates with. When ripple is missing the adapter is left on LAL, and a LAL answer here is
-        not merely unavailable -- it is *wrong in a way that consumes events*: it can report an event
-        finished when ripple would still be producing it, and the batched path then returns early on
-        the empty batch, so generation never runs and the install error never surfaces. The event is
-        skipped, the index advances, and nothing is reported.
+        generates with. When ripple is missing the adapter is left on the default library, whose
+        tail is shorter than ripple's at some masses and cutoffs -- so *acting* on that answer can
+        skip an event ripple would still be producing.
 
-        Raises:
-            ImportError: If placement is asked of a batched run whose generating library is absent.
+        Only the skip is dangerous, so only the skip is withheld: the tail reports *unknown*, which
+        by this module's standing rule claims the event rather than dropping it. The batch is then
+        non-empty, generation runs, and ripple's own install error surfaces where it belongs.
+        Refusing to answer at all was tried and was too broad -- it made every batched unit test and
+        every construct-and-inspect caller raise, in an environment where nothing was going to
+        generate anyway.
+
+        Returns:
+            Whether the answering backend is the one that will generate.
         """
-        if self._substituted_waveform_backend != _RIPPLE_UNAVAILABLE:
-            return
-        raise ImportError(
-            "execution: batched generates with ripple, so segment placement has to ask ripple where "
-            "each waveform starts and ends -- and ripple is not installed. Answering with the "
-            "default library instead would skip events it reports as finished while ripple would "
-            "still be producing them, without ever reaching the code that raises this at "
-            "generation. Install the extra: pip install 'gwmock-signal[jax]'."
-        )
+        return self._substituted_waveform_backend != _RIPPLE_UNAVAILABLE
 
     def _event_ended_before_segment_start(self, parameters: Mapping[str, Any]) -> bool:
         """Return whether this event's waveform has finished before the current segment begins.
@@ -892,7 +889,18 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         """
         if self.signal_adapter is None:
             return None
-        self._require_placement_backend()
+        if not self._placement_backend_can_answer():
+            # Unknown, not zero: the caller claims the event and generation raises the real error.
+            reason = "ripple is not installed, so the tail would describe a different library"
+            if reason not in self._post_coalescence_query_failures:
+                self._post_coalescence_query_failures.add(reason)
+                logger.warning(
+                    "Cannot establish how long after coalescence a waveform ends (%s). Every event "
+                    "is claimed rather than skipped, which is the conservative direction; "
+                    "generation will fail with the install instruction.",
+                    reason,
+                )
+            return None
         # Called directly, exactly as the pre side calls its own query, and deliberately *not*
         # behind a `getattr` guard. A guard here returns `None` for an adapter without the method
         # and says nothing, which is precisely how this change shipped as a silent no-op: the
@@ -935,7 +943,6 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         """
         if self.signal_adapter is None:
             return None
-        self._require_placement_backend()
         try:
             return self.signal_adapter.pre_coalescence_duration(
                 parameters,

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -33,6 +33,11 @@ from gwmock.simulator.state import StateAttribute
 #: supplying arguments would quietly change which library generates the waveforms.
 _DEFAULT_WAVEFORM_BACKEND = "lal"
 
+#: Sentinel recorded when a batched config needed ripple for its placement queries and could not
+#: have it. Distinct from ``None`` -- which means nothing was substituted and the default genuinely
+#: applies -- because the two must behave differently: one answers, the other must refuse.
+_RIPPLE_UNAVAILABLE = "__ripple_unavailable__"
+
 logger = logging.getLogger("gwmock")
 
 
@@ -419,7 +424,18 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                 waveform_backend_name = "ripple"
                 substituted = "ripple"
             except ImportError:
-                logger.debug("ripple is unavailable, so the adapter keeps the default backend.")
+                # Construction still succeeds -- one reviewer showed that raising here breaks config
+                # validation, stubbed placement and every caller that only builds an orchestrator.
+                # But it must not proceed silently either: another reviewer then showed that a
+                # LAL-backed adapter answers placement, skips an event ripple would still be
+                # producing, and advances `population_index` -- and because the batched path returns
+                # early on an empty batch, generation never runs and the install error never
+                # surfaces. The event is consumed, never generated, and nothing is reported.
+                #
+                # So the failure is deferred to the first placement query instead of being dropped:
+                # constructing is harmless, asking a question whose answer would be wrong is not.
+                substituted = _RIPPLE_UNAVAILABLE
+                logger.debug("ripple is unavailable; placement queries will refuse rather than answer.")
 
         if waveform_backend_name is not None or waveform_backend_arguments:
             backend_arguments["waveform_backend"] = instantiate_backend(
@@ -526,6 +542,11 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         configured = self._configured_waveform_backend()
         if configured is not None:
             return configured
+        if self._substituted_waveform_backend == _RIPPLE_UNAVAILABLE:
+            # Nothing was substituted, and nothing generated either -- such a run cannot get past
+            # its first placement query. Reporting the sentinel as a library name would be worse
+            # than reporting the truth, which is that the default applied.
+            return None
         # Recorded by the code that made the substitution rather than recovered from the adapter.
         # The first version of this walked `_backend._waveform_factory` looking for a RippleBackend,
         # guessed the attribute name wrong, and silently returned None for every run -- reporting
@@ -764,6 +785,29 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         start_time_value = float(coa_time) if lead is None else float(coa_time) - float(lead)
         return start_time_value < end_time_value
 
+    def _require_placement_backend(self) -> None:
+        """Refuse to answer a placement question the run cannot answer correctly.
+
+        A batched config with no ``waveform-backend`` needs ripple, because that is what it
+        generates with. When ripple is missing the adapter is left on LAL, and a LAL answer here is
+        not merely unavailable -- it is *wrong in a way that consumes events*: it can report an event
+        finished when ripple would still be producing it, and the batched path then returns early on
+        the empty batch, so generation never runs and the install error never surfaces. The event is
+        skipped, the index advances, and nothing is reported.
+
+        Raises:
+            ImportError: If placement is asked of a batched run whose generating library is absent.
+        """
+        if self._substituted_waveform_backend != _RIPPLE_UNAVAILABLE:
+            return
+        raise ImportError(
+            "execution: batched generates with ripple, so segment placement has to ask ripple where "
+            "each waveform starts and ends -- and ripple is not installed. Answering with the "
+            "default library instead would skip events it reports as finished while ripple would "
+            "still be producing them, without ever reaching the code that raises this at "
+            "generation. Install the extra: pip install 'gwmock-signal[jax]'."
+        )
+
     def _event_ended_before_segment_start(self, parameters: Mapping[str, Any]) -> bool:
         """Return whether this event's waveform has finished before the current segment begins.
 
@@ -828,6 +872,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         """
         if self.signal_adapter is None:
             return None
+        self._require_placement_backend()
         # Called directly, exactly as the pre side calls its own query, and deliberately *not*
         # behind a `getattr` guard. A guard here returns `None` for an adapter without the method
         # and says nothing, which is precisely how this change shipped as a silent no-op: the
@@ -870,6 +915,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         """
         if self.signal_adapter is None:
             return None
+        self._require_placement_backend()
         try:
             return self.signal_adapter.pre_coalescence_duration(
                 parameters,

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -380,6 +380,22 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         # resolver and is rejected there instead of being treated as absent.
         waveform_backend_name = getattr(signal_config, "waveform_backend", None)
         waveform_backend_arguments = _normalize_keys(dict(signal_config.waveform_backend_arguments))
+
+        # `execution: batched` always generates with ripple -- `_batched_waveform_backend` refuses
+        # any other library rather than substituting one. So when a batched config names no backend,
+        # the adapter must be built on ripple too, or the *placement queries* answer for a LAL buffer
+        # while generation produces a ripple one.
+        #
+        # That mismatch deletes signal, and not hypothetically. The two libraries round buffer
+        # lengths onto different grids, so which tail is longer flips with mass and cutoff: measured
+        # across 24 mass/cutoff combinations, 9 have ripple's tail longer than LAL's -- 1.4+1.35 at
+        # 5 Hz answers 819.20 s against a generated 934.17 s, so an event up to 115 s of whose
+        # content lands inside the segment is reported finished and skipped. Low cutoffs and low
+        # masses are exactly the ET regime. Aligning the two here removes the whole class rather
+        # than relying on which way the rounding happens to fall.
+        if waveform_backend_name is None and str(getattr(signal_config, "execution", "per-event")) == "batched":
+            waveform_backend_name = "ripple"
+
         if waveform_backend_name is not None or waveform_backend_arguments:
             backend_arguments["waveform_backend"] = instantiate_backend(
                 "waveform",

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -785,6 +785,26 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         start_time_value = float(coa_time) if lead is None else float(coa_time) - float(lead)
         return start_time_value < end_time_value
 
+    @property
+    def signal_adapter(self):
+        """The adapter answering placement queries and generating signals."""
+        return self._signal_adapter
+
+    @signal_adapter.setter
+    def signal_adapter(self, adapter) -> None:
+        """Replace the adapter, and stop claiming a substitution that described the old one.
+
+        ``_substituted_waveform_backend`` records which library `from_config` built the adapter on.
+        Replacing the adapter -- which tests do routinely, and which library callers may do --
+        invalidates that: a reviewer showed the recorded value survived the swap, so provenance
+        reported ripple while a LAL-backed stand-in answered every query. Clearing it makes the
+        record describe nothing rather than describe the wrong thing, and a caller who knows better
+        can set it explicitly.
+        """
+        self._signal_adapter = adapter
+        if getattr(self, "_substituted_waveform_backend", None) is not None:
+            self._substituted_waveform_backend = None
+
     def _require_placement_backend(self) -> None:
         """Refuse to answer a placement question the run cannot answer correctly.
 

--- a/src/gwmock/cli/adapter_orchestration.py
+++ b/src/gwmock/cli/adapter_orchestration.py
@@ -98,6 +98,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         population_seed: int | None = None,
         signal_adapter: SignalAdapter | None = None,
         noise_adapter: NoiseAdapter | None = None,
+        substituted_waveform_backend: str | None = None,
     ) -> None:
         self._population_events = tuple(population_events)
         self._population_metadata = dict(population_metadata)
@@ -154,6 +155,10 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         # thousands of times. Keyed by the failure text rather than a flag, because a single
         # malformed row fails only its own query and its cause differs from a whole-catalogue one --
         # collapsing both into one warning would name the wrong cause for everything after it.
+        #: Library the run was switched to when the config named none -- ripple for a batched
+        #: config, because that is what `execution: batched` generates with. `None` when nothing
+        #: was substituted. Provenance reads this so it names the library that actually ran.
+        self._substituted_waveform_backend = substituted_waveform_backend
         self._pre_coalescence_query_failures: set[str] = set()
         self._post_coalescence_query_failures: set[str] = set()
         #: How far the last batched walk traversed, set by `_events_for_this_segment` and consumed
@@ -215,8 +220,9 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         elif has_signal:
             source_type = str(orchestration_config.signal.source_type)  # type: ignore[union-attr]
 
+        substituted_waveform_backend: str | None = None
         if has_signal:
-            signal_adapter = cls._instantiate_signal_adapter(
+            signal_adapter, substituted_waveform_backend = cls._instantiate_signal_adapter(
                 orchestration_config.signal,
                 source_type=source_type,
                 detector_network=detector_network,
@@ -257,6 +263,7 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             orchestration_config=orchestration_config,
             population_seed=population_seed,
             signal_adapter=signal_adapter,
+            substituted_waveform_backend=substituted_waveform_backend,
             noise_adapter=noise_adapter,
         )
 
@@ -359,7 +366,9 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         source_type: str,
         detector_network: Network,
         duration: float,
-    ) -> SignalAdapter:
+    ) -> tuple[SignalAdapter, str | None]:
+        """Return the adapter and the backend name substituted for it, if any."""
+        substituted: str | None = None
         backend_name = signal_config.backend or source_type
         backend_class = resolve_backend_class("signal", backend_name)
         backend_arguments = _normalize_keys(dict(signal_config.arguments))
@@ -393,8 +402,24 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         # content lands inside the segment is reported finished and skipped. Low cutoffs and low
         # masses are exactly the ET regime. Aligning the two here removes the whole class rather
         # than relying on which way the rounding happens to fall.
-        if waveform_backend_name is None and str(getattr(signal_config, "execution", "per-event")) == "batched":
-            waveform_backend_name = "ripple"
+        batched = str(getattr(signal_config, "execution", "per-event")) == "batched"
+        if waveform_backend_name is None and batched:
+            # Not eager: a reviewer showed that instantiating ripple here breaks every caller that
+            # only wants to *construct* an orchestrator without the [jax] extra -- config
+            # validation, stubbed placement, the tests that pass waveform_backend=None -- and worse,
+            # it masks a real configuration error behind "rippleGW is not installed".
+            #
+            # Falling back is safe precisely where it applies: without ripple the batched path
+            # cannot generate at all, so no placement decision it might get wrong is ever acted on,
+            # and generation raises the actionable install error instead of this one.
+            try:
+                backend_arguments["waveform_backend"] = instantiate_backend(
+                    "waveform", "ripple", init_kwargs=waveform_backend_arguments
+                )
+                waveform_backend_name = "ripple"
+                substituted = "ripple"
+            except ImportError:
+                logger.debug("ripple is unavailable, so the adapter keeps the default backend.")
 
         if waveform_backend_name is not None or waveform_backend_arguments:
             backend_arguments["waveform_backend"] = instantiate_backend(
@@ -408,11 +433,12 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
             backend_arguments=backend_arguments,
         )
         validate_backend("signal", backend_name, backend_class, backend_instance)
-        return SignalAdapter.from_backend(
+        adapter = SignalAdapter.from_backend(
             source_type=source_type,
             backend=backend_instance,
             network=detector_network,
         )
+        return adapter, substituted
 
     @staticmethod
     def _instantiate_noise_adapter(noise_config) -> NoiseAdapter:
@@ -451,9 +477,15 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
                     # data: the same approximant from LAL and from ripple agree closely but not
                     # exactly, so without this two runs with materially different strain would
                     # carry identical provenance. Read from the config rather than stored
-                    # separately, to keep one source of truth. ``None`` means none was requested,
-                    # and gwmock-signal's own default (LAL) applied.
-                    "waveform_backend": self._configured_waveform_backend(),
+                    # separately, to keep one source of truth. ``None`` means none was requested
+                    # *and* none was substituted, so gwmock-signal's own default (LAL) applied.
+                    #
+                    # A batched config naming no backend is such a substitution: the adapter is
+                    # built on ripple, because that is what `execution: batched` generates with.
+                    # Reading the raw key here would record ``None`` for a run that used ripple, so
+                    # provenance and replay would name a different library than the one that
+                    # produced the data -- and the note above is exactly why that matters.
+                    "waveform_backend": self._effective_waveform_backend(),
                     "waveform_backend_arguments": self._configured_waveform_backend_arguments(),
                     "waveform_arguments": self.waveform_arguments,
                     "waveform_options": self.waveform_options,
@@ -479,6 +511,27 @@ class AdapterOrchestrator(TimeSeriesMixin, Simulator):
         """Return the requested waveform-backend name, or ``None`` if the default applied."""
         signal_config = self.orchestration_config.signal
         return None if signal_config is None else getattr(signal_config, "waveform_backend", None)
+
+    def _effective_waveform_backend(self) -> str | None:
+        """Return the waveform library this run actually used, not the one the config named.
+
+        The two differ in exactly one case, and it is a case provenance must not misreport: a
+        batched config naming no backend is built on ripple, because ``execution: batched``
+        generates with ripple and the placement queries have to describe the buffer generation will
+        produce. Recording the raw key would file such a run under the default library.
+
+        Returns:
+            The backend name, or ``None`` when none was requested and none was substituted.
+        """
+        configured = self._configured_waveform_backend()
+        if configured is not None:
+            return configured
+        # Recorded by the code that made the substitution rather than recovered from the adapter.
+        # The first version of this walked `_backend._waveform_factory` looking for a RippleBackend,
+        # guessed the attribute name wrong, and silently returned None for every run -- reporting
+        # the library correctly only by accident. Two private attributes across a package boundary
+        # is what this codebase warns about elsewhere, and this is why.
+        return self._substituted_waveform_backend
 
     def _configured_waveform_backend_arguments(self) -> dict[str, Any]:
         """Return the waveform-backend constructor arguments, empty when none were given."""

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -629,3 +629,62 @@ class TestTheQueryAnswersForTheBackendThatGenerates:
             f"event whose content reaches {generated - answered} s further than the query admits "
             "can be skipped while it is still contributing to the segment"
         )
+
+
+class TestTheRippleSubstitutionIsHonest:
+    """Substituting ripple for a batched config must not break construction or lie in provenance.
+
+    Both cases are reviewer findings against the first version of the fix, which instantiated ripple
+    eagerly in ``from_config`` and left the metadata reading the raw config key.
+    """
+
+    def test_metadata_names_the_library_that_actually_ran(self, tmp_path):
+        """Provenance must say ripple, because ripple is what answered and generated.
+
+        The metadata comment says ``None`` means gwmock-signal's default (LAL) applied. Reading the
+        raw config key would file a ripple run under LAL -- and that field exists precisely because
+        the two libraries produce different strain, so a wrong value is worse than a missing one.
+        """
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        orchestrator = _orchestrator(tmp_path, "batched", waveform_backend=None)
+
+        assert orchestrator._effective_waveform_backend() == "ripple"
+
+    def test_a_per_event_config_still_reports_no_substitution(self, tmp_path):
+        """The substitution is batched-only, so per-event provenance must be unchanged."""
+        orchestrator = _orchestrator(tmp_path, "per-event", waveform_backend=None)
+
+        assert orchestrator._effective_waveform_backend() is None
+
+    def test_an_explicit_backend_is_reported_as_configured(self, tmp_path):
+        """A named backend is not a substitution and must be reported as the config wrote it."""
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        orchestrator = _orchestrator(tmp_path, "batched", waveform_backend="ripple")
+
+        assert orchestrator._effective_waveform_backend() == "ripple"
+
+    def test_construction_survives_without_the_jax_extra(self, tmp_path, monkeypatch):
+        """A batched orchestrator must still *construct* when ripple is not installed.
+
+        The first version of this fix instantiated ripple eagerly, so config validation, stubbed
+        placement and every test passing ``waveform_backend=None`` began failing with "rippleGW is
+        not installed" -- and a genuine configuration error would surface as that message instead of
+        its own. Falling back is safe here and only here: without ripple the batched path cannot
+        generate at all, so no placement answer it might get wrong is ever acted on.
+        """
+        from gwmock.cli import adapter_orchestration as module
+
+        real = module.instantiate_backend
+
+        def _no_ripple(kind, name, *args, **kwargs):
+            if kind == "waveform" and name == "ripple":
+                raise ImportError("ripple (rippleGW) is not installed. Run: pip install 'gwmock-signal[jax]'")
+            return real(kind, name, *args, **kwargs)
+
+        monkeypatch.setattr(module, "instantiate_backend", _no_ripple)
+
+        orchestrator = _orchestrator(tmp_path, "batched", waveform_backend=None)
+
+        assert orchestrator.signal_adapter is not None
+        # And it does not then claim a library it failed to load.
+        assert orchestrator._effective_waveform_backend() is None

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -743,3 +743,40 @@ class TestTheRippleSubstitutionIsHonest:
         assert orchestrator.signal_adapter is not None
         # And it does not then claim a library it failed to load.
         assert orchestrator._effective_waveform_backend() is None
+
+    def test_placement_refuses_rather_than_answering_with_the_wrong_library(self, tmp_path, monkeypatch):
+        """The reproducer a reviewer built against the first version of this fallback.
+
+        Constructing is harmless; *answering* is not. With ripple missing, the LAL-backed adapter
+        reported a 1.4+1.35 event at 5 Hz as finished on its 819.20 s tail, when ripple would have
+        produced 934.17 s and still been contributing to the segment. `_events_for_this_segment`
+        skipped it and advanced `population_index`; `_simulate_batched_segment` then returned early
+        on the empty batch, so generation never ran and the install error never surfaced. The event
+        was consumed, never generated, and nothing was reported -- exactly the outcome my "no ripple
+        means no generation, so nothing acts on a wrong answer" reasoning ruled out.
+        """
+        from gwmock.cli import adapter_orchestration as module
+
+        real = module.instantiate_backend
+
+        def _no_ripple(kind, name, *args, **kwargs):
+            if kind == "waveform" and name == "ripple":
+                raise ImportError("ripple (rippleGW) is not installed.")
+            return real(kind, name, *args, **kwargs)
+
+        monkeypatch.setattr(module, "instantiate_backend", _no_ripple)
+        orchestrator = _orchestrator(tmp_path, "batched", waveform_backend=None, **{"minimum-frequency": 5.0})
+        start = float(getattr(orchestrator.start_time, "value", orchestrator.start_time))
+        _install(orchestrator, [start - 850.0])
+        orchestrator._population_events = [
+            {**_SKIP_EVENT, "detector_frame_mass_1": 1.4, "detector_frame_mass_2": 1.35, "coa_time": start - 850.0}
+        ]
+        orchestrator._placement_order_cache = None
+        orchestrator.population_index = 0
+
+        with pytest.raises(ImportError, match="gwmock-signal\\[jax\\]"):
+            orchestrator._simulate()
+
+        assert int(orchestrator.population_index) == 0, (
+            "the event was consumed by a placement answer the run could not stand behind"
+        )

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -482,3 +482,119 @@ class TestReferenceFrequencyReachesTheBackend:
         )
 
         assert orchestrator._batched_waveform_backend()._f_ref == 25.0
+
+
+#: A complete BBH parameter set, so both the placement query and generation can answer.
+_SKIP_EVENT: dict[str, Any] = {
+    "detector_frame_mass_1": 30.0,
+    "detector_frame_mass_2": 25.0,
+    "distance": 400.0,
+    "right_ascension": 1.0,
+    "declination": 0.5,
+    "polarization_angle": 0.2,
+    "inclination": 0.3,
+}
+
+
+def _install(orchestrator, coa_times: list[float]) -> None:
+    """Replace the catalogue and drop the cached placement order."""
+    orchestrator._population_events = [{**_SKIP_EVENT, "coa_time": t} for t in coa_times]
+    orchestrator._placement_order_cache = None
+    orchestrator.population_index = 0
+
+
+class TestTheBatchedPathActuallySkips:
+    """The lower bound on the path a GPU run takes, with real ripple numbers.
+
+    ``TestCatalogueConsumption`` already asserts the two modes agree on ``population_index`` -- but
+    every event in the bundled catalogue coalesces inside the segment, so it agrees with **zero
+    skips taken**, which is the trivial case. The skip decision itself has been exercised with stubs
+    and with the default LAL adapter; never end to end through ripple, which is what
+    ``execution: batched`` generates with.
+    """
+
+    def test_a_finished_event_is_skipped_and_consumed(self, tmp_path):
+        """Real query, real generation, no substitution."""
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        orchestrator = _orchestrator(tmp_path, "batched")
+        start = float(getattr(orchestrator.start_time, "value", orchestrator.start_time))
+        _install(orchestrator, [start - 900.0, start - 600.0, start + 2.0, start + 6.0])
+
+        event_ids, events = orchestrator._events_for_this_segment()
+
+        assert len(events) == 2, f"batched {len(events)} events for a segment containing 2"
+        assert sorted(event_ids) == [2, 3]
+
+    def test_both_modes_agree_when_skips_are_actually_taken(self, tmp_path):
+        """The agreement the existing test cannot show, because it never skips anything.
+
+        ``population_index`` is checkpointed, so a run switched between modes must not lose or
+        repeat an event -- and the interesting case is precisely the one where the two paths each
+        have to step over the same finished events.
+        """
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        start = _START
+        catalogue = [start - 900.0, start - 600.0, start + 2.0, start + 6.0]
+
+        per_event = _orchestrator(tmp_path / "per", "per-event")
+        batched = _orchestrator(tmp_path / "bat", "batched")
+        _install(per_event, catalogue)
+        _install(batched, catalogue)
+
+        per_event._simulate()
+        batched._simulate()
+
+        assert int(batched.population_index) == int(per_event.population_index)
+        # The index alone cannot see this. A walk that stopped skipping would *generate* the
+        # finished events instead of stepping over them and still arrive at 4, so agreement on the
+        # index is satisfied by both the fixed and the broken path -- a mutation proved exactly that.
+        # What separates them is how many events each one actually produced.
+        assert len(batched._batch_injections) == 2, (
+            f"the batched path generated {len(batched._batch_injections)} events; the finished ones "
+            "were not skipped, so this test is not covering what it exists for"
+        )
+        assert len(per_event._batch_injections) == 2, (
+            f"the per-event path generated {len(per_event._batch_injections)} events; it agreed on "
+            "the index while doing different work"
+        )
+        assert int(batched.population_index) == 4
+
+
+class TestTheQueryAndGenerationCanDisagreeAboutTheBackend:
+    """A batched config with no ``waveform-backend`` asks LAL where a ripple buffer ends.
+
+    The batched path always generates with ripple; the adapter answering the placement query uses
+    the configured backend, which defaults to LAL. So in that configuration the tail that decides
+    whether an event is skipped describes a *different library's* buffer than the one produced.
+
+    Today that is safe only because LAL's buffer is the longer of the two, so the query overstates
+    the tail and the run errs toward claiming -- wasted work rather than deleted signal. Safe by
+    asymmetry, not by design, and nothing checked it. This is the check: if a change ever makes
+    ripple's tail the longer one, an event could be skipped while ripple is still producing it.
+    """
+
+    def test_the_answering_backend_never_understates_the_generating_one(self, tmp_path):
+        """The direction of the mismatch, which is the whole safety argument."""
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        from gwmock_signal.waveform.backends.ripple import RippleBackend
+
+        orchestrator = _orchestrator(tmp_path, "batched", waveform_backend=None)
+        answered = orchestrator._post_coalescence_duration({**_SKIP_EVENT, "coa_time": _START + 4.0})
+
+        ripple = RippleBackend()
+        generated = ripple.post_coalescence_duration(
+            "IMRPhenomD",
+            _SAMPLING_FREQUENCY,
+            30.0,
+            mass1=_SKIP_EVENT["detector_frame_mass_1"],
+            mass2=_SKIP_EVENT["detector_frame_mass_2"],
+            distance=_SKIP_EVENT["distance"],
+            inclination=_SKIP_EVENT["inclination"],
+        )
+
+        assert answered is not None
+        assert generated is not None
+        assert answered >= generated, (
+            f"the query answers {answered} s but ripple generates {generated} s of tail: an event "
+            "could be skipped while ripple is still producing it"
+        )

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -765,7 +765,7 @@ class TestTheRippleSubstitutionIsHonest:
             "provenance still claims the library the replaced adapter was built on"
         )
 
-    def test_placement_refuses_rather_than_answering_with_the_wrong_library(self, tmp_path, monkeypatch):
+    def test_nothing_is_skipped_on_an_answer_the_run_cannot_stand_behind(self, tmp_path, monkeypatch):
         """The reproducer a reviewer built against the first version of this fallback.
 
         Constructing is harmless; *answering* is not. With ripple missing, the LAL-backed adapter
@@ -795,9 +795,20 @@ class TestTheRippleSubstitutionIsHonest:
         orchestrator._placement_order_cache = None
         orchestrator.population_index = 0
 
-        with pytest.raises(ImportError, match="gwmock-signal\\[jax\\]"):
-            orchestrator._simulate()
+        # Nothing may be skipped on an answer this run cannot stand behind, so the tail reports
+        # unknown and the event is claimed. The batch is then non-empty, and on a machine without
+        # ripple generation raises the install error -- loudly, where it belongs, instead of an
+        # empty batch quietly completing and checkpointing the events as done.
+        #
+        # The generation half is deliberately not asserted here: this test forces the *construction*
+        # import to fail, so on a machine that has ripple -- which is where the suite runs --
+        # generation succeeds and consumes the event legitimately. Asserting a raise would pass only
+        # where ripple is absent and mislead everywhere else.
+        event = orchestrator._population_events[0]
 
-        assert int(orchestrator.population_index) == 0, (
-            "the event was consumed by a placement answer the run could not stand behind"
+        assert orchestrator._post_coalescence_duration(event) is None, (
+            "the tail was answered by a library that is not the one this run generates with"
+        )
+        assert not orchestrator._event_ended_before_segment_start(event), (
+            "the event was skipped on a tail the run could not stand behind"
         )

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -560,41 +560,72 @@ class TestTheBatchedPathActuallySkips:
         assert int(batched.population_index) == 4
 
 
-class TestTheQueryAndGenerationCanDisagreeAboutTheBackend:
-    """A batched config with no ``waveform-backend`` asks LAL where a ripple buffer ends.
+class TestTheQueryAnswersForTheBackendThatGenerates:
+    """A batched run must not ask one library where another library's buffer ends.
 
-    The batched path always generates with ripple; the adapter answering the placement query uses
-    the configured backend, which defaults to LAL. So in that configuration the tail that decides
-    whether an event is skipped describes a *different library's* buffer than the one produced.
+    ``execution: batched`` always generates with ripple. The adapter answering the placement query
+    used to default to LAL, so the tail deciding whether an event was finished described a different
+    library's buffer -- and the two round buffer lengths onto different grids, so which is longer
+    flips with mass and cutoff.
 
-    Today that is safe only because LAL's buffer is the longer of the two, so the query overstates
-    the tail and the run errs toward claiming -- wasted work rather than deleted signal. Safe by
-    asymmetry, not by design, and nothing checked it. This is the check: if a change ever makes
-    ripple's tail the longer one, an event could be skipped while ripple is still producing it.
+    That was not a hypothetical. Measured across 24 mass/cutoff combinations before the fix, **9 had
+    ripple's tail longer than LAL's**: 1.4+1.35 at 5 Hz answered 819.20 s against a generated
+    934.17 s, so an event with up to 115 s of content inside the segment was reported finished and
+    skipped. Low masses and low cutoffs are the Einstein Telescope regime. Two reviewers found this
+    independently, from a test that had pinned a single safe point (30+25 at 30 Hz) as though the
+    asymmetry were an invariant.
     """
 
-    def test_the_answering_backend_never_understates_the_generating_one(self, tmp_path):
-        """The direction of the mismatch, which is the whole safety argument."""
+    @pytest.mark.parametrize(
+        ("mass_1", "mass_2", "minimum_frequency"),
+        [
+            (30.0, 25.0, 30.0),  # was safe before the fix
+            (1.4, 1.35, 30.0),  # reversed: 6.4004 answered against 8.4375 generated
+            (1.4, 1.35, 5.0),  # reversed worst: 819.20 against 934.17
+            (4.5, 3.0, 30.0),  # reversed: 1.5996 against 1.8750
+            (3.0, 3.0, 5.0),  # reversed: 204.80 against 256.00
+            (30.0, 25.0, 20.0),  # reversed narrowly: 0.4004 against 0.4502
+        ],
+    )
+    def test_the_answering_tail_is_the_generated_one(self, tmp_path, mass_1, mass_2, minimum_frequency):
+        """Equality, not an inequality: the query and generation must describe one buffer.
+
+        The previous version of this test asserted ``answered >= generated`` -- an inequality that
+        holds at some parameters and not others, so it enshrined a coin-flip of rounding as a safety
+        property. With the adapter built on the generating backend there is nothing to compare
+        conservatively: the two are the same number.
+        """
         pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
         from gwmock_signal.waveform.backends.ripple import RippleBackend
 
-        orchestrator = _orchestrator(tmp_path, "batched", waveform_backend=None)
-        answered = orchestrator._post_coalescence_duration({**_SKIP_EVENT, "coa_time": _START + 4.0})
+        orchestrator = _orchestrator(
+            tmp_path / f"{mass_1}_{mass_2}_{minimum_frequency}",
+            "batched",
+            waveform_backend=None,
+            **{"minimum-frequency": minimum_frequency},
+        )
+        parameters = {
+            **_SKIP_EVENT,
+            "detector_frame_mass_1": mass_1,
+            "detector_frame_mass_2": mass_2,
+            "coa_time": _START + 4.0,
+        }
 
-        ripple = RippleBackend()
-        generated = ripple.post_coalescence_duration(
+        answered = orchestrator._post_coalescence_duration(parameters)
+        generated = RippleBackend().post_coalescence_duration(
             "IMRPhenomD",
             _SAMPLING_FREQUENCY,
-            30.0,
-            mass1=_SKIP_EVENT["detector_frame_mass_1"],
-            mass2=_SKIP_EVENT["detector_frame_mass_2"],
+            minimum_frequency,
+            mass1=mass_1,
+            mass2=mass_2,
             distance=_SKIP_EVENT["distance"],
             inclination=_SKIP_EVENT["inclination"],
         )
 
         assert answered is not None
         assert generated is not None
-        assert answered >= generated, (
-            f"the query answers {answered} s but ripple generates {generated} s of tail: an event "
-            "could be skipped while ripple is still producing it"
+        assert answered == pytest.approx(generated, abs=0.5 / _SAMPLING_FREQUENCY), (
+            f"the placement query answers {answered} s while ripple generates {generated} s; an "
+            f"event whose content reaches {generated - answered} s further than the query admits "
+            "can be skipped while it is still contributing to the segment"
         )

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -631,6 +631,61 @@ class TestTheQueryAnswersForTheBackendThatGenerates:
         )
 
 
+class TestTheLeadIsAlignedToo:
+    """The lead moved as well, and that is what actually relocates boundary events.
+
+    A reviewer found this after the tail fix: the adapter answers both queries, so aligning it to
+    ripple changed ``pre_coalescence_duration`` too -- and the lead drives ``_placement_key`` and the
+    upper bound. LAL and ripple disagree there as well (30+25 at 30 Hz: 3.60 s against 2.81 s), so an
+    event at ``end + 3.0`` was claimed by this segment before the fix and belongs to the next one
+    after it.
+
+    That is the same defect as the tail, on the other side: the query described a buffer a different
+    library would produce. It is a real behaviour change, it moves boundary events for configs where
+    the tail direction was already safe, and the tail sweep does not see it.
+    """
+
+    @pytest.mark.parametrize(
+        ("mass_1", "mass_2", "minimum_frequency"),
+        [(30.0, 25.0, 30.0), (1.4, 1.35, 5.0), (4.5, 3.0, 30.0)],
+    )
+    def test_the_answering_lead_is_the_generated_one(self, tmp_path, mass_1, mass_2, minimum_frequency):
+        """Equality against the generating backend, exactly as for the tail."""
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        from gwmock_signal.waveform.backends.ripple import RippleBackend
+
+        orchestrator = _orchestrator(
+            tmp_path / f"lead_{mass_1}_{minimum_frequency}",
+            "batched",
+            waveform_backend=None,
+            **{"minimum-frequency": minimum_frequency},
+        )
+        parameters = {
+            **_SKIP_EVENT,
+            "detector_frame_mass_1": mass_1,
+            "detector_frame_mass_2": mass_2,
+            "coa_time": _START + 4.0,
+        }
+
+        answered = orchestrator._pre_coalescence_duration(parameters)
+        generated = RippleBackend().pre_coalescence_duration(
+            "IMRPhenomD",
+            _SAMPLING_FREQUENCY,
+            minimum_frequency,
+            mass1=mass_1,
+            mass2=mass_2,
+            distance=_SKIP_EVENT["distance"],
+            inclination=_SKIP_EVENT["inclination"],
+        )
+
+        assert answered is not None
+        assert generated is not None
+        assert answered == pytest.approx(generated, abs=0.5 / _SAMPLING_FREQUENCY), (
+            f"the placement query answers a {answered} s lead while ripple generates {generated} s; "
+            "the segment an event is claimed by is decided from a different library's buffer"
+        )
+
+
 class TestTheRippleSubstitutionIsHonest:
     """Substituting ripple for a batched config must not break construction or lie in provenance.
 

--- a/tests/cli/test_device_execution.py
+++ b/tests/cli/test_device_execution.py
@@ -744,6 +744,27 @@ class TestTheRippleSubstitutionIsHonest:
         # And it does not then claim a library it failed to load.
         assert orchestrator._effective_waveform_backend() is None
 
+    def test_replacing_the_adapter_stops_the_substitution_claim(self, tmp_path):
+        """The record describes the adapter `from_config` built, so a swap must invalidate it.
+
+        A reviewer found the value surviving the replacement: provenance kept reporting ripple while
+        a LAL-backed stand-in answered every placement query. Tests substitute adapters routinely, so
+        this is the common path, not an exotic one. Clearing on assignment makes the record describe
+        nothing rather than describe the wrong thing.
+        """
+        pytest.importorskip("ripplegw", reason="the [jax] extra is not installed")
+        orchestrator = _orchestrator(tmp_path, "batched", waveform_backend=None)
+        assert orchestrator._effective_waveform_backend() == "ripple"
+
+        class _StandIn:
+            detector_names = ("E1",)
+
+        orchestrator.signal_adapter = _StandIn()
+
+        assert orchestrator._effective_waveform_backend() is None, (
+            "provenance still claims the library the replaced adapter was built on"
+        )
+
     def test_placement_refuses_rather_than_answering_with_the_wrong_library(self, tmp_path, monkeypatch):
         """The reproducer a reviewer built against the first version of this fallback.
 

--- a/tests/cli/test_events_ending_before_the_segment.py
+++ b/tests/cli/test_events_ending_before_the_segment.py
@@ -293,7 +293,13 @@ class TestTheRealAdapterAnswers:
         Closes the last gap between "the adapter has the method" and "the orchestrator calls it":
         the two are wired by name, and a rename on either side would leave both tests above
         passing.
+
+        Needs ripple, and that is the point rather than an inconvenience: this fixture is a *batched*
+        config, and a batched run whose generating library is missing now answers the tail as
+        unknown on purpose, so that nothing is skipped on a number describing a different library's
+        buffer. Without the extra there is no answer to reach.
         """
+        pytest.importorskip("ripplegw", reason="a batched run cannot answer the tail without it")
         orchestrator = _orchestrator(tmp_path)
 
         tail = orchestrator._post_coalescence_duration({**_COMPLETE_EVENT, "coa_time": _START + 4.0})


### PR DESCRIPTION
## 📝 Summary

`execution: batched` always generates with ripple, but a batched config naming no
`waveform-backend` built its adapter on LAL. The placement queries deciding where each waveform
starts and ends therefore described a **different library's buffer** than the one generated.

The two libraries round buffer lengths onto different grids, so which tail is longer flips with
mass and cutoff. Across 24 mass/cutoff combinations, **9 have ripple's tail longer than LAL's**:

| binary | cutoff | LAL answered | ripple generates | content droppable |
| --- | --- | --- | --- | --- |
| 1.4+1.35 | 5 Hz | 819.20 s | 934.17 s | **115.0 s** |
| 3.0+3.0 | 5 Hz | 204.80 s | 256.00 s | **51.2 s** |
| 4.5+3.0 | 10 Hz | 25.60 s | 29.66 s | 4.1 s |
| 1.4+1.35 | 30 Hz | 6.40 s | 8.44 s | 2.0 s |

On those combinations an event whose ripple content reaches into the segment is reported finished
on LAL's shorter answer and skipped, deleting signal — the outcome the unknown-is-not-zero rule in
#332 exists to prevent. Low mass at low cutoff is the ET regime.

### What changed

- **A batched config naming no `waveform-backend` now builds its adapter on ripple**, so placement
  and generation describe one buffer. This aligns `pre_coalescence_duration` as well as
  `post_coalescence_duration`; both had the mismatch.
- **When ripple is not installed the tail reports unknown instead of answering.** Unknown claims the
  event, so nothing is skipped on a number this run cannot stand behind; the batch stays non-empty
  and generation raises ripple's own install error. Answering with the default library could skip
  events, and because the batched path returns early on an empty batch, generation would never run
  and the install error would never surface.
- **Provenance names the library that ran.** A substituted backend is recorded where the
  substitution happens, and the record is cleared when `signal_adapter` is replaced, so it cannot
  outlive the adapter it describes.

### ⚠️ Behaviour change

**Boundary events move** for batched configs naming no `waveform-backend`. LAL and ripple also
disagree on the lead (30+25 at 30 Hz: 3.60 s against 2.81 s), so an event at `end + 3.0` was claimed
by this segment before and belongs to the next one after. The new placement is the correct one, but
a run's segmentation can change. Approved by the maintainer.

The shipped e2e scenario is unaffected — its output is byte-identical before and after, because it
has no event near a boundary.

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

*(Both: it fixes data loss, and it changes which segment claims a boundary event.)*

## 🧪 How Has This Been Tested?

- [x] **Unit Tests:** `uv run pytest` → **1116 passed, 23 skipped**.
- [x] **Equality sweeps rather than a single point:** six mass/cutoff points for the tail and three
      for the lead assert the query equals the generating backend. All six tail points fail with the
      fix reverted, including the one that passed beforehand — equality is stronger than the
      inequality it replaces.
- [x] **The skip is exercised end to end through real ripple**, not a stub, and both execution modes
      are checked to agree *with skips actually taken*.
- [x] **Ten mutations, each killed by the test that owns it**, including one reinstating the
      original defect, one restoring the silent fallback, and one leaking the substitution record
      into provenance.
- [x] **Without the `[jax]` extra:** construction still succeeds, the tail reports unknown, and
      nothing is skipped.
- [x] **e2e compared by content against unmodified `main`:** byte-identical.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature
      works.

**On the unchecked box:** no user-guide entry for the placement change. The pre side has no guide
coverage either, so this matches existing precedent rather than opening a new gap, and it is tracked
separately.

## 📷 Screenshots (if applicable)

No UI. The output this changes is the placement answer, measured against the installed backends
before the fix:

```
 30.0+25.0  f= 30.0  LAL     0.400391  ripple     0.312500  safe=True
 30.0+25.0  f= 20.0  LAL     0.400391  ripple     0.450195  safe=False
 30.0+25.0  f= 10.0  LAL     1.599609  ripple     1.423828  safe=True
 30.0+25.0  f=  5.0  LAL     6.400391  ripple     7.119141  safe=False
 10.0+8.0   f= 30.0  LAL     0.799805  ripple     0.659180  safe=True
 10.0+8.0   f= 20.0  LAL     1.599609  ripple     1.406250  safe=True
 10.0+8.0   f= 10.0  LAL     6.400391  ripple     7.119141  safe=False
 10.0+8.0   f=  5.0  LAL    51.200195  ripple    42.714844  safe=True
  4.5+3.0   f= 30.0  LAL     1.599609  ripple     1.875000  safe=False
  4.5+3.0   f= 20.0  LAL     6.400391  ripple     5.000000  safe=True
  4.5+3.0   f= 10.0  LAL    25.599609  ripple    29.663086  safe=False
  4.5+3.0   f=  5.0  LAL   204.799805  ripple   184.528320  safe=True
  3.0+3.0   f= 30.0  LAL     3.200195  ripple     2.500000  safe=True
  3.0+3.0   f= 20.0  LAL     6.400391  ripple     6.750000  safe=False
  3.0+3.0   f= 10.0  LAL    51.200195  ripple    41.005859  safe=True
  3.0+3.0   f=  5.0  LAL   204.799805  ripple   256.000000  safe=False
  1.4+1.35  f= 30.0  LAL     6.400391  ripple     8.437500  safe=False
  1.4+1.35  f= 20.0  LAL    25.599609  ripple    23.730469  safe=True
  1.4+1.35  f= 10.0  LAL   204.799805  ripple   148.315430  safe=True
  1.4+1.35  f=  5.0  LAL   819.200195  ripple   934.173828  safe=False
 60.0+50.0  f= 30.0  LAL     0.400391  ripple     0.263672  safe=True
 60.0+50.0  f= 20.0  LAL     0.400391  ripple     0.312500  safe=True
 60.0+50.0  f= 10.0  LAL     0.799805  ripple     0.674805  safe=True
 60.0+50.0  f=  5.0  LAL     3.200195  ripple     2.636719  safe=True

UNSAFE combinations: 9 of 24
```

`safe=False` marks a row where the query would report an event finished while ripple is still
producing it. After the fix both columns are the same number by construction, which is what the
equality sweep asserts.
