### PR TITLE
fix(cli): make the signal index's rename durable before its digest describes it

### DIFF
--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -937,8 +937,10 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> _Committ
         is that reading ``index_file`` can be served from a stale client cache, so digesting a re-read
         could record the digest of this client's *stale view* — and a later client with the same stale
         view would then match it and overwrite silently, which is the bug rather than the fix. The
-        flush outcome travels with it because recording that digest is only sound when the name it
-        describes will still be there after a crash.
+        flush outcome travels with it so the caller can *report* a rename whose durability is
+        unverifiable. It is not a gate on recording the digest: an earlier version of this function made
+        it one, and that turned a rare loud failure into a routine silent one -- see the decision comment
+        in :func:`update_signal_index`.
 
     Raises:
         OSError: If the file cannot be written or renamed.
@@ -1137,7 +1139,8 @@ def _fsync_directory(directory: Path) -> _DirectoryFlush:
         directory: Directory whose entries should be flushed.
 
     Returns:
-        Which of the three outcomes occurred.
+        Which of the four outcomes occurred: flushed, unsupported by the platform, refused by the
+        filesystem, or a directory that could not be opened.
     """
     # No `pragma: no cover`. Every branch here is reached by
     # `tests/cli/test_index_directory_durability.py` -- this one by deleting the attribute, the two

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -1000,32 +1000,48 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> _Committ
     return _CommittedIndex(digest, flush)
 
 
-# Devices whose last directory flush was refused, so the warning is not repeated per batch.
+# What is currently known to be degraded, so the warning is not repeated per batch. Entries are
+# `(scope, key)`: a device number for a filesystem that refuses the flush, a directory for one that
+# cannot be opened. Both are cleared when a flush there succeeds, so an episode that ends and returns
+# is reported again -- a permanent cache went silent after the first episode of an intermittent mount.
 #
-# Keyed by `st_dev` and not by the index's path, which was wrong three ways. Refusing to flush is a
-# property of the *filesystem*: keying by path warned once per metadata directory, so a run over twenty
-# of them on one refusing mount emitted twenty copies of a multi-line warning and retained twenty cache
-# entries forever -- the module's only unbounded cache. Two spellings of one directory (a relative path
-# resolved from different working directories) both collided and duplicated, in either direction. And a
-# device set that is *cleared on success* lets a mount that recovers and degrades again warn a second
-# time, which a permanent cache cannot: an intermittent mount went silent after its first episode.
-_DEGRADED_MOUNTS: set[int | None] = set()
+# The two scopes exist because the two faults have different extents and different repairs. An fsync
+# the filesystem rejects is a property of the mount, so keying it per index warned once per metadata
+# directory: a run over twenty of them emitted twenty copies of a multi-line warning and kept twenty
+# entries for the life of the process. A directory that cannot be *opened* is a property of that
+# directory's permissions, and keying it by device hid the second such directory on a filesystem
+# entirely -- its own repair never shown. Path spelling is not a key in either case: a relative path
+# resolved from two working directories used to warn once for two filesystems, and one directory
+# reached by two spellings used to warn twice.
+#
+# `st_dev` is the best filesystem identity `os.stat` offers, and it is not perfect: Linux allocates
+# device numbers for NFS, tmpfs, FUSE and overlay from a pool and reuses them after unmount, so a
+# still-degraded number inherited by a new mount suppresses that mount's first warning. The mount id
+# that would distinguish them (`STATX_MNT_ID`) is not exposed through `os.stat`, and clearing on
+# success already covers the case where the new mount works. Accepted, and recorded here rather than
+# left for the next reader to rediscover.
+#
+# Not synchronised. Every production caller holds the index's `flock`, the writer is a sequential
+# batch loop, and the resource-monitor thread never touches it; the check-then-add is formally racy
+# but a 64-thread stress probe produced exactly one warning, and the worst case is a duplicated or
+# missing *warning*, never a correctness path.
+_DEGRADED_TARGETS: set[tuple[str, object]] = set()
 
 
 def _note_flush_outcome(directory: Path, flush: _DirectoryFlush, index_file: Path, sidecar_name: str) -> None:
-    """Warn on entering a refused-flush episode, once per filesystem rather than once per batch.
+    """Warn on entering a degraded episode, once per affected scope rather than once per batch.
 
-    At ``WARNING`` deliberately. The CLI logs at ``INFO`` by default, so the ``logger.debug`` line
-    inside :func:`_fsync_directory` produces nothing an operator sees, and a degradation with no signal
+    At ``WARNING`` deliberately. The CLI logs at ``INFO`` by default, so the ``logger.debug`` lines
+    inside :func:`_fsync_directory` produce nothing an operator sees, and a degradation with no signal
     is indistinguishable from a guarantee. Once per *episode* per process: a scheduler invoking gwmock
-    repeatedly on a refusing mount is told every time, which is the right way round for a condition an
-    operator can act on.
+    repeatedly against a degraded mount is told every time, which is the right way round for a condition
+    an operator can act on.
 
     ``UNSUPPORTED`` says nothing. It is a permanent property of the platform rather than a fault, and a
     warning on every run about a gap nobody can close is how the ones that can be acted on get ignored.
 
     Args:
-        directory: The directory whose flush was attempted; identified by device.
+        directory: The directory whose flush was attempted.
         flush: What :func:`_fsync_directory` managed.
         index_file: The index whose rename could not be made durable.
         sidecar_name: File name of the sidecar recording its digest.
@@ -1033,29 +1049,47 @@ def _note_flush_outcome(directory: Path, flush: _DirectoryFlush, index_file: Pat
     if flush is _DirectoryFlush.UNSUPPORTED:
         return
     try:
-        device: int | None = directory.stat().st_dev
+        device: object = directory.stat().st_dev
     except OSError:
         # Unidentifiable is its own key rather than a reason to skip: losing the device number must not
         # lose the warning.
         device = None
     if flush is _DirectoryFlush.FLUSHED:
-        _DEGRADED_MOUNTS.discard(device)
+        # Both scopes clear: whichever fault was recorded for this directory, a flush that succeeds here
+        # ends its episode.
+        _DEGRADED_TARGETS.discard(("filesystem", device))
+        _DEGRADED_TARGETS.discard(("directory", str(directory)))
         return
-    if device in _DEGRADED_MOUNTS:
+    if flush is _DirectoryFlush.UNREADABLE:
+        target = ("directory", str(directory))
+        message = (
+            "%s could not be opened to flush its entries, so the rename that installed this update is "
+            "not known to have reached stable storage. The index and its digest are correct and "
+            "complete, and the staleness guard is intact. This is a property of this directory rather "
+            "than of the filesystem -- most often its permissions: flushing needs to open it for "
+            "reading, which a write-only directory refuses. What is not covered: a crash before the "
+            "directory entry reaches the disk can reboot to the previous index while %s describes this "
+            "one, and every later write then refuses as stale against a good file -- repaired by "
+            "stopping the writers and deleting that sidecar, which holds only the digest and the lock. "
+            "Warned once per directory while the condition lasts, and again if it clears and returns."
+        )
+    else:
+        target = ("filesystem", device)
+        message = (
+            "The filesystem holding %s refused to flush the directory, so the rename that installed "
+            "this update is not known to have reached stable storage. The index and its digest are "
+            "correct and complete, and the staleness guard is intact. What is not covered: a crash "
+            "before the directory entry reaches the disk can reboot to the previous index while %s "
+            "describes this one, and every later write then refuses as stale against a good file -- "
+            "repaired by stopping the writers and deleting that sidecar, which holds only the digest "
+            "and the lock. On a network mount that window lasts until the client sends the rename, "
+            "which is seconds rather than instants. Warned once per filesystem while the condition "
+            "lasts, and again if it clears and returns."
+        )
+    if target in _DEGRADED_TARGETS:
         return
-    _DEGRADED_MOUNTS.add(device)
-    logger.warning(
-        "The filesystem holding %s refused to flush the directory, so the rename that installed this "
-        "update is not known to have reached stable storage. The index and its digest are correct and "
-        "complete, and the staleness guard is intact. What is not covered: a crash before the directory "
-        "entry reaches the disk can reboot to the previous index while %s describes this one, and every "
-        "later write then refuses as stale against a good file -- repaired by stopping the writers and "
-        "deleting that sidecar, which holds only the digest and the lock. On a network mount that window "
-        "lasts until the client sends the rename, which is seconds rather than instants. Warned once per "
-        "filesystem while the condition lasts, and again if it clears and returns.",
-        index_file,
-        sidecar_name,
-    )
+    _DEGRADED_TARGETS.add(target)
+    logger.warning(message, index_file, sidecar_name)
 
 
 class _DirectoryFlush(Enum):
@@ -1068,7 +1102,10 @@ class _DirectoryFlush(Enum):
     """This platform offers no way to flush a directory here. Durability is unverifiable."""
 
     REFUSED = "refused"
-    """The filesystem rejected the flush. Durability is unverifiable *and* unexpected."""
+    """The filesystem rejected the flush itself. Unverifiable, unexpected, and true of the whole mount."""
+
+    UNREADABLE = "unreadable"
+    """This directory could not be opened to flush it. Its own problem, not the filesystem's."""
 
 
 def _fsync_directory(directory: Path) -> _DirectoryFlush:
@@ -1103,7 +1140,7 @@ def _fsync_directory(directory: Path) -> _DirectoryFlush:
         descriptor = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
     except OSError as error:
         logger.debug("Could not open %s to flush its entries: %s", directory, error)
-        return _DirectoryFlush.REFUSED
+        return _DirectoryFlush.UNREADABLE
     try:
         os.fsync(descriptor)
     except OSError as error:

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -973,10 +973,51 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> str:
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temporary, index_file)
+        # The rename itself has to reach the disk before the digest describing it does. `os.replace`
+        # is atomic with respect to readers, which is what the comment above is about, but atomicity
+        # is not durability: the directory entry can still be in the page cache when
+        # `_record_digest` writes the sidecar. A crash in that window leaves the *old* index with the
+        # *new* digest, and every later write then refuses as stale against a perfectly good file --
+        # loud and recoverable by deleting the sidecar, never a silent blessing of wrong bytes, but
+        # it needs an operator.
+        _fsync_directory(index_file.parent)
     except BaseException:
         temporary.unlink(missing_ok=True)
         raise
     return digest
+
+
+def _fsync_directory(directory: Path) -> None:
+    """Flush *directory*'s entries, so a rename inside it survives a crash. Best effort.
+
+    POSIX only, and deliberately not emulated elsewhere. Windows cannot open a directory with
+    ``os.open``, and the equivalent there would be a ``FlushFileBuffers`` call through ``ctypes`` on a
+    handle obtained with ``CreateFileW`` -- code no host in this project can execute. A reviewer
+    proposed exactly that; it is left out, because untested platform code that looks like protection
+    is worse than a documented gap. NTFS journals metadata, so the exposure there is smaller in any
+    case.
+
+    Swallows ``OSError`` rather than failing the write. The index is already committed by the time
+    this runs, so raising here would turn a successful update into an error and leave the caller
+    unable to tell that its data landed. A filesystem that refuses the fsync -- some network mounts do
+    -- gets the previous durability, which is what it had before this existed.
+
+    Args:
+        directory: Directory whose entries should be flushed.
+    """
+    if not hasattr(os, "O_DIRECTORY"):  # pragma: no cover - POSIX-only attribute
+        return
+    try:
+        descriptor = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
+    except OSError as error:  # pragma: no cover - depends on the filesystem
+        logger.debug("Could not open %s to flush its entries: %s", directory, error)
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError as error:  # pragma: no cover - depends on the filesystem
+        logger.debug("Could not flush the entries of %s: %s", directory, error)
+    finally:
+        os.close(descriptor)
 
 
 def _existing_index_mode(index_file: Path) -> int | None:

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -21,11 +21,12 @@ import time
 import uuid
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from enum import Enum
 from functools import cache
 from importlib import import_module
 from importlib import metadata as importlib_metadata
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 import numpy as np
 import yaml
@@ -851,6 +852,23 @@ def _recorded_digest(lock_file: Path) -> str | None:
     return recorded or None
 
 
+def _clear_digest(lock_file: Path) -> None:
+    """Erase the sidecar's digest, returning the directory to the permissive legacy path.
+
+    For the one case where neither keeping nor advancing the digest is crash-safe: the index is
+    installed, but the durability of its name is unknown. An empty sidecar is the only state
+    :func:`_require_fresh_index_read` accepts whichever index a crash leaves behind.
+
+    Failing to clear it is raised, not swallowed, for the same reason failing to record is: the
+    sidecar would keep a digest describing the index this update replaced, which is the permanent
+    wedge with none of the warning.
+
+    Args:
+        lock_file: The sidecar beside the index.
+    """
+    _record_digest(lock_file, "")
+
+
 def _record_digest(lock_file: Path, digest: str) -> None:
     """Write the digest of the index just committed into the sidecar.
 
@@ -904,7 +922,17 @@ def _record_digest(lock_file: Path, digest: str) -> None:
         ) from error
 
 
-def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> str:
+class _CommittedIndex(NamedTuple):
+    """An index that has been installed, and what is known about the durability of its name."""
+
+    digest: str
+    """The sha256 of the bytes committed."""
+
+    directory_flush: _DirectoryFlush
+    """Whether the rename that installed those bytes was made durable."""
+
+
+def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> _CommittedIndex:
     """Write the index so a reader sees either the old file or the new one, never a fragment.
 
     ``open(path, "w")`` truncates in place, so a crash or a full disk part-way through the dump
@@ -921,11 +949,13 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> str:
         index: The index mapping to serialise.
 
     Returns:
-        The sha256 of the bytes committed. Returned rather than re-read afterwards: the whole
-        defect this guards is that reading ``index_file`` can be served from a stale client
-        cache, so digesting a re-read could record the digest of this client's *stale view* — and
-        a later client with the same stale view would then match it and overwrite silently, which
-        is the bug rather than the fix.
+        The sha256 of the bytes committed, and whether the rename that installed them was made
+        durable. The digest is returned rather than re-read afterwards: the whole defect this guards
+        is that reading ``index_file`` can be served from a stale client cache, so digesting a re-read
+        could record the digest of this client's *stale view* — and a later client with the same stale
+        view would then match it and overwrite silently, which is the bug rather than the fix. The
+        flush outcome travels with it because recording that digest is only sound when the name it
+        describes will still be there after a crash.
 
     Raises:
         OSError: If the file cannot be written or renamed.
@@ -980,15 +1010,57 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> str:
         # *new* digest, and every later write then refuses as stale against a perfectly good file --
         # loud and recoverable by deleting the sidecar, never a silent blessing of wrong bytes, but
         # it needs an operator.
-        _fsync_directory(index_file.parent)
+        flush = _fsync_directory(index_file.parent)
     except BaseException:
         temporary.unlink(missing_ok=True)
         raise
-    return digest
+    return _CommittedIndex(digest, flush)
 
 
-def _fsync_directory(directory: Path) -> None:
-    """Flush *directory*'s entries, so a rename inside it survives a crash. Best effort.
+@cache
+def _warn_flush_refused_once(index_file: Path, sidecar_name: str) -> None:
+    """Say once per index that its directory cannot be flushed, so its digest is being withheld.
+
+    Once per *index*, not once per batch. A mount that refuses the flush refuses it every time, and a
+    run writes one batch after another: warning each time is how the message that matters gets
+    filtered out. Cached rather than flagged for the same reason as :func:`_warn_unlocked_once` -- the
+    "warns once" claim is then enforced by the decorator and not by a global nobody re-checks.
+
+    At ``WARNING`` deliberately. The CLI logs at ``INFO`` by default, so the ``logger.debug`` line
+    inside :func:`_fsync_directory` produces nothing an operator sees, and a degradation with no signal
+    is indistinguishable from a guarantee.
+
+    Args:
+        index_file: The index whose rename could not be made durable.
+        sidecar_name: File name of the sidecar whose digest was cleared.
+    """
+    logger.warning(
+        "The filesystem holding %s refused to flush the directory, so this update's name is not known "
+        "to have reached stable storage. Its digest has been cleared from %s rather than recorded: "
+        "recording it would make every later write refuse as stale if the machine crashed now. The "
+        "index itself is correct and complete. These writes are unprotected against a stale read, so "
+        "run them from a single host -- a mount that refuses directory flushes cannot support the "
+        "cross-host guard at all. Warned once per index; the condition persists.",
+        index_file,
+        sidecar_name,
+    )
+
+
+class _DirectoryFlush(Enum):
+    """Whether a rename was made durable, which decides if its digest may be recorded."""
+
+    FLUSHED = "flushed"
+    """The directory's entries reached stable storage: the digest describes a durable name."""
+
+    UNSUPPORTED = "unsupported"
+    """This platform offers no way to flush a directory here. Durability is unverifiable."""
+
+    REFUSED = "refused"
+    """The filesystem rejected the flush. Durability is unverifiable *and* unexpected."""
+
+
+def _fsync_directory(directory: Path) -> _DirectoryFlush:
+    """Flush *directory*'s entries, so a rename inside it survives a crash.
 
     POSIX only, and deliberately not emulated elsewhere. Windows cannot open a directory with
     ``os.open``, and the equivalent there would be a ``FlushFileBuffers`` call through ``ctypes`` on a
@@ -997,27 +1069,37 @@ def _fsync_directory(directory: Path) -> None:
     is worse than a documented gap. NTFS journals metadata, so the exposure there is smaller in any
     case.
 
-    Swallows ``OSError`` rather than failing the write. The index is already committed by the time
-    this runs, so raising here would turn a successful update into an error and leave the caller
-    unable to tell that its data landed. A filesystem that refuses the fsync -- some network mounts do
-    -- gets the previous durability, which is what it had before this existed.
+    Reports its outcome rather than raising. The index is already committed by the time this runs, so
+    raising would turn a landed update into an error. But the outcome cannot be *dropped* either: the
+    caller records a digest next, and a digest recorded for a rename that never reached the disk is
+    precisely the wedge this function exists to prevent. :func:`update_signal_index` decides what to
+    do with each outcome; the two failures are kept distinct because they warrant different answers.
 
     Args:
         directory: Directory whose entries should be flushed.
+
+    Returns:
+        Which of the three outcomes occurred.
     """
-    if not hasattr(os, "O_DIRECTORY"):  # pragma: no cover - POSIX-only attribute
-        return
+    # No `pragma: no cover`. Every branch here is reached by
+    # `tests/cli/test_index_directory_durability.py` -- this one by deleting the attribute, the two
+    # failures by an unopenable directory and a refusing fsync. A pragma claiming an executed branch
+    # cannot run is how a break in it still reports green, which this file has already paid for once.
+    if not hasattr(os, "O_DIRECTORY"):
+        return _DirectoryFlush.UNSUPPORTED
     try:
         descriptor = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
-    except OSError as error:  # pragma: no cover - depends on the filesystem
+    except OSError as error:
         logger.debug("Could not open %s to flush its entries: %s", directory, error)
-        return
+        return _DirectoryFlush.REFUSED
     try:
         os.fsync(descriptor)
-    except OSError as error:  # pragma: no cover - depends on the filesystem
+    except OSError as error:
         logger.debug("Could not flush the entries of %s: %s", directory, error)
+        return _DirectoryFlush.REFUSED
     finally:
         os.close(descriptor)
+    return _DirectoryFlush.FLUSHED
 
 
 def _existing_index_mode(index_file: Path) -> int | None:
@@ -1110,7 +1192,26 @@ def update_signal_index(
             return
         _require_fresh_index_read(index_file, lock_file)
         committed = _update_signal_index_locked(index_file, injections, metadata, metadata_file_name, encoding)
-        _record_digest(lock_file, committed)
+        if committed.directory_flush is _DirectoryFlush.REFUSED:
+            # The index is installed but its *name* may not survive a crash, so recording this digest
+            # would risk the exact wedge the digest exists to prevent: reboot serves the old index
+            # under the new digest and every later write refuses as stale against a good file.
+            #
+            # Not recording is not enough, and that is the trap. Leaving the sidecar's *previous*
+            # digest in place describes the old index while the new one is installed -- a mismatch in
+            # the other direction, wedged the same way. Only three states are crash-safe to leave
+            # behind, and of the three -- old digest, new digest, no digest -- `_require_fresh_index_read`
+            # accepts just the last. So the digest is cleared: one write loses the staleness guard
+            # (warned about, per write) instead of the directory wedging permanently.
+            _clear_digest(lock_file)
+            _warn_flush_refused_once(index_file, lock_file.name)
+        else:
+            # `UNSUPPORTED` records too, deliberately. A platform with no directory-flush primitive
+            # can never satisfy the check, so clearing on it would disable the cross-host guard on
+            # every write there for good -- a certain loss against the uncertain one of a crash in a
+            # sub-millisecond window, the same trade the legacy-digest acceptance above makes. The
+            # gap is real and documented on `_fsync_directory`, not silently papered over.
+            _record_digest(lock_file, committed.digest)
 
 
 def _require_fresh_index_read(index_file: Path, lock_file: Path) -> None:
@@ -1181,7 +1282,7 @@ def _update_signal_index_locked(
     metadata: dict[str, Any],
     metadata_file_name: str,
     encoding: str,
-) -> str:
+) -> _CommittedIndex:
     """Do the read-modify-write, with the caller holding the index lock.
 
     Split out so the critical section is a single named span: the read, the withdrawal and the
@@ -1194,6 +1295,10 @@ def _update_signal_index_locked(
         metadata: The batch metadata record just written.
         metadata_file_name: File name of that batch metadata record.
         encoding: File encoding for reading the index file.
+
+    Returns:
+        The committed index's digest and the durability of the rename that installed it, for the
+        caller to turn into a recorded digest or a cleared one.
     """
     if index_file.exists():
         try:

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -1000,31 +1000,59 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> _Committ
     return _CommittedIndex(digest, flush)
 
 
-@cache
-def _warn_flush_refused_once(index_file: Path, sidecar_name: str) -> None:
-    """Say once per index that its directory cannot be flushed, so its updates are not durable.
+# Devices whose last directory flush was refused, so the warning is not repeated per batch.
+#
+# Keyed by `st_dev` and not by the index's path, which was wrong three ways. Refusing to flush is a
+# property of the *filesystem*: keying by path warned once per metadata directory, so a run over twenty
+# of them on one refusing mount emitted twenty copies of a multi-line warning and retained twenty cache
+# entries forever -- the module's only unbounded cache. Two spellings of one directory (a relative path
+# resolved from different working directories) both collided and duplicated, in either direction. And a
+# device set that is *cleared on success* lets a mount that recovers and degrades again warn a second
+# time, which a permanent cache cannot: an intermittent mount went silent after its first episode.
+_DEGRADED_MOUNTS: set[int | None] = set()
 
-    Once per *index*, not once per batch. A mount that refuses the flush refuses it every time, and a
-    run writes one batch after another: warning each time is how the message that matters gets
-    filtered out. Cached rather than flagged for the same reason as :func:`_warn_unlocked_once` -- the
-    "warns once" claim is then enforced by the decorator and not by a global nobody re-checks.
+
+def _note_flush_outcome(directory: Path, flush: _DirectoryFlush, index_file: Path, sidecar_name: str) -> None:
+    """Warn on entering a refused-flush episode, once per filesystem rather than once per batch.
 
     At ``WARNING`` deliberately. The CLI logs at ``INFO`` by default, so the ``logger.debug`` line
     inside :func:`_fsync_directory` produces nothing an operator sees, and a degradation with no signal
-    is indistinguishable from a guarantee.
+    is indistinguishable from a guarantee. Once per *episode* per process: a scheduler invoking gwmock
+    repeatedly on a refusing mount is told every time, which is the right way round for a condition an
+    operator can act on.
+
+    ``UNSUPPORTED`` says nothing. It is a permanent property of the platform rather than a fault, and a
+    warning on every run about a gap nobody can close is how the ones that can be acted on get ignored.
 
     Args:
+        directory: The directory whose flush was attempted; identified by device.
+        flush: What :func:`_fsync_directory` managed.
         index_file: The index whose rename could not be made durable.
         sidecar_name: File name of the sidecar recording its digest.
     """
+    if flush is _DirectoryFlush.UNSUPPORTED:
+        return
+    try:
+        device: int | None = directory.stat().st_dev
+    except OSError:
+        # Unidentifiable is its own key rather than a reason to skip: losing the device number must not
+        # lose the warning.
+        device = None
+    if flush is _DirectoryFlush.FLUSHED:
+        _DEGRADED_MOUNTS.discard(device)
+        return
+    if device in _DEGRADED_MOUNTS:
+        return
+    _DEGRADED_MOUNTS.add(device)
     logger.warning(
         "The filesystem holding %s refused to flush the directory, so the rename that installed this "
         "update is not known to have reached stable storage. The index and its digest are correct and "
-        "complete, and the staleness guard is intact. What is not covered: if the machine loses power "
-        "in the window before the directory entry reaches the disk, the reboot can serve the previous "
-        "index while %s records this one, and every later write then refuses as stale against a good "
-        "file -- repaired by stopping the writers and deleting that sidecar, which holds only the "
-        "digest and the lock. Warned once per index; the condition persists for every batch.",
+        "complete, and the staleness guard is intact. What is not covered: a crash before the directory "
+        "entry reaches the disk can reboot to the previous index while %s describes this one, and every "
+        "later write then refuses as stale against a good file -- repaired by stopping the writers and "
+        "deleting that sidecar, which holds only the digest and the lock. On a network mount that window "
+        "lasts until the client sends the rename, which is seconds rather than instants. Warned once per "
+        "filesystem while the condition lasts, and again if it clears and returns.",
         index_file,
         sidecar_name,
     )
@@ -1187,18 +1215,20 @@ def update_signal_index(
         #   - The next batch would then warn "predates the staleness guard", which is a lie about an
         #     index written seconds earlier, and it fires per batch.
         #   - Withholding cannot even deliver its own invariant: the clear happens after the rename, so
-        #     a crash between them leaves the old digest describing the new index -- the same wedge.
+        #     a crash between them leaves the sidecar's old digest against a possibly-new index, which
+        #     refuses exactly as the state it was trying to avoid does.
         #
-        # So the guard is kept and the durability gap is carried instead. If a crash does land in the
-        # window, the outcome is a refusal against a good index: loud, and recoverable by deleting the
-        # sidecar. A rare loud failure is the right thing to keep over a routine silent one.
+        # So the guard is kept and the durability gap is carried instead. A crash in that window leaves
+        # the index and the sidecar disagreeing in one direction or the other, and either way the next
+        # write refuses -- loud, and repaired by deleting the sidecar.
+        #
+        # Not "a rare window", which is what this comment claimed until a reviewer measured the class of
+        # mount involved: an NFS client holds the rename until it sends the RPC, so on the filesystems
+        # that refuse the flush the exposure is seconds rather than instants. The trade stands anyway --
+        # a loud recoverable failure beats a silent one whatever its probability -- but it does not rest
+        # on the window being small.
         _record_digest(lock_file, committed.digest)
-        if committed.directory_flush is _DirectoryFlush.REFUSED:
-            # `REFUSED` is unexpected and per-filesystem, so it warns. `UNSUPPORTED` does not: it is a
-            # permanent property of the platform, and a warning on every run about a gap the operator
-            # cannot close is how the warnings that matter get filtered out. Documented on
-            # `_fsync_directory` instead.
-            _warn_flush_refused_once(index_file, lock_file.name)
+        _note_flush_outcome(index_file.parent, committed.directory_flush, index_file, lock_file.name)
 
 
 def _require_fresh_index_read(index_file: Path, lock_file: Path) -> None:

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -1010,9 +1010,13 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> _Committ
 # directory: a run over twenty of them emitted twenty copies of a multi-line warning and kept twenty
 # entries for the life of the process. A directory that cannot be *opened* is a property of that
 # directory's permissions, and keying it by device hid the second such directory on a filesystem
-# entirely -- its own repair never shown. Path spelling is not a key in either case: a relative path
-# resolved from two working directories used to warn once for two filesystems, and one directory
-# reached by two spellings used to warn twice.
+# entirely -- its own repair never shown. The directory scope keys on the *absolute* path rather than
+# the spelling it was given: one relative path used from two working directories is two different
+# directories, and suppressing the second one's warning is the failure direction that costs an operator
+# a repair. Two spellings of one directory -- through a symlink, or a bind mount -- still warn twice,
+# which is the harmless direction and not worth a `resolve()` that can fail on the directory being
+# reported. Spelling was never a key for the filesystem scope, where it warned once for what were two
+# different mounts.
 #
 # `st_dev` is the best filesystem identity `os.stat` offers, and it is not perfect: Linux allocates
 # device numbers for NFS, tmpfs, FUSE and overlay from a pool and reuses them after unmount, so a
@@ -1058,33 +1062,38 @@ def _note_flush_outcome(directory: Path, flush: _DirectoryFlush, index_file: Pat
         # Both scopes clear: whichever fault was recorded for this directory, a flush that succeeds here
         # ends its episode.
         _DEGRADED_TARGETS.discard(("filesystem", device))
-        _DEGRADED_TARGETS.discard(("directory", str(directory)))
+        _DEGRADED_TARGETS.discard(("directory", os.path.abspath(directory)))
         return
     if flush is _DirectoryFlush.UNREADABLE:
-        target = ("directory", str(directory))
+        target = ("directory", os.path.abspath(directory))
         message = (
             "%s could not be opened to flush its entries, so the rename that installed this update is "
             "not known to have reached stable storage. The index and its digest are correct and "
             "complete, and the staleness guard is intact. This is a property of this directory rather "
             "than of the filesystem -- most often its permissions: flushing needs to open it for "
-            "reading, which a write-only directory refuses. What is not covered: a crash before the "
-            "directory entry reaches the disk can reboot to the previous index while %s describes this "
-            "one, and every later write then refuses as stale against a good file -- repaired by "
-            "stopping the writers and deleting that sidecar, which holds only the digest and the lock. "
-            "Warned once per directory while the condition lasts, and again if it clears and returns."
+            "reading, which a write-only directory refuses. Repair it by making the directory readable "
+            "by the account running gwmock; deleting the sidecar does not help, because the next write "
+            "cannot flush it either. What is not covered until then: a crash before the directory entry "
+            "reaches the disk can reboot to the previous index while %s describes this one, and every "
+            "later write refuses as stale against a good file -- recovered from by stopping the writers "
+            "and deleting that sidecar, which holds only the digest and the lock. Warned once per "
+            "directory while the condition lasts, and again if it clears and returns."
         )
     else:
         target = ("filesystem", device)
         message = (
             "The filesystem holding %s refused to flush the directory, so the rename that installed "
             "this update is not known to have reached stable storage. The index and its digest are "
-            "correct and complete, and the staleness guard is intact. What is not covered: a crash "
-            "before the directory entry reaches the disk can reboot to the previous index while %s "
-            "describes this one, and every later write then refuses as stale against a good file -- "
-            "repaired by stopping the writers and deleting that sidecar, which holds only the digest "
-            "and the lock. On a network mount that window lasts until the client sends the rename, "
-            "which is seconds rather than instants. Warned once per filesystem while the condition "
-            "lasts, and again if it clears and returns."
+            "correct and complete, and the staleness guard is intact. Nothing on this mount repairs "
+            "it -- a filesystem that rejects the call offers no way to make a rename durable -- so the "
+            "choice is to accept the exposure or to put the metadata directory on a filesystem that "
+            "supports the flush. What is not covered meanwhile: a crash before the directory entry "
+            "reaches the disk can reboot to the previous index while %s describes this one, and every "
+            "later write refuses as stale against a good file -- recovered from by stopping the writers "
+            "and deleting that sidecar, which holds only the digest and the lock. On a network mount "
+            "that window lasts until the client sends the rename, which is seconds rather than "
+            "instants. Warned once per filesystem while the condition lasts, and again if it clears "
+            "and returns."
         )
     if target in _DEGRADED_TARGETS:
         return

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -1104,7 +1104,12 @@ def _note_flush_outcome(directory: Path, flush: _DirectoryFlush, index_file: Pat
 
 
 class _DirectoryFlush(Enum):
-    """Whether a rename was made durable, which decides if its digest may be recorded."""
+    """Whether a rename was made durable, and if not, how that is reported.
+
+    Not a gate on recording the digest -- the digest is recorded whatever this says. An earlier version
+    of this branch made it one; see the decision comment in :func:`update_signal_index` for why that was
+    reversed.
+    """
 
     FLUSHED = "flushed"
     """The directory's entries reached stable storage: the digest describes a durable name."""

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -1066,7 +1066,21 @@ def _note_flush_outcome(directory: Path, flush: _DirectoryFlush, index_file: Pat
         _DEGRADED_TARGETS.discard(("filesystem", device))
         _DEGRADED_TARGETS.discard(("directory", os.path.abspath(directory)))
         return
-    if flush is _DirectoryFlush.UNREADABLE:
+    if flush is _DirectoryFlush.UNAVAILABLE:
+        target = ("directory", os.path.abspath(directory))
+        message = (
+            "%s could not be opened to flush its entries, so the rename that installed this update is "
+            "not known to have reached stable storage. The index and its digest are correct and "
+            "complete, and the staleness guard is intact. No repair can be named from here -- the "
+            "causes range from a directory removed under the run to a process out of file descriptors "
+            "-- so the specific error is in the debug log. What is not covered until it is fixed: a "
+            "crash before the directory entry reaches the disk can reboot to the previous index while "
+            "%s describes this one, and every later write refuses as stale against a good file -- "
+            "recovered from by stopping the writers and deleting that sidecar, which holds only the "
+            "digest and the lock. Warned once per directory while the condition lasts, and again if it "
+            "clears and returns."
+        )
+    elif flush is _DirectoryFlush.UNREADABLE:
         target = ("directory", os.path.abspath(directory))
         message = (
             "%s could not be opened to flush its entries, so the rename that installed this update is "
@@ -1121,7 +1135,10 @@ class _DirectoryFlush(Enum):
     """The filesystem rejected the flush itself. Unverifiable, unexpected, and true of the whole mount."""
 
     UNREADABLE = "unreadable"
-    """This directory could not be opened to flush it. Its own problem, not the filesystem's."""
+    """This directory refused to be opened for reading. Its own permissions, and repairable as such."""
+
+    UNAVAILABLE = "unavailable"
+    """This directory could not be opened for some other reason. No repair can be prescribed."""
 
 
 def _fsync_directory(directory: Path) -> _DirectoryFlush:
@@ -1144,8 +1161,9 @@ def _fsync_directory(directory: Path) -> _DirectoryFlush:
         directory: Directory whose entries should be flushed.
 
     Returns:
-        Which of the four outcomes occurred: flushed, unsupported by the platform, refused by the
-        filesystem, or a directory that could not be opened.
+        Which of the five outcomes occurred: flushed, unsupported by the platform, refused by the
+        filesystem, a directory that refused to be opened, or one that could not be opened for another
+        reason.
     """
     # No `pragma: no cover`. Every branch here is reached by
     # `tests/cli/test_index_directory_durability.py` -- this one by deleting the attribute, the two
@@ -1155,9 +1173,18 @@ def _fsync_directory(directory: Path) -> _DirectoryFlush:
         return _DirectoryFlush.UNSUPPORTED
     try:
         descriptor = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
-    except OSError as error:
-        logger.debug("Could not open %s to flush its entries: %s", directory, error)
+    except PermissionError as error:
+        logger.debug("Not permitted to open %s to flush its entries: %s", directory, error)
         return _DirectoryFlush.UNREADABLE
+    except OSError as error:
+        # Everything else the open can fail with -- `EMFILE`/`ENFILE` from an exhausted descriptor
+        # table, `ENOENT` from a directory removed under the run, `EIO` from the device. Kept apart from
+        # the permission case because that one's warning names a repair -- widen the mode -- which none
+        # of these are fixed by, and a message that prescribes the wrong repair is worse than a generic
+        # one. The specific errno reaches the debug log rather than the warning, which stays stable
+        # enough to grep for.
+        logger.debug("Could not open %s to flush its entries: %s", directory, error)
+        return _DirectoryFlush.UNAVAILABLE
     try:
         os.fsync(descriptor)
     except OSError as error:

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -852,23 +852,6 @@ def _recorded_digest(lock_file: Path) -> str | None:
     return recorded or None
 
 
-def _clear_digest(lock_file: Path) -> None:
-    """Erase the sidecar's digest, returning the directory to the permissive legacy path.
-
-    For the one case where neither keeping nor advancing the digest is crash-safe: the index is
-    installed, but the durability of its name is unknown. An empty sidecar is the only state
-    :func:`_require_fresh_index_read` accepts whichever index a crash leaves behind.
-
-    Failing to clear it is raised, not swallowed, for the same reason failing to record is: the
-    sidecar would keep a digest describing the index this update replaced, which is the permanent
-    wedge with none of the warning.
-
-    Args:
-        lock_file: The sidecar beside the index.
-    """
-    _record_digest(lock_file, "")
-
-
 def _record_digest(lock_file: Path, digest: str) -> None:
     """Write the digest of the index just committed into the sidecar.
 
@@ -1019,7 +1002,7 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> _Committ
 
 @cache
 def _warn_flush_refused_once(index_file: Path, sidecar_name: str) -> None:
-    """Say once per index that its directory cannot be flushed, so its digest is being withheld.
+    """Say once per index that its directory cannot be flushed, so its updates are not durable.
 
     Once per *index*, not once per batch. A mount that refuses the flush refuses it every time, and a
     run writes one batch after another: warning each time is how the message that matters gets
@@ -1032,15 +1015,16 @@ def _warn_flush_refused_once(index_file: Path, sidecar_name: str) -> None:
 
     Args:
         index_file: The index whose rename could not be made durable.
-        sidecar_name: File name of the sidecar whose digest was cleared.
+        sidecar_name: File name of the sidecar recording its digest.
     """
     logger.warning(
-        "The filesystem holding %s refused to flush the directory, so this update's name is not known "
-        "to have reached stable storage. Its digest has been cleared from %s rather than recorded: "
-        "recording it would make every later write refuse as stale if the machine crashed now. The "
-        "index itself is correct and complete. These writes are unprotected against a stale read, so "
-        "run them from a single host -- a mount that refuses directory flushes cannot support the "
-        "cross-host guard at all. Warned once per index; the condition persists.",
+        "The filesystem holding %s refused to flush the directory, so the rename that installed this "
+        "update is not known to have reached stable storage. The index and its digest are correct and "
+        "complete, and the staleness guard is intact. What is not covered: if the machine loses power "
+        "in the window before the directory entry reaches the disk, the reboot can serve the previous "
+        "index while %s records this one, and every later write then refuses as stale against a good "
+        "file -- repaired by stopping the writers and deleting that sidecar, which holds only the "
+        "digest and the lock. Warned once per index; the condition persists for every batch.",
         index_file,
         sidecar_name,
     )
@@ -1192,26 +1176,29 @@ def update_signal_index(
             return
         _require_fresh_index_read(index_file, lock_file)
         committed = _update_signal_index_locked(index_file, injections, metadata, metadata_file_name, encoding)
+        # Recorded whatever the flush managed, and this is a decision with a history. An earlier
+        # version of this branch *withheld* the digest when the directory could not be flushed, on the
+        # grounds that a digest describing a possibly-non-durable rename can wedge the directory after
+        # a crash. Two reviewers showed that trade is inverted:
+        #
+        #   - An empty sidecar is the permissive legacy path, so a writer on another host with a stale
+        #     cached view is *accepted* and its write discards the entries it could not see. That is
+        #     silent loss on exactly the shared mounts this guard was added for, and it needs no crash.
+        #   - The next batch would then warn "predates the staleness guard", which is a lie about an
+        #     index written seconds earlier, and it fires per batch.
+        #   - Withholding cannot even deliver its own invariant: the clear happens after the rename, so
+        #     a crash between them leaves the old digest describing the new index -- the same wedge.
+        #
+        # So the guard is kept and the durability gap is carried instead. If a crash does land in the
+        # window, the outcome is a refusal against a good index: loud, and recoverable by deleting the
+        # sidecar. A rare loud failure is the right thing to keep over a routine silent one.
+        _record_digest(lock_file, committed.digest)
         if committed.directory_flush is _DirectoryFlush.REFUSED:
-            # The index is installed but its *name* may not survive a crash, so recording this digest
-            # would risk the exact wedge the digest exists to prevent: reboot serves the old index
-            # under the new digest and every later write refuses as stale against a good file.
-            #
-            # Not recording is not enough, and that is the trap. Leaving the sidecar's *previous*
-            # digest in place describes the old index while the new one is installed -- a mismatch in
-            # the other direction, wedged the same way. Only three states are crash-safe to leave
-            # behind, and of the three -- old digest, new digest, no digest -- `_require_fresh_index_read`
-            # accepts just the last. So the digest is cleared: one write loses the staleness guard
-            # (warned about, per write) instead of the directory wedging permanently.
-            _clear_digest(lock_file)
+            # `REFUSED` is unexpected and per-filesystem, so it warns. `UNSUPPORTED` does not: it is a
+            # permanent property of the platform, and a warning on every run about a gap the operator
+            # cannot close is how the warnings that matter get filtered out. Documented on
+            # `_fsync_directory` instead.
             _warn_flush_refused_once(index_file, lock_file.name)
-        else:
-            # `UNSUPPORTED` records too, deliberately. A platform with no directory-flush primitive
-            # can never satisfy the check, so clearing on it would disable the cross-host guard on
-            # every write there for good -- a certain loss against the uncertain one of a crash in a
-            # sub-millisecond window, the same trade the legacy-digest acceptance above makes. The
-            # gap is real and documented on `_fsync_directory`, not silently papered over.
-            _record_digest(lock_file, committed.digest)
 
 
 def _require_fresh_index_read(index_file: Path, lock_file: Path) -> None:
@@ -1298,7 +1285,7 @@ def _update_signal_index_locked(
 
     Returns:
         The committed index's digest and the durability of the rename that installed it, for the
-        caller to turn into a recorded digest or a cleared one.
+        caller to record and, when the durability is unverifiable, to warn about.
     """
     if index_file.exists():
         try:

--- a/tests/cli/test_index_directory_durability.py
+++ b/tests/cli/test_index_directory_durability.py
@@ -467,6 +467,49 @@ def test_two_unreadable_directories_on_one_filesystem_each_warn(
     )
 
 
+@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
+def test_a_directory_whose_permissions_are_fixed_and_broken_again_warns_again(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The directory scope needs its own clear-on-success, exactly as the filesystem scope does.
+
+    A mutation that cleared only the filesystem scope survived every other test: an operator who fixes
+    the directory's mode, and later breaks it again, would then never be told a second time. Same defect
+    as the permanent cache this branch already replaced once, in the scope added last.
+    """
+    directory = tmp_path / "run"
+    directory.mkdir()
+
+    def note() -> None:
+        simulate_utils._note_flush_outcome(
+            directory,
+            simulate_utils._fsync_directory(directory),
+            directory / "signal_index.yaml",
+            "signal_index.yaml.lock",
+        )
+
+    directory.chmod(0o333)
+    try:
+        try:
+            os.close(os.open(directory, os.O_RDONLY | os.O_DIRECTORY))
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this user can read a write-only directory, so the refusal cannot be produced")
+
+        with caplog.at_level(logging.WARNING, logger="gwmock.cli.simulate_utils"):
+            note()
+            directory.chmod(0o755)  # the operator fixes it
+            note()
+            directory.chmod(0o333)  # and it breaks again
+            note()
+    finally:
+        directory.chmod(0o755)
+
+    unreadable = [r for r in caplog.records if "could not be opened to flush" in r.message]
+    assert len(unreadable) == 2, f"expected one warning per episode, got {len(unreadable)}"
+
+
 def test_the_flush_is_skipped_where_the_platform_has_no_directory_open(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/cli/test_index_directory_durability.py
+++ b/tests/cli/test_index_directory_durability.py
@@ -42,6 +42,7 @@ change can silently break.
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import logging
 import os
@@ -312,6 +313,43 @@ def test_a_directory_that_cannot_be_opened_for_reading_is_unreadable(tmp_path: P
         assert simulate_utils._fsync_directory(metadata_directory) is simulate_utils._DirectoryFlush.UNREADABLE
     finally:
         metadata_directory.chmod(0o755)
+
+
+@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
+def test_an_open_failure_that_is_not_about_permissions_prescribes_no_repair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``EMFILE`` is not a permission problem, and must not be answered with a permission repair.
+
+    Every ``OSError`` from the open used to be classified as unreadable, whose warning tells the operator
+    to widen the directory's mode -- which repairs nothing when the real cause is an exhausted descriptor
+    table, a directory removed under the run, or a device error. An automated reviewer caught it: the same
+    wrong-repair defect as an earlier round, in the branch that round added.
+
+    Patching ``os.open`` is safe here where patching ``Path.stat`` was not -- nothing else in this path
+    calls it with ``O_DIRECTORY``.
+    """
+    real_open = os.open
+
+    def _refuse_to_open(path, flags, *args, **kwargs):
+        if flags & os.O_DIRECTORY:
+            raise OSError(errno.EMFILE, "Too many open files")
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(os, "open", _refuse_to_open)
+
+    assert simulate_utils._fsync_directory(tmp_path) is simulate_utils._DirectoryFlush.UNAVAILABLE
+
+    with caplog.at_level(logging.WARNING, logger="gwmock.cli.simulate_utils"):
+        update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+
+    warnings = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warnings) == 1, f"expected one warning, got {warnings}"
+    assert "could not be opened" in warnings[0]
+    assert "permissions" not in warnings[0], (
+        f"a descriptor exhaustion was answered with a permissions repair: {warnings[0]}"
+    )
+    assert "No repair can be named" in warnings[0]
 
 
 @pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")

--- a/tests/cli/test_index_directory_durability.py
+++ b/tests/cli/test_index_directory_durability.py
@@ -334,22 +334,31 @@ def test_the_flush_is_skipped_where_the_platform_has_no_directory_open(
     assert (tmp_path / "signal_index.yaml").exists()
 
 
-def test_a_platform_without_directory_flushing_still_records_its_digest(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_a_platform_without_directory_flushing_records_its_digest_and_stays_quiet(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """The staleness guard stays on where durability cannot be verified at all.
+    """The staleness guard stays on where durability cannot be verified at all, and says nothing.
 
-    Every flush outcome records now, so this is the same policy as a refused flush rather than an
-    exception to it. It is pinned separately because the platform reaches the decision by a different
-    branch, and because a change that withholds the digest on either would have to break this test
-    explicitly rather than by omission.
+    Every flush outcome records now, so the digest half is the same policy as a refused flush rather
+    than an exception to it. It is pinned separately because the platform reaches the decision by a
+    different branch, and because a change that withholds the digest on either would have to break this
+    test explicitly rather than by omission.
+
+    The silence is the other half, and it needs its own assertion: a mutation that warned on *every*
+    non-flushed outcome passed every other test in this file. Warning here would fire on every run of
+    every batch on a platform whose gap the operator cannot close, which is how the warnings that can
+    be acted on get filtered out.
     """
     monkeypatch.delattr(os, "O_DIRECTORY", raising=False)
+    simulate_utils._warn_flush_refused_once.cache_clear()
 
-    update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+    with caplog.at_level(logging.WARNING, logger="gwmock.cli.simulate_utils"):
+        update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
 
     recorded = (tmp_path / "signal_index.yaml.lock").read_text().strip()
-    assert recorded, "the digest was cleared on a platform that cannot flush directories at all"
+    assert recorded, "the digest was withheld on a platform that cannot flush directories at all"
     assert recorded == hashlib.sha256((tmp_path / "signal_index.yaml").read_bytes()).hexdigest(), (
         "the recorded digest does not describe the index that was committed"
     )
+    warnings = [record.message for record in caplog.records if record.levelno >= logging.WARNING]
+    assert warnings == [], f"a platform gap the operator cannot close warned anyway: {warnings}"

--- a/tests/cli/test_index_directory_durability.py
+++ b/tests/cli/test_index_directory_durability.py
@@ -216,7 +216,7 @@ def test_a_refused_flush_still_records_the_digest_of_what_it_committed(
 def test_a_stale_reader_is_still_refused_on_a_filesystem_that_cannot_flush(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The cost of withholding the digest, pinned: silent loss on the mounts the guard exists for.
+    """The guard still refuses a stale read when the flush fails -- which is what withholding would cost.
 
     A reviewer supplied this ordering. Writer A's flush is refused; if that withheld the digest, the
     sidecar is empty, and a writer on another host whose cached view predates A's update takes the

--- a/tests/cli/test_index_directory_durability.py
+++ b/tests/cli/test_index_directory_durability.py
@@ -23,7 +23,8 @@ backwards before landing here.** The digest is recorded anyway. Withholding it l
 describing a rename that might vanish -- but an empty sidecar *is* the permissive legacy path, so a
 writer on another host with a stale cached view is accepted and silently discards the entries it could
 not see, with no crash needed. Withholding also cannot deliver its own invariant, since clearing happens
-after the rename and a crash between them leaves the old digest describing the new index regardless.
+after the rename and a crash between them leaves the sidecar's old digest against a possibly-new index,
+which refuses exactly as the state it was avoiding does.
 
 So the guard is kept and the durability gap is carried. A crash in that window leaves index and sidecar
 disagreeing one way or the other, and either way the next write refuses: loud, and repaired by deleting
@@ -320,9 +321,11 @@ def test_the_degradation_warns_where_an_operator_will_see_it_but_only_once(
     """A degradation with no signal is indistinguishable from a guarantee.
 
     ``_fsync_directory`` logs at ``DEBUG`` and the CLI runs at ``INFO``, so the flush failure alone
-    produces nothing an operator sees. The warning has to be at ``WARNING`` -- and once per index, not
-    once per batch, because a mount that refuses the flush refuses it for every batch in the run and a
-    per-batch warning is how the message gets filtered out.
+    produces nothing an operator sees. The warning has to be at ``WARNING`` -- and once per *filesystem*
+    rather than once per batch, because a mount that refuses the flush refuses it for every batch in the
+    run and a per-batch warning is how the message gets filtered out. One index is written here, so this
+    test cannot tell per-filesystem from per-index; the scope itself is pinned by
+    `test_many_directories_on_one_refusing_filesystem_warn_once_between_them`.
     """
     _refuse_directory_fsync(monkeypatch)
 
@@ -373,9 +376,10 @@ def test_many_directories_on_one_refusing_filesystem_warn_once_between_them(
 
     Keyed per index, a run over twenty metadata directories on one refusing mount emitted twenty copies
     of a multi-line warning and kept twenty cache entries for the life of the process. A reviewer
-    measured both. Keying on ``st_dev`` collapses them, and it also fixes the path-spelling collisions
-    the other reviewer found -- two spellings of one directory used to warn twice, and one relative path
-    resolved from two working directories used to warn once for what were different filesystems.
+    measured both. Keying on ``st_dev`` collapses them. These four directories share one device, so
+    what is demonstrated here is the collapse and nothing more -- the path-spelling collisions the other
+    reviewer found are asserted for the directory scope by
+    `test_one_relative_spelling_in_two_working_directories_is_two_directories`, not here.
     """
     directories = [tmp_path / f"run-{index}" for index in range(4)]
     for directory in directories:

--- a/tests/cli/test_index_directory_durability.py
+++ b/tests/cli/test_index_directory_durability.py
@@ -18,19 +18,23 @@ in the page cache while ``_record_digest`` writes the sidecar. A crash in that w
 **old** index with the **new** digest, and every later write refuses as stale against a good file --
 loud, recoverable by deleting the sidecar, and needing an operator.
 
-Flushing is only half of it, and the half a reviewer had to point out. When the flush cannot be done,
-the digest must not be recorded either -- a digest describing a name that may not survive is the same
-wedge with an extra step. Nor may the *previous* digest simply be left in place: it then describes the
-old index while the new one is installed, wedged in the other direction. Of the three states a crash
-can leave -- old digest, new digest, no digest -- only the last is accepted whichever index survives,
-so a refused flush clears it. A platform with no directory-flush primitive at all is treated
-differently, and `test_a_platform_without_directory_flushing_still_records_its_digest` says why.
+**What happens when the flush cannot be done is the interesting half, and two rounds of review got it
+backwards before landing here.** The digest is recorded anyway. Withholding it looks safer -- no digest
+describing a rename that might vanish -- but an empty sidecar *is* the permissive legacy path, so a
+writer on another host with a stale cached view is accepted and silently discards the entries it could
+not see, with no crash needed. Withholding also cannot deliver its own invariant, since clearing happens
+after the rename and a crash between them leaves the old digest describing the new index regardless.
 
-**What these tests pin, and what they cannot.** They pin the mechanism: that the directory is fsynced,
-after the rename, before the digest is recorded, and that the digest is withheld when it is not. They
-do **not** demonstrate durability -- that needs power loss or a crash-consistency harness, and no test
-here can produce one. The rollback test replays the resulting *state*, not the crash. Found by a
-reviewer during R24; the ordering is the part a future change can silently break.
+So the guard is kept and the durability gap is carried. If a crash does land in the window the outcome
+is a refusal against a good index: loud, and repaired by deleting the sidecar. A rare loud failure is
+worth keeping over a routine silent one -- and both failure modes have a test here, because the argument
+is only as good as the ordering it is checked against.
+
+**What these tests pin, and what they cannot.** They pin the mechanism: the directory is fsynced, after
+the rename, before the digest is recorded. They do **not** demonstrate durability -- that needs power
+loss or a crash-consistency harness, and no test here can produce one. The crash tests replay the
+resulting *state*, not the crash. Found by a reviewer during R24; the ordering is the part a future
+change can silently break.
 """
 
 from __future__ import annotations
@@ -38,6 +42,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import re
 import stat
 from pathlib import Path
 from typing import Any
@@ -46,7 +51,7 @@ import pytest
 import yaml
 
 from gwmock.cli import simulate_utils
-from gwmock.cli.simulate_utils import update_signal_index
+from gwmock.cli.simulate_utils import StaleIndexReadError, update_signal_index
 
 pytestmark = pytest.mark.unit
 
@@ -165,53 +170,97 @@ def test_a_filesystem_refusing_the_flush_does_not_fail_the_write(
 
 
 @pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
-def test_a_refused_flush_clears_the_digest_instead_of_recording_one(
+def test_a_refused_flush_still_records_the_digest_of_what_it_committed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A digest may only be recorded for a rename known to be durable, and the old one must go.
+    """The staleness guard survives a filesystem that cannot flush directories.
 
-    Surviving the write is not the property that matters -- recording the digest anyway also survives,
-    which is why the assertion here is on the sidecar and not on the index.
-
-    The first write is flushed normally so a digest is actually **there** to be cleared. Without it,
-    this test starts from the empty sidecar the lock creates and cannot tell clearing from doing
-    nothing: a mutation that dropped the clear and kept only the warning passed.
+    An earlier version of this branch withheld the digest here, reasoning that a digest for a rename of
+    unknown durability can wedge the directory after a crash. That is the wrong way round, and the test
+    below shows what it costs. The durability gap is carried instead, and warned about.
     """
-    update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
-    sidecar = tmp_path / "signal_index.yaml.lock"
-    assert sidecar.read_text().strip(), "the first write recorded no digest, so there is nothing to clear"
-
     _refuse_directory_fsync(monkeypatch)
+
+    update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
     update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
 
-    assert sidecar.read_text().strip() == "", (
-        "the sidecar still holds a digest after an unflushed write. Either it describes the index this "
-        "update replaced -- wedging the next write against a good file -- or it describes a name that "
-        f"may not survive a crash: {sidecar.read_text()!r}"
+    recorded = (tmp_path / "signal_index.yaml.lock").read_text().strip()
+    assert recorded == hashlib.sha256((tmp_path / "signal_index.yaml").read_bytes()).hexdigest(), (
+        "the sidecar does not describe the index on disk, so the next writer cannot tell a stale read "
+        f"from a current one: {recorded!r}"
     )
 
 
 @pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
-def test_the_next_write_after_an_unflushed_one_is_not_refused_as_stale(
+def test_a_stale_reader_is_still_refused_on_a_filesystem_that_cannot_flush(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Keeping the previous digest wedges the directory with no crash involved at all.
+    """The cost of withholding the digest, pinned: silent loss on the mounts the guard exists for.
 
-    This is the ordering that makes "just don't record it" wrong, and it needs no power loss: the
-    unflushed rename *does* land, so the sidecar's older digest now describes an index that has been
-    replaced. The next write reads a good index, finds it does not match, and raises
-    ``StaleIndexReadError`` -- permanently, since nothing advances the digest but a successful write.
+    A reviewer supplied this ordering. Writer A's flush is refused; if that withheld the digest, the
+    sidecar is empty, and a writer on another host whose cached view predates A's update takes the
+    *permissive legacy path* -- it is accepted, and its write discards the entries it could not see. No
+    crash, no error, both runs exit 0. Refusing a stale read is loud and costs one batch; believing one
+    costs the entries.
+
+    Note which mounts these are. A filesystem that refuses ``fsync`` on a directory is the same class
+    that serves stale cached reads, so the guard is being disabled exactly where it is load-bearing.
+    """
+    _refuse_directory_fsync(monkeypatch)
+    update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+    update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
+
+    index_file = tmp_path / "signal_index.yaml"
+    assert sorted(yaml.safe_load(index_file.read_text())) == ["1", "2"]
+
+    # The other host's stale view: the index as it was one update ago. Only the index's bytes are
+    # patched -- blanking the sidecar too would send the guard down its "no digest" branch and pass for
+    # the wrong reason.
+    one_update_ago = yaml.safe_dump({"1": {"batches": [], "coa_time": 101.0}}).encode()
+    real_read_bytes = Path.read_bytes
+    monkeypatch.setattr(
+        Path,
+        "read_bytes",
+        lambda self: one_update_ago if self == index_file else real_read_bytes(self),
+    )
+
+    with pytest.raises(StaleIndexReadError, match="stale"):
+        update_signal_index(tmp_path, _metadata(3, 2), "orchestration-2.metadata.json")
+
+    monkeypatch.undo()
+    assert sorted(yaml.safe_load(index_file.read_text())) == ["1", "2"], (
+        "the refusal itself damaged the index, which is no better than believing the stale read"
+    )
+
+
+@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
+def test_a_crash_losing_an_unflushed_rename_refuses_loudly_and_names_the_repair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gap this branch knowingly carries, and the shape of it when it fires.
+
+    Recording the digest for a rename that may not be durable means a crash in that window reboots to
+    the *previous* index while the sidecar describes the new one. That state is a refusal, not a silent
+    acceptance -- and the message has to carry the repair, because nothing advances the digest by
+    itself: only deleting the sidecar clears it.
+
+    Rolling the index bytes back by hand is the closest a test without power loss gets to that state.
     """
     update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+    index_file = tmp_path / "signal_index.yaml"
+    before_the_lost_write = index_file.read_bytes()
 
     _refuse_directory_fsync(monkeypatch)
     update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
     monkeypatch.undo()
 
-    update_signal_index(tmp_path, _metadata(3, 2), "orchestration-2.metadata.json")
+    # The crash: the rename that installed event 2's index never reached stable storage.
+    index_file.write_bytes(before_the_lost_write)
 
-    index = yaml.safe_load((tmp_path / "signal_index.yaml").read_text())
-    assert sorted(index) == ["1", "2", "3"], f"the write after an unflushed one did not land: {sorted(index)}"
+    # The repair, not merely the sidecar's name: a refusal that does not say what to delete leaves the
+    # operator with a permanently wedged directory and no instruction.
+    with pytest.raises(StaleIndexReadError, match=re.escape("delete signal_index.yaml.lock")):
+        update_signal_index(tmp_path, _metadata(3, 2), "orchestration-2.metadata.json")
 
 
 @pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
@@ -257,41 +306,14 @@ def test_the_degradation_warns_where_an_operator_will_see_it_but_only_once(
         update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
         update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
 
-    refusals = [record for record in caplog.records if "refused to flush the directory" in record.message]
-    assert len(refusals) == 1, f"expected exactly one warning across two batches, got {len(refusals)}"
-    assert refusals[0].levelno == logging.WARNING
-
-
-@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
-def test_the_directory_does_not_wedge_when_an_unflushed_rename_is_rolled_back(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The crash ordering itself, replayed: an unflushed rename lost, the sidecar surviving.
-
-    A crash after ``os.replace`` but before its directory entry reaches the disk can reboot to the
-    *previous* index -- while the sidecar, written in place, keeps whatever digest it holds. Rolling the
-    index bytes back by hand is the closest a test without power loss gets to that state.
-
-    With a digest recorded, the next write reads an index that does not match it and raises
-    ``StaleIndexReadError`` against a perfectly good file, and the directory stays wedged until an
-    operator deletes the sidecar. With the digest cleared, the same state is the permissive legacy path:
-    it warns and proceeds.
-    """
-    update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
-    index_file = tmp_path / "signal_index.yaml"
-    before_the_lost_write = index_file.read_bytes()
-
-    _refuse_directory_fsync(monkeypatch)
-    update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
-    monkeypatch.undo()
-
-    # The crash: the rename that installed event 2's index never reached stable storage.
-    index_file.write_bytes(before_the_lost_write)
-
-    update_signal_index(tmp_path, _metadata(3, 2), "orchestration-2.metadata.json")
-
-    index = yaml.safe_load(index_file.read_text())
-    assert sorted(index) == ["1", "3"], f"the write after the rolled-back rename did not land: {sorted(index)}"
+    warnings = [record for record in caplog.records if record.levelno >= logging.WARNING]
+    refusals = [record for record in warnings if "refused to flush the directory" in record.message]
+    assert len(refusals) == 1, f"expected exactly one refusal warning across two batches, got {len(refusals)}"
+    # Every warning, not only this one. The earlier version counted its own message and called that
+    # "only once" while the second batch emitted a *different* warning claiming the index "predates the
+    # staleness guard" -- a lie about an index written seconds earlier, and per batch. It came from
+    # withholding the digest; counting all warnings is what would have caught it.
+    assert warnings == refusals, f"the degradation emitted other warnings too: {[r.message for r in warnings]}"
 
 
 def test_the_flush_is_skipped_where_the_platform_has_no_directory_open(
@@ -317,10 +339,10 @@ def test_a_platform_without_directory_flushing_still_records_its_digest(
 ) -> None:
     """The staleness guard stays on where durability cannot be verified at all.
 
-    Distinct from a *refused* flush, which clears the digest. A platform with no directory-flush
-    primitive can never satisfy the check, so clearing there would disable the cross-host guard on
-    every write for good -- a certain loss against the uncertain one of a crash in a sub-millisecond
-    window. Without this test, clearing unconditionally passes every other test in this file.
+    Every flush outcome records now, so this is the same policy as a refused flush rather than an
+    exception to it. It is pinned separately because the platform reaches the decision by a different
+    branch, and because a change that withholds the digest on either would have to break this test
+    explicitly rather than by omission.
     """
     monkeypatch.delattr(os, "O_DIRECTORY", raising=False)
 

--- a/tests/cli/test_index_directory_durability.py
+++ b/tests/cli/test_index_directory_durability.py
@@ -18,19 +18,32 @@ in the page cache while ``_record_digest`` writes the sidecar. A crash in that w
 **old** index with the **new** digest, and every later write refuses as stale against a good file --
 loud, recoverable by deleting the sidecar, and needing an operator.
 
+Flushing is only half of it, and the half a reviewer had to point out. When the flush cannot be done,
+the digest must not be recorded either -- a digest describing a name that may not survive is the same
+wedge with an extra step. Nor may the *previous* digest simply be left in place: it then describes the
+old index while the new one is installed, wedged in the other direction. Of the three states a crash
+can leave -- old digest, new digest, no digest -- only the last is accepted whichever index survives,
+so a refused flush clears it. A platform with no directory-flush primitive at all is treated
+differently, and `test_a_platform_without_directory_flushing_still_records_its_digest` says why.
+
 **What these tests pin, and what they cannot.** They pin the mechanism: that the directory is fsynced,
-after the rename, before the function returns its digest. They do **not** demonstrate durability --
-that needs power loss or a crash-consistency harness, and no test here can produce one. Found by a
+after the rename, before the digest is recorded, and that the digest is withheld when it is not. They
+do **not** demonstrate durability -- that needs power loss or a crash-consistency harness, and no test
+here can produce one. The rollback test replays the resulting *state*, not the crash. Found by a
 reviewer during R24; the ordering is the part a future change can silently break.
 """
 
 from __future__ import annotations
 
+import hashlib
+import logging
 import os
+import stat
 from pathlib import Path
 from typing import Any
 
 import pytest
+import yaml
 
 from gwmock.cli import simulate_utils
 from gwmock.cli.simulate_utils import update_signal_index
@@ -46,29 +59,26 @@ def _metadata(event_id: int, batch: int) -> dict[str, Any]:
     }
 
 
-def _track_directory_fds(monkeypatch: pytest.MonkeyPatch) -> set[int]:
-    """Return a live set of open directory descriptors.
+def _is(descriptor: int, path: Path) -> bool:
+    """Whether *descriptor* is open on *path*, by the file's identity on disk.
 
-    Descriptors are **recycled**: the first version of this helper added directory fds to a set and
-    never removed them, so the sidecar reused a closed directory's number and the fault injection
-    below hit the digest write instead. Closes are tracked for that reason.
+    Three identifications were tried here and two were wrong. The ``O_DIRECTORY`` flag was wrong in
+    both directions: flushing the **wrong** directory -- ``index_file.parent.parent`` -- still produced
+    an ``O_DIRECTORY`` open and passed every assertion, while a correct refactor to
+    ``os.open(directory, os.O_RDONLY)`` would have failed them. Spying on ``os.open`` to record paths
+    was wrong too, and quietly: ``Path.open`` reaches the ``open()`` syscall through ``io.FileIO`` in C
+    and never calls the ``os.open`` *Python* function, so the sidecar's descriptor was invisible and the
+    assertion about it could not fail.
+
+    ``st_dev``/``st_ino`` is neither: it survives any refactor of how the file is opened, and it cannot
+    confuse two different files. Recycled descriptors stop mattering, because the identity is read from
+    the descriptor at the moment it is used.
     """
-    directory_fds: set[int] = set()
-    real_open, real_close = os.open, os.close
-
-    def _spy_open(path, flags, *args, **kwargs):
-        descriptor = real_open(path, flags, *args, **kwargs)
-        if flags & getattr(os, "O_DIRECTORY", 0):
-            directory_fds.add(descriptor)
-        return descriptor
-
-    def _spy_close(descriptor):
-        directory_fds.discard(descriptor)
-        return real_close(descriptor)
-
-    monkeypatch.setattr(os, "open", _spy_open)
-    monkeypatch.setattr(os, "close", _spy_close)
-    return directory_fds
+    try:
+        opened, target = os.fstat(descriptor), path.stat()
+    except OSError:
+        return False
+    return (opened.st_dev, opened.st_ino) == (target.st_dev, target.st_ino)
 
 
 @pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
@@ -81,15 +91,26 @@ def test_the_directory_is_flushed_after_the_rename(tmp_path: Path, monkeypatch: 
     """
     events: list[str] = []
     real_replace, real_fsync = os.replace, os.fsync
-    directory_fds = _track_directory_fds(monkeypatch)
+    sidecar = tmp_path / "signal_index.yaml.lock"
 
     def _spy_replace(src, dst, *args, **kwargs):
+        result = real_replace(src, dst, *args, **kwargs)
         events.append("replace")
-        return real_replace(src, dst, *args, **kwargs)
+        return result
 
     def _spy_fsync(fd):
-        events.append("fsync-directory" if fd in directory_fds else "fsync-file")
-        return real_fsync(fd)
+        # Recorded *after* the call, and only if it returns. Recording first meant a host whose
+        # directory fsync fails -- a write-only directory, a refusing mount -- logged the flush as
+        # having happened, because the production code swallows the error. The test then passed while
+        # nothing was flushed.
+        result = real_fsync(fd)
+        if _is(fd, tmp_path):
+            events.append("fsync-directory")
+        elif _is(fd, sidecar):
+            events.append("fsync-sidecar")
+        else:
+            events.append("fsync-file")
+        return result
 
     monkeypatch.setattr(os, "replace", _spy_replace)
     monkeypatch.setattr(os, "fsync", _spy_fsync)
@@ -97,14 +118,31 @@ def test_the_directory_is_flushed_after_the_rename(tmp_path: Path, monkeypatch: 
     update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
 
     assert "replace" in events, "the index was never renamed into place"
-    assert "fsync-directory" in events, "the directory was not flushed, so the rename is not durable"
+    assert "fsync-directory" in events, (
+        f"the index's own directory was not flushed, so the rename is not durable: {events}"
+    )
     assert events.index("replace") < events.index("fsync-directory"), (
         f"the directory was flushed before the rename it must persist: {events}"
     )
-    # The sidecar's digest write is the last fsync, so the directory flush must precede it.
-    assert events.index("fsync-directory") < len(events) - 1, (
-        f"nothing followed the directory flush, so the digest write was not after it: {events}"
+    # Named explicitly rather than "something followed the flush", which was the weaker assertion an
+    # earlier version made while its comment claimed this one.
+    assert "fsync-sidecar" in events, f"the digest was never fsynced, so the order is untested: {events}"
+    assert events.index("fsync-directory") < events.index("fsync-sidecar"), (
+        f"the digest reached the disk before the rename it describes: {events}"
     )
+
+
+def _refuse_directory_fsync(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every fsync of a *directory* fail with ``EINVAL``, as some network mounts do."""
+    real_fsync = os.fsync
+
+    def _fsync(fd):
+        if stat.S_ISDIR(os.fstat(fd).st_mode):
+            raise OSError(22, "Invalid argument")
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", _fsync)
+    simulate_utils._warn_flush_refused_once.cache_clear()
 
 
 @pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
@@ -117,23 +155,115 @@ def test_a_filesystem_refusing_the_flush_does_not_fail_the_write(
     failed update to a caller whose data had in fact landed -- strictly worse than the durability gap
     this closes, because the caller would then retry or abort on a false negative.
     """
-    real_fsync = os.fsync
-    directory_fds = _track_directory_fds(monkeypatch)
-
-    def _refuse_directory_fsync(fd):
-        if fd in directory_fds:
-            raise OSError(22, "Invalid argument")
-        return real_fsync(fd)
-
-    monkeypatch.setattr(os, "fsync", _refuse_directory_fsync)
+    _refuse_directory_fsync(monkeypatch)
 
     update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
     update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
 
-    import yaml
-
     index = yaml.safe_load((tmp_path / "signal_index.yaml").read_text())
     assert sorted(index) == ["1", "2"], f"a refused directory flush cost an event: {sorted(index)}"
+
+
+@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
+def test_a_refused_flush_clears_the_digest_instead_of_recording_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A digest may only be recorded for a rename known to be durable.
+
+    Surviving the write is not the property that matters -- recording the digest anyway also survives,
+    which is why the assertion here is on the sidecar and not on the index. The digest describes a name
+    that may still be in the page cache; recording it bets the directory on that write reaching the
+    disk, and the test below replays the ordering where it does not.
+    """
+    _refuse_directory_fsync(monkeypatch)
+
+    update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+
+    sidecar = tmp_path / "signal_index.yaml.lock"
+    assert sidecar.read_text().strip() == "", (
+        "a digest was recorded for a rename whose durability is unknown, which is the wedge this "
+        f"guards: {sidecar.read_text()!r}"
+    )
+
+
+@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
+def test_a_directory_that_cannot_be_opened_for_reading_is_a_refusal(tmp_path: Path) -> None:
+    """The ``os.open`` failure is a real input, not a defensive branch.
+
+    A write-only metadata directory -- mode ``0o333`` -- accepts the ``os.replace`` that installs the
+    index but refuses ``os.open(directory, O_RDONLY | O_DIRECTORY)`` with ``EACCES``. A reviewer
+    supplied this case; the branch had no test and was the one still marked unreachable.
+    """
+    metadata_directory = tmp_path / "metadata"
+    metadata_directory.mkdir()
+    metadata_directory.chmod(0o333)
+    try:
+        # The real permission, not a patched `os.open`: root ignores the mode, and a mocked refusal
+        # would pass on a host where the branch cannot actually be reached.
+        try:
+            os.close(os.open(metadata_directory, os.O_RDONLY | os.O_DIRECTORY))
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this user can read a write-only directory, so the refusal cannot be produced")
+
+        assert simulate_utils._fsync_directory(metadata_directory) is simulate_utils._DirectoryFlush.REFUSED
+    finally:
+        metadata_directory.chmod(0o755)
+
+
+@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
+def test_the_degradation_warns_where_an_operator_will_see_it_but_only_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A degradation with no signal is indistinguishable from a guarantee.
+
+    ``_fsync_directory`` logs at ``DEBUG`` and the CLI runs at ``INFO``, so the flush failure alone
+    produces nothing an operator sees. The warning has to be at ``WARNING`` -- and once per index, not
+    once per batch, because a mount that refuses the flush refuses it for every batch in the run and a
+    per-batch warning is how the message gets filtered out.
+    """
+    _refuse_directory_fsync(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="gwmock.cli.simulate_utils"):
+        update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+        update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
+
+    refusals = [record for record in caplog.records if "refused to flush the directory" in record.message]
+    assert len(refusals) == 1, f"expected exactly one warning across two batches, got {len(refusals)}"
+    assert refusals[0].levelno == logging.WARNING
+
+
+@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
+def test_the_directory_does_not_wedge_when_an_unflushed_rename_is_rolled_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The crash ordering itself, replayed: an unflushed rename lost, the sidecar surviving.
+
+    A crash after ``os.replace`` but before its directory entry reaches the disk can reboot to the
+    *previous* index -- while the sidecar, written in place, keeps whatever digest it holds. Rolling the
+    index bytes back by hand is the closest a test without power loss gets to that state.
+
+    With a digest recorded, the next write reads an index that does not match it and raises
+    ``StaleIndexReadError`` against a perfectly good file, and the directory stays wedged until an
+    operator deletes the sidecar. With the digest cleared, the same state is the permissive legacy path:
+    it warns and proceeds.
+    """
+    update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+    index_file = tmp_path / "signal_index.yaml"
+    before_the_lost_write = index_file.read_bytes()
+
+    _refuse_directory_fsync(monkeypatch)
+    update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
+    monkeypatch.undo()
+
+    # The crash: the rename that installed event 2's index never reached stable storage.
+    index_file.write_bytes(before_the_lost_write)
+
+    update_signal_index(tmp_path, _metadata(3, 2), "orchestration-2.metadata.json")
+
+    index = yaml.safe_load(index_file.read_text())
+    assert sorted(index) == ["1", "3"], f"the write after the rolled-back rename did not land: {sorted(index)}"
 
 
 def test_the_flush_is_skipped_where_the_platform_has_no_directory_open(
@@ -148,7 +278,28 @@ def test_the_flush_is_skipped_where_the_platform_has_no_directory_open(
     """
     monkeypatch.delattr(os, "O_DIRECTORY", raising=False)
 
-    simulate_utils._fsync_directory(tmp_path)  # must not raise
+    assert simulate_utils._fsync_directory(tmp_path) is simulate_utils._DirectoryFlush.UNSUPPORTED
     update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
 
     assert (tmp_path / "signal_index.yaml").exists()
+
+
+def test_a_platform_without_directory_flushing_still_records_its_digest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The staleness guard stays on where durability cannot be verified at all.
+
+    Distinct from a *refused* flush, which clears the digest. A platform with no directory-flush
+    primitive can never satisfy the check, so clearing there would disable the cross-host guard on
+    every write for good -- a certain loss against the uncertain one of a crash in a sub-millisecond
+    window. Without this test, clearing unconditionally passes every other test in this file.
+    """
+    monkeypatch.delattr(os, "O_DIRECTORY", raising=False)
+
+    update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+
+    recorded = (tmp_path / "signal_index.yaml.lock").read_text().strip()
+    assert recorded, "the digest was cleared on a platform that cannot flush directories at all"
+    assert recorded == hashlib.sha256((tmp_path / "signal_index.yaml").read_bytes()).hexdigest(), (
+        "the recorded digest does not describe the index that was committed"
+    )

--- a/tests/cli/test_index_directory_durability.py
+++ b/tests/cli/test_index_directory_durability.py
@@ -1,0 +1,154 @@
+# Copyright (C) 2026 Leuven Gravity Institute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+"""Making the index's rename durable before its digest describes it.
+
+``_atomically_write_index`` fsyncs the temporary's contents and then ``os.replace``s it into place.
+That is atomic with respect to readers, but atomicity is not durability: the directory entry can sit
+in the page cache while ``_record_digest`` writes the sidecar. A crash in that window leaves the
+**old** index with the **new** digest, and every later write refuses as stale against a good file --
+loud, recoverable by deleting the sidecar, and needing an operator.
+
+**What these tests pin, and what they cannot.** They pin the mechanism: that the directory is fsynced,
+after the rename, before the function returns its digest. They do **not** demonstrate durability --
+that needs power loss or a crash-consistency harness, and no test here can produce one. Found by a
+reviewer during R24; the ordering is the part a future change can silently break.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gwmock.cli import simulate_utils
+from gwmock.cli.simulate_utils import update_signal_index
+
+pytestmark = pytest.mark.unit
+
+
+def _metadata(event_id: int, batch: int) -> dict[str, Any]:
+    """One batch's metadata injecting a single distinct event."""
+    return {
+        "signal": {"injections": [{"event_id": event_id, "parameters": {"coa_time": 100.0 + event_id}}]},
+        "outputs": [{"kind": "signal", "path": f"signal/signal-{batch}.gwf"}],
+    }
+
+
+def _track_directory_fds(monkeypatch: pytest.MonkeyPatch) -> set[int]:
+    """Return a live set of open directory descriptors.
+
+    Descriptors are **recycled**: the first version of this helper added directory fds to a set and
+    never removed them, so the sidecar reused a closed directory's number and the fault injection
+    below hit the digest write instead. Closes are tracked for that reason.
+    """
+    directory_fds: set[int] = set()
+    real_open, real_close = os.open, os.close
+
+    def _spy_open(path, flags, *args, **kwargs):
+        descriptor = real_open(path, flags, *args, **kwargs)
+        if flags & getattr(os, "O_DIRECTORY", 0):
+            directory_fds.add(descriptor)
+        return descriptor
+
+    def _spy_close(descriptor):
+        directory_fds.discard(descriptor)
+        return real_close(descriptor)
+
+    monkeypatch.setattr(os, "open", _spy_open)
+    monkeypatch.setattr(os, "close", _spy_close)
+    return directory_fds
+
+
+@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
+def test_the_directory_is_flushed_after_the_rename(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Order is the assertion: rename, then directory fsync, then the digest is returned.
+
+    Flushing before the rename would be useless -- the entry it needs to persist does not exist yet --
+    and flushing after ``_record_digest`` would leave exactly the window this closes. A spy records
+    the sequence rather than the outcome, because the outcome is indistinguishable without a crash.
+    """
+    events: list[str] = []
+    real_replace, real_fsync = os.replace, os.fsync
+    directory_fds = _track_directory_fds(monkeypatch)
+
+    def _spy_replace(src, dst, *args, **kwargs):
+        events.append("replace")
+        return real_replace(src, dst, *args, **kwargs)
+
+    def _spy_fsync(fd):
+        events.append("fsync-directory" if fd in directory_fds else "fsync-file")
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "replace", _spy_replace)
+    monkeypatch.setattr(os, "fsync", _spy_fsync)
+
+    update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+
+    assert "replace" in events, "the index was never renamed into place"
+    assert "fsync-directory" in events, "the directory was not flushed, so the rename is not durable"
+    assert events.index("replace") < events.index("fsync-directory"), (
+        f"the directory was flushed before the rename it must persist: {events}"
+    )
+    # The sidecar's digest write is the last fsync, so the directory flush must precede it.
+    assert events.index("fsync-directory") < len(events) - 1, (
+        f"nothing followed the directory flush, so the digest write was not after it: {events}"
+    )
+
+
+@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
+def test_a_filesystem_refusing_the_flush_does_not_fail_the_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The index is already committed when the flush runs, so refusing it must not raise.
+
+    Some network mounts reject an fsync on a directory. Turning that into an exception would report a
+    failed update to a caller whose data had in fact landed -- strictly worse than the durability gap
+    this closes, because the caller would then retry or abort on a false negative.
+    """
+    real_fsync = os.fsync
+    directory_fds = _track_directory_fds(monkeypatch)
+
+    def _refuse_directory_fsync(fd):
+        if fd in directory_fds:
+            raise OSError(22, "Invalid argument")
+        return real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", _refuse_directory_fsync)
+
+    update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+    update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
+
+    import yaml
+
+    index = yaml.safe_load((tmp_path / "signal_index.yaml").read_text())
+    assert sorted(index) == ["1", "2"], f"a refused directory flush cost an event: {sorted(index)}"
+
+
+def test_the_flush_is_skipped_where_the_platform_has_no_directory_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Windows cannot open a directory with ``os.open``, and no host here can test the alternative.
+
+    A reviewer proposed a ``FlushFileBuffers`` path through ``ctypes``. It is deliberately absent:
+    untested platform code that looks like protection is worse than a documented gap. What is pinned
+    here is that its absence is *handled* -- the write still succeeds -- rather than raising an
+    ``AttributeError`` on the platform the branch exists for.
+    """
+    monkeypatch.delattr(os, "O_DIRECTORY", raising=False)
+
+    simulate_utils._fsync_directory(tmp_path)  # must not raise
+    update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+
+    assert (tmp_path / "signal_index.yaml").exists()

--- a/tests/cli/test_index_directory_durability.py
+++ b/tests/cli/test_index_directory_durability.py
@@ -25,10 +25,12 @@ writer on another host with a stale cached view is accepted and silently discard
 not see, with no crash needed. Withholding also cannot deliver its own invariant, since clearing happens
 after the rename and a crash between them leaves the old digest describing the new index regardless.
 
-So the guard is kept and the durability gap is carried. If a crash does land in the window the outcome
-is a refusal against a good index: loud, and repaired by deleting the sidecar. A rare loud failure is
-worth keeping over a routine silent one -- and both failure modes have a test here, because the argument
-is only as good as the ordering it is checked against.
+So the guard is kept and the durability gap is carried. A crash in that window leaves index and sidecar
+disagreeing one way or the other, and either way the next write refuses: loud, and repaired by deleting
+the sidecar. Not "a rare window" -- an NFS client holds the rename until it sends the RPC, so on the very
+mounts that refuse the flush the exposure is seconds. A loud recoverable failure beats a silent one
+whatever the probability, and both failure modes have a test here, because the argument is only as good
+as the ordering it is checked against.
 
 **What these tests pin, and what they cannot.** They pin the mechanism: the directory is fsynced, after
 the rename, before the digest is recorded. They do **not** demonstrate durability -- that needs power
@@ -54,6 +56,17 @@ from gwmock.cli import simulate_utils
 from gwmock.cli.simulate_utils import StaleIndexReadError, update_signal_index
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _forget_degraded_mounts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give each test its own degraded-mount set.
+
+    Process state, so without this a test's first refusal is suppressed by an earlier test's. It is a
+    fixture rather than a call inside the refusal helper: doing it there is what hid the case where a
+    mount recovers and degrades again, since every episode looked like the first.
+    """
+    monkeypatch.setattr(simulate_utils, "_DEGRADED_MOUNTS", set())
 
 
 def _metadata(event_id: int, batch: int) -> dict[str, Any]:
@@ -147,7 +160,6 @@ def _refuse_directory_fsync(monkeypatch: pytest.MonkeyPatch) -> None:
         return real_fsync(fd)
 
     monkeypatch.setattr(os, "fsync", _fsync)
-    simulate_utils._warn_flush_refused_once.cache_clear()
 
 
 @pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
@@ -316,6 +328,61 @@ def test_the_degradation_warns_where_an_operator_will_see_it_but_only_once(
     assert warnings == refusals, f"the degradation emitted other warnings too: {[r.message for r in warnings]}"
 
 
+@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
+def test_a_mount_that_recovers_and_degrades_again_warns_again(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An episode that ends and returns is a second episode, not a repeat of the first.
+
+    The suppression was a permanent cache before a reviewer probed this: refuse, recover, refuse again in
+    one process produced a single warning, so an intermittently-refusing mount -- a server restart, a
+    remount, a flaky FUSE layer -- went silent for every episode after the first. The tests hid it too,
+    by resetting the cache inside the refusal helper.
+    """
+    with caplog.at_level(logging.WARNING, logger="gwmock.cli.simulate_utils"):
+        _refuse_directory_fsync(monkeypatch)
+        update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+        monkeypatch.undo()  # the mount recovers
+
+        update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
+
+        _refuse_directory_fsync(monkeypatch)  # and degrades again
+        update_signal_index(tmp_path, _metadata(3, 2), "orchestration-2.metadata.json")
+
+    refusals = [r for r in caplog.records if "refused to flush the directory" in r.message]
+    assert len(refusals) == 2, f"expected one warning per episode, got {len(refusals)}"
+
+
+@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
+def test_many_directories_on_one_refusing_filesystem_warn_once_between_them(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Refusing to flush is a property of the filesystem, so it is reported once for the filesystem.
+
+    Keyed per index, a run over twenty metadata directories on one refusing mount emitted twenty copies
+    of a multi-line warning and kept twenty cache entries for the life of the process. A reviewer
+    measured both. Keying on ``st_dev`` collapses them, and it also fixes the path-spelling collisions
+    the other reviewer found -- two spellings of one directory used to warn twice, and one relative path
+    resolved from two working directories used to warn once for what were different filesystems.
+    """
+    directories = [tmp_path / f"run-{index}" for index in range(4)]
+    for directory in directories:
+        directory.mkdir()
+
+    _refuse_directory_fsync(monkeypatch)
+    with caplog.at_level(logging.WARNING, logger="gwmock.cli.simulate_utils"):
+        for index, directory in enumerate(directories):
+            update_signal_index(directory, _metadata(index + 1, index), f"orchestration-{index}.metadata.json")
+
+    refusals = [r for r in caplog.records if "refused to flush the directory" in r.message]
+    assert len(refusals) == 1, (
+        f"one refusing filesystem produced {len(refusals)} warnings across {len(directories)} directories"
+    )
+    assert len(simulate_utils._DEGRADED_MOUNTS) == 1, (
+        f"the degraded-mount set grew per directory rather than per filesystem: {simulate_utils._DEGRADED_MOUNTS}"
+    )
+
+
 def test_the_flush_is_skipped_where_the_platform_has_no_directory_open(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -350,7 +417,6 @@ def test_a_platform_without_directory_flushing_records_its_digest_and_stays_quie
     be acted on get filtered out.
     """
     monkeypatch.delattr(os, "O_DIRECTORY", raising=False)
-    simulate_utils._warn_flush_refused_once.cache_clear()
 
     with caplog.at_level(logging.WARNING, logger="gwmock.cli.simulate_utils"):
         update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")

--- a/tests/cli/test_index_directory_durability.py
+++ b/tests/cli/test_index_directory_durability.py
@@ -150,16 +150,24 @@ def test_the_directory_is_flushed_after_the_rename(tmp_path: Path, monkeypatch: 
     )
 
 
-def _refuse_directory_fsync(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Make every fsync of a *directory* fail with ``EINVAL``, as some network mounts do."""
+def _refuse_directory_fsync(monkeypatch: pytest.MonkeyPatch) -> list[bool]:
+    """Make fsync of a *directory* fail with ``EINVAL``, as some network mounts do.
+
+    Returns a one-element switch so a test can let the mount recover and degrade again. Flipping the
+    switch rather than calling ``monkeypatch.undo()`` is deliberate: ``undo`` reverts *every* patch,
+    including the autouse fixture's replacement of the degraded-mount set, which restored the real
+    module-level set mid-test and made the toggle test pass whatever the suppression did.
+    """
+    refusing = [True]
     real_fsync = os.fsync
 
     def _fsync(fd):
-        if stat.S_ISDIR(os.fstat(fd).st_mode):
+        if refusing[0] and stat.S_ISDIR(os.fstat(fd).st_mode):
             raise OSError(22, "Invalid argument")
         return real_fsync(fd)
 
     monkeypatch.setattr(os, "fsync", _fsync)
+    return refusing
 
 
 @pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
@@ -262,9 +270,9 @@ def test_a_crash_losing_an_unflushed_rename_refuses_loudly_and_names_the_repair(
     index_file = tmp_path / "signal_index.yaml"
     before_the_lost_write = index_file.read_bytes()
 
-    _refuse_directory_fsync(monkeypatch)
+    refusing = _refuse_directory_fsync(monkeypatch)
     update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
-    monkeypatch.undo()
+    refusing[0] = False
 
     # The crash: the rename that installed event 2's index never reached stable storage.
     index_file.write_bytes(before_the_lost_write)
@@ -339,14 +347,14 @@ def test_a_mount_that_recovers_and_degrades_again_warns_again(
     remount, a flaky FUSE layer -- went silent for every episode after the first. The tests hid it too,
     by resetting the cache inside the refusal helper.
     """
+    refusing = _refuse_directory_fsync(monkeypatch)
     with caplog.at_level(logging.WARNING, logger="gwmock.cli.simulate_utils"):
-        _refuse_directory_fsync(monkeypatch)
         update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
-        monkeypatch.undo()  # the mount recovers
 
+        refusing[0] = False  # the mount recovers
         update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
 
-        _refuse_directory_fsync(monkeypatch)  # and degrades again
+        refusing[0] = True  # and degrades again
         update_signal_index(tmp_path, _metadata(3, 2), "orchestration-2.metadata.json")
 
     refusals = [r for r in caplog.records if "refused to flush the directory" in r.message]
@@ -380,6 +388,35 @@ def test_many_directories_on_one_refusing_filesystem_warn_once_between_them(
     )
     assert len(simulate_utils._DEGRADED_MOUNTS) == 1, (
         f"the degraded-mount set grew per directory rather than per filesystem: {simulate_utils._DEGRADED_MOUNTS}"
+    )
+
+
+def test_an_unidentifiable_filesystem_still_warns(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Losing the device number must not lose the warning.
+
+    Suppression is keyed on ``st_dev``, which is itself a syscall that can fail -- a metadata directory
+    removed under a running job is the ordinary way. Skipping the warning when the key cannot be read
+    would silence exactly the degraded setups this reports on, so an unreadable device becomes its own
+    key instead. A mutation that returned early there passed every other test in this file.
+
+    Calls the helper directly on a directory that does not exist, rather than patching ``Path.stat``: the
+    patch also caught ``mkdir(exist_ok=True)``, which stats to decide whether the existing path is a
+    directory, and the test failed in its own setup.
+    """
+    missing = tmp_path / "unmounted"
+
+    with caplog.at_level(logging.WARNING, logger="gwmock.cli.simulate_utils"):
+        simulate_utils._note_flush_outcome(
+            missing,
+            simulate_utils._DirectoryFlush.REFUSED,
+            missing / "signal_index.yaml",
+            "signal_index.yaml.lock",
+        )
+
+    refusals = [r for r in caplog.records if "refused to flush the directory" in r.message]
+    assert len(refusals) == 1, f"the warning was lost with the device number: {len(refusals)}"
+    assert {None} == simulate_utils._DEGRADED_MOUNTS, (
+        f"an unidentifiable filesystem was not given a key of its own: {simulate_utils._DEGRADED_MOUNTS}"
     )
 
 

--- a/tests/cli/test_index_directory_durability.py
+++ b/tests/cli/test_index_directory_durability.py
@@ -168,22 +168,50 @@ def test_a_filesystem_refusing_the_flush_does_not_fail_the_write(
 def test_a_refused_flush_clears_the_digest_instead_of_recording_one(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A digest may only be recorded for a rename known to be durable.
+    """A digest may only be recorded for a rename known to be durable, and the old one must go.
 
     Surviving the write is not the property that matters -- recording the digest anyway also survives,
-    which is why the assertion here is on the sidecar and not on the index. The digest describes a name
-    that may still be in the page cache; recording it bets the directory on that write reaching the
-    disk, and the test below replays the ordering where it does not.
-    """
-    _refuse_directory_fsync(monkeypatch)
+    which is why the assertion here is on the sidecar and not on the index.
 
+    The first write is flushed normally so a digest is actually **there** to be cleared. Without it,
+    this test starts from the empty sidecar the lock creates and cannot tell clearing from doing
+    nothing: a mutation that dropped the clear and kept only the warning passed.
+    """
+    update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
+    sidecar = tmp_path / "signal_index.yaml.lock"
+    assert sidecar.read_text().strip(), "the first write recorded no digest, so there is nothing to clear"
+
+    _refuse_directory_fsync(monkeypatch)
+    update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
+
+    assert sidecar.read_text().strip() == "", (
+        "the sidecar still holds a digest after an unflushed write. Either it describes the index this "
+        "update replaced -- wedging the next write against a good file -- or it describes a name that "
+        f"may not survive a crash: {sidecar.read_text()!r}"
+    )
+
+
+@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
+def test_the_next_write_after_an_unflushed_one_is_not_refused_as_stale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Keeping the previous digest wedges the directory with no crash involved at all.
+
+    This is the ordering that makes "just don't record it" wrong, and it needs no power loss: the
+    unflushed rename *does* land, so the sidecar's older digest now describes an index that has been
+    replaced. The next write reads a good index, finds it does not match, and raises
+    ``StaleIndexReadError`` -- permanently, since nothing advances the digest but a successful write.
+    """
     update_signal_index(tmp_path, _metadata(1, 0), "orchestration-0.metadata.json")
 
-    sidecar = tmp_path / "signal_index.yaml.lock"
-    assert sidecar.read_text().strip() == "", (
-        "a digest was recorded for a rename whose durability is unknown, which is the wedge this "
-        f"guards: {sidecar.read_text()!r}"
-    )
+    _refuse_directory_fsync(monkeypatch)
+    update_signal_index(tmp_path, _metadata(2, 1), "orchestration-1.metadata.json")
+    monkeypatch.undo()
+
+    update_signal_index(tmp_path, _metadata(3, 2), "orchestration-2.metadata.json")
+
+    index = yaml.safe_load((tmp_path / "signal_index.yaml").read_text())
+    assert sorted(index) == ["1", "2", "3"], f"the write after an unflushed one did not land: {sorted(index)}"
 
 
 @pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")

--- a/tests/cli/test_index_directory_durability.py
+++ b/tests/cli/test_index_directory_durability.py
@@ -66,7 +66,7 @@ def _forget_degraded_mounts(monkeypatch: pytest.MonkeyPatch) -> None:
     fixture rather than a call inside the refusal helper: doing it there is what hid the case where a
     mount recovers and degrades again, since every episode looked like the first.
     """
-    monkeypatch.setattr(simulate_utils, "_DEGRADED_MOUNTS", set())
+    monkeypatch.setattr(simulate_utils, "_DEGRADED_TARGETS", set())
 
 
 def _metadata(event_id: int, batch: int) -> dict[str, Any]:
@@ -304,7 +304,7 @@ def test_a_directory_that_cannot_be_opened_for_reading_is_a_refusal(tmp_path: Pa
         else:
             pytest.skip("this user can read a write-only directory, so the refusal cannot be produced")
 
-        assert simulate_utils._fsync_directory(metadata_directory) is simulate_utils._DirectoryFlush.REFUSED
+        assert simulate_utils._fsync_directory(metadata_directory) is simulate_utils._DirectoryFlush.UNREADABLE
     finally:
         metadata_directory.chmod(0o755)
 
@@ -386,9 +386,6 @@ def test_many_directories_on_one_refusing_filesystem_warn_once_between_them(
     assert len(refusals) == 1, (
         f"one refusing filesystem produced {len(refusals)} warnings across {len(directories)} directories"
     )
-    assert len(simulate_utils._DEGRADED_MOUNTS) == 1, (
-        f"the degraded-mount set grew per directory rather than per filesystem: {simulate_utils._DEGRADED_MOUNTS}"
-    )
 
 
 def test_an_unidentifiable_filesystem_still_warns(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
@@ -413,10 +410,60 @@ def test_an_unidentifiable_filesystem_still_warns(tmp_path: Path, caplog: pytest
             "signal_index.yaml.lock",
         )
 
+        # Twice, deliberately. One call warns under any suppression at all, so a single warning cannot
+        # tell "keyed as its own scope" from "warns every time"; the second call distinguishes them, and
+        # it does so through the log rather than by reading the private set.
+        simulate_utils._note_flush_outcome(
+            missing,
+            simulate_utils._DirectoryFlush.REFUSED,
+            missing / "signal_index.yaml",
+            "signal_index.yaml.lock",
+        )
+
     refusals = [r for r in caplog.records if "refused to flush the directory" in r.message]
-    assert len(refusals) == 1, f"the warning was lost with the device number: {len(refusals)}"
-    assert {None} == simulate_utils._DEGRADED_MOUNTS, (
-        f"an unidentifiable filesystem was not given a key of its own: {simulate_utils._DEGRADED_MOUNTS}"
+    assert len(refusals) == 1, f"expected one warning across two calls, got {len(refusals)}"
+
+
+@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
+def test_two_unreadable_directories_on_one_filesystem_each_warn(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A directory that cannot be opened is its own fault, not the filesystem's.
+
+    Both share ``st_dev``, so keying this by device reported the first and silently swallowed the
+    second -- and since the cause is that directory's own permissions, the operator never saw the repair
+    for it. A reviewer supplied the input. The mode is real rather than patched: root ignores it, so the
+    test skips instead of faking a refusal it cannot produce.
+    """
+    directories = [tmp_path / "run-a", tmp_path / "run-b"]
+    for directory in directories:
+        directory.mkdir()
+        directory.chmod(0o333)
+    try:
+        try:
+            os.close(os.open(directories[0], os.O_RDONLY | os.O_DIRECTORY))
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this user can read a write-only directory, so the refusal cannot be produced")
+
+        assert directories[0].stat().st_dev == directories[1].stat().st_dev, "the input needs one filesystem"
+
+        with caplog.at_level(logging.WARNING, logger="gwmock.cli.simulate_utils"):
+            for directory in directories:
+                simulate_utils._note_flush_outcome(
+                    directory,
+                    simulate_utils._fsync_directory(directory),
+                    directory / "signal_index.yaml",
+                    "signal_index.yaml.lock",
+                )
+    finally:
+        for directory in directories:
+            directory.chmod(0o755)
+
+    unreadable = [r for r in caplog.records if "could not be opened to flush" in r.message]
+    assert len(unreadable) == 2, (
+        f"two directories with their own permission problem produced {len(unreadable)} warnings"
     )
 
 

--- a/tests/cli/test_index_directory_durability.py
+++ b/tests/cli/test_index_directory_durability.py
@@ -59,8 +59,8 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.fixture(autouse=True)
-def _forget_degraded_mounts(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Give each test its own degraded-mount set.
+def _forget_degraded_targets(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give each test its own degraded-target set.
 
     Process state, so without this a test's first refusal is suppressed by an earlier test's. It is a
     fixture rather than a call inside the refusal helper: doing it there is what hid the case where a
@@ -284,7 +284,7 @@ def test_a_crash_losing_an_unflushed_rename_refuses_loudly_and_names_the_repair(
 
 
 @pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
-def test_a_directory_that_cannot_be_opened_for_reading_is_a_refusal(tmp_path: Path) -> None:
+def test_a_directory_that_cannot_be_opened_for_reading_is_unreadable(tmp_path: Path) -> None:
     """The ``os.open`` failure is a real input, not a defensive branch.
 
     A write-only metadata directory -- mode ``0o333`` -- accepts the ``os.replace`` that installs the
@@ -302,6 +302,10 @@ def test_a_directory_that_cannot_be_opened_for_reading_is_a_refusal(tmp_path: Pa
         except PermissionError:
             pass
         else:
+            # Root ignores the mode, so the branch genuinely cannot be reached and skipping is honest.
+            # The project's CI runs as a non-root user on ubuntu-latest and macos-latest, so this is
+            # exercised there -- but a root cell added to that matrix would make these tests vanish
+            # silently rather than fail.
             pytest.skip("this user can read a write-only directory, so the refusal cannot be produced")
 
         assert simulate_utils._fsync_directory(metadata_directory) is simulate_utils._DirectoryFlush.UNREADABLE
@@ -445,6 +449,10 @@ def test_two_unreadable_directories_on_one_filesystem_each_warn(
         except PermissionError:
             pass
         else:
+            # Root ignores the mode, so the branch genuinely cannot be reached and skipping is honest.
+            # The project's CI runs as a non-root user on ubuntu-latest and macos-latest, so this is
+            # exercised there -- but a root cell added to that matrix would make these tests vanish
+            # silently rather than fail.
             pytest.skip("this user can read a write-only directory, so the refusal cannot be produced")
 
         assert directories[0].stat().st_dev == directories[1].stat().st_dev, "the input needs one filesystem"
@@ -495,6 +503,10 @@ def test_a_directory_whose_permissions_are_fixed_and_broken_again_warns_again(
         except PermissionError:
             pass
         else:
+            # Root ignores the mode, so the branch genuinely cannot be reached and skipping is honest.
+            # The project's CI runs as a non-root user on ubuntu-latest and macos-latest, so this is
+            # exercised there -- but a root cell added to that matrix would make these tests vanish
+            # silently rather than fail.
             pytest.skip("this user can read a write-only directory, so the refusal cannot be produced")
 
         with caplog.at_level(logging.WARNING, logger="gwmock.cli.simulate_utils"):
@@ -508,6 +520,47 @@ def test_a_directory_whose_permissions_are_fixed_and_broken_again_warns_again(
 
     unreadable = [r for r in caplog.records if "could not be opened to flush" in r.message]
     assert len(unreadable) == 2, f"expected one warning per episode, got {len(unreadable)}"
+
+
+@pytest.mark.skipif(not hasattr(os, "O_DIRECTORY"), reason="directory fsync is POSIX-only")
+def test_one_relative_spelling_in_two_working_directories_is_two_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The directory key is the absolute path, because the same spelling can name different directories.
+
+    A reviewer supplied this: keyed on the string it was handed, ``Path("metadata")`` reached from two
+    working directories is one key, so the second directory's permission problem is suppressed and its
+    repair never shown. The reviewers disagreed on whether the CLI can reach it -- the other argued the
+    path passed in is stable, making duplication the only live direction -- and the disagreement is
+    resolved by fixing the key, since suppressing a warning is the direction that costs a repair.
+    """
+    for name in ("a", "b"):
+        (tmp_path / name / "metadata").mkdir(parents=True)
+        (tmp_path / name / "metadata").chmod(0o333)
+    try:
+        try:
+            os.close(os.open(tmp_path / "a" / "metadata", os.O_RDONLY | os.O_DIRECTORY))
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("this user can read a write-only directory, so the refusal cannot be produced")
+
+        with caplog.at_level(logging.WARNING, logger="gwmock.cli.simulate_utils"):
+            for name in ("a", "b"):
+                monkeypatch.chdir(tmp_path / name)
+                relative = Path("metadata")
+                simulate_utils._note_flush_outcome(
+                    relative,
+                    simulate_utils._fsync_directory(relative),
+                    relative / "signal_index.yaml",
+                    "signal_index.yaml.lock",
+                )
+    finally:
+        for name in ("a", "b"):
+            (tmp_path / name / "metadata").chmod(0o755)
+
+    unreadable = [r for r in caplog.records if "could not be opened to flush" in r.message]
+    assert len(unreadable) == 2, f"two directories sharing one relative spelling produced {len(unreadable)} warnings"
 
 
 def test_the_flush_is_skipped_where_the_platform_has_no_directory_open(


### PR DESCRIPTION
## 📝 Summary

`_atomically_write_index` fsynced the temporary's *contents* and then `os.replace`d it, but never
flushed the parent directory. `os.replace` is atomic with respect to readers; atomicity is not
durability, so the directory entry could still be in the page cache when `_record_digest` wrote the
sidecar. A crash in that window reboots to the previous index while the sidecar describes the new one,
and every later write then refuses as stale against a perfectly good file — by the function's own
docstring, a permanent wedge until an operator deletes the sidecar.

The directory is now flushed between the rename and the digest write. Where that flush cannot be
performed, the digest is still recorded and the degradation is reported:

- **The filesystem refuses `fsync` on a directory** (some network mounts): warned once per filesystem,
  stating that no repair exists on that mount and naming the alternative.
- **The directory cannot be opened for reading** (its own permissions, e.g. write-only): warned once
  per directory, stating the actual repair — make it readable; deleting the sidecar does not help,
  because the next write cannot flush it either.
- **The platform has no directory-flush primitive** (Windows): records and stays silent. A warning on
  every run about a gap the operator cannot close only buries the ones that can be acted on.

Both degraded states clear when a flush there succeeds, so a condition that ends and returns is
reported again.

Recording the digest regardless is deliberate. Withholding it leaves an empty sidecar, and an empty
sidecar is the permissive legacy path: a writer on another host with a stale cached view is accepted
and discards the entries it could not see — silent loss, no crash needed, on exactly the mounts this
guard exists for. The exposure that remains is a crash inside the unflushed window, which produces a
refusal against a good index: loud, and recoverable. A rare loud failure is worth keeping over a
routine silent one. On a refusing NFS mount that window lasts until the client sends the rename —
seconds, not instants — so the trade does not rest on the window being small.

No Windows `FlushFileBuffers` path is included: no host in this project can execute it, and untested
platform code that looks like protection is worse than a documented gap.

Tier: **T2** (behaviour).

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

## 🧪 How Has This Been Tested?

- [x] **Unit tests:** `uv run pytest` — **1140 passed** with the `jax` extra, **1098 passed** without it
      (CI's plain `uv sync --group dev` cell; `ripplegw` is the axis that differs, since `jax` itself is
      a base dependency of gwmock-pop).
- [x] **New tests:** `tests/cli/test_index_directory_durability.py` — 15 tests covering the flush
      ordering, both failure classifications, the digest policy under each outcome, the suppression
      scopes and their clearing, and the two crash-adjacent states (a stale cross-host reader still
      refused; a lost unflushed rename refusing loudly and naming the repair).
- [x] **Mutation testing:** 16 mutations of the changed logic, all killed by tests that name them.

The new tests state in their own docstrings that they pin the *mechanism* and cannot demonstrate
durability — that needs power loss or a crash-consistency harness. The crash tests replay the resulting
state, not the crash.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation — none needed; the behaviour is internal to
      index writing and surfaces only as operator warnings.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved index update reliability by ensuring committed digests are recorded even when directory durability checks are unavailable or refused.
  * Added recovery handling for stale reads and crash-related index states.
  * Improved warnings for degraded durability, avoiding repeated notifications while preserving separate filesystem and directory failure details.
* **Tests**
  * Expanded coverage for atomic writes, directory flushing, failure scenarios, stale data rejection, recovery messaging, and warning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->