### PR TITLE
fix(cli): cover the population file's content in the run's identity

### DIFF
--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -34,7 +34,13 @@ from gwmock_noise import SimulationResult
 from tqdm import tqdm
 
 from gwmock.cli.adapter_orchestration import AdapterOrchestrationResult, AdapterOrchestrator
-from gwmock.cli.utils.checkpoint import CheckpointManager, require_matching_config, run_fingerprint, spillover_applies
+from gwmock.cli.utils.checkpoint import (
+    CheckpointManager,
+    require_matching_config,
+    run_fingerprint,
+    spillover_applies,
+    warn_if_inputs_are_unverified,
+)
 from gwmock.cli.utils.config import OrchestrationConfig, SimulatorConfig, resolve_class_path
 from gwmock.cli.utils.environment import capture_environment
 from gwmock.cli.utils.hash import compute_content_hash, compute_file_hash
@@ -2042,11 +2048,12 @@ def execute_plan(  # noqa: PLR0915
     # swapping that file's bytes left this identity unchanged and a resume mixed two catalogues into one
     # run -- measured at batch 0 holding the old catalogue's event while batches 1 and 2 held the new
     # one's, exit code 0.
+    referenced_populations = _referenced_population_files(plan)
     plan_sha256 = run_fingerprint(
         [batch.config_sha256 for batch in plan.batches],
         output_directory,
         metadata_directory,
-        _referenced_population_files(plan),
+        referenced_populations,
     )
     if checkpoint:
         require_matching_config(checkpoint.get("config_sha256"), plan_sha256, checkpoint_manager.checkpoint_file)
@@ -2055,6 +2062,9 @@ def execute_plan(  # noqa: PLR0915
     # sends every resume down the "outputs are missing" branch.
     loaded_batch_indices = set(checkpoint.get("completed_batch_indices") or [])
     resuming = bool(loaded_batch_indices)
+    # Said on a resume, because that is when an unverifiable population can silently mix two catalogues:
+    # the fingerprints match whatever the bytes were, so this check is the only signal the operator gets.
+    warn_if_inputs_are_unverified(referenced_populations, resuming)
 
     # Reconcile the checkpoint against the filesystem: a batch may be recorded as
     # completed while its output is missing (partial write at interrupt, an external

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -36,10 +36,10 @@ from tqdm import tqdm
 from gwmock.cli.adapter_orchestration import AdapterOrchestrationResult, AdapterOrchestrator
 from gwmock.cli.utils.checkpoint import (
     CheckpointManager,
+    report_unverified_inputs,
     require_matching_config,
     run_fingerprint,
     spillover_applies,
-    warn_if_inputs_are_unverified,
 )
 from gwmock.cli.utils.config import OrchestrationConfig, SimulatorConfig, resolve_class_path
 from gwmock.cli.utils.environment import capture_environment
@@ -2064,7 +2064,7 @@ def execute_plan(  # noqa: PLR0915
     resuming = bool(loaded_batch_indices)
     # Said on a resume, because that is when an unverifiable population can silently mix two catalogues:
     # the fingerprints match whatever the bytes were, so this check is the only signal the operator gets.
-    warn_if_inputs_are_unverified(referenced_populations, resuming)
+    report_unverified_inputs(referenced_populations, resuming)
 
     # Reconcile the checkpoint against the filesystem: a batch may be recorded as
     # completed while its output is missing (partial write at interrupt, an external

--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -1877,6 +1877,27 @@ def _resolve_recorded_output_paths(metadata: dict[str, Any], working_directory: 
     return paths
 
 
+def _referenced_population_files(plan: SimulationPlan) -> list[str]:
+    """Every population source the plan's batches name, for the run's identity.
+
+    Read from each batch's own config rather than the first: a plan assembled from several metadata
+    records can name more than one catalogue, and taking one of them would let the rest change
+    unnoticed -- the same reasoning as hashing every batch's config rather than the first.
+
+    Only the population is collected. Other paths a config can reference are out of scope here, and
+    :func:`run_fingerprint` says so rather than implying they are covered.
+    """
+    references: list[str] = []
+    for batch in plan.batches:
+        population = getattr(batch.simulator_config, "population", None)
+        if population is None:
+            continue
+        source = (getattr(population, "arguments", None) or {}).get("path")
+        if source:
+            references.append(str(source))
+    return references
+
+
 def _batch_outputs_present(batch: SimulationBatch, metadata_directory: Path) -> bool | None:
     """Return whether the outputs recorded for ``batch`` all exist on disk.
 
@@ -2017,7 +2038,16 @@ def execute_plan(  # noqa: PLR0915
     # Not `batch.config_sha256` on its own: that hashes the config *file*, so the same file run with
     # a different `--output-dir` fingerprints identically and the guard waves it through -- measured
     # at 2 frames where a clean run writes 3. The identity has to include where the outputs go.
-    plan_sha256 = run_fingerprint([batch.config_sha256 for batch in plan.batches], output_directory, metadata_directory)
+    # The population file's *content*, not only its path: a config names its catalogue by name, so
+    # swapping that file's bytes left this identity unchanged and a resume mixed two catalogues into one
+    # run -- measured at batch 0 holding the old catalogue's event while batches 1 and 2 held the new
+    # one's, exit code 0.
+    plan_sha256 = run_fingerprint(
+        [batch.config_sha256 for batch in plan.batches],
+        output_directory,
+        metadata_directory,
+        _referenced_population_files(plan),
+    )
     if checkpoint:
         require_matching_config(checkpoint.get("config_sha256"), plan_sha256, checkpoint_manager.checkpoint_file)
     # A set, matching what `get_completed_batch_indices` returned: it is compared against

--- a/src/gwmock/cli/utils/checkpoint.py
+++ b/src/gwmock/cli/utils/checkpoint.py
@@ -123,8 +123,8 @@ def _input_digest(reference: str) -> str:
     A remote reference is a marker rather than a fetch: identifying the run is not worth downloading the
     catalogue twice. **This means remote populations get no content coverage at all** -- the marker adds
     nothing the config hash did not already carry, and a re-fetch that returns different bytes between an
-    interrupt and a resume is undetected. :func:`run_fingerprint` warns about that rather than implying
-    the gap is closed.
+    interrupt and a resume is undetected. :func:`report_unverified_inputs`, called from the resume path, says so at
+    ``INFO`` -- it cannot tell a pinned URL from a mutable one, so it informs rather than warns.
 
     An unreadable reference is a marker too, not an exception. This runs before the plan executes, so a
     population staged later or a path typo has to reach its own error rather than a traceback from the
@@ -136,10 +136,46 @@ def _input_digest(reference: str) -> str:
     path = Path(reference).expanduser()
     try:
         with path.open("rb") as handle:
-            return _digest_normalised(handle)
+            # Text normalisation on a binary catalogue is not harmless, it is a false negative: an HDF5
+            # dataset holding int8 13 (`\r`) and one holding 10 (`\n`) normalise to the same bytes, so two
+            # different populations hash identically and the resume they should refuse goes through. Found
+            # in review. Only what the loader parses as text is normalised; everything else is hashed raw.
+            if _is_text_catalogue(path):
+                return _digest_normalised(handle)
+            return _digest_raw(handle)
     except OSError as error:
         logger.debug("Could not hash the run input %s: %s", path, error)
         return "<unhashed>"
+
+
+# Suffixes the population loader parses as text. Mirrors `gwmock_pop`'s
+# `loaders.file_loader.infer_population_file_format`, which maps `.csv` to "csv" and `.hdf5`/`.h5` to
+# "hdf5". Duplicated rather than imported because it is private, and compared against it in the tests
+# whenever it can be imported -- the same arrangement as the URL predicate, for the same reason.
+_TEXT_CATALOGUE_SUFFIXES = frozenset({".csv"})
+
+
+def _is_text_catalogue(path: Path) -> bool:
+    """Whether the loader would parse *path* as text, and line endings therefore carry no content."""
+    return path.suffix.lower() in _TEXT_CATALOGUE_SUFFIXES
+
+
+def _digest_raw(handle: IO[bytes]) -> str:
+    """sha256 of *handle*'s bytes exactly as they are.
+
+    For a binary catalogue, where every byte is content and `\r`/`\n` are values rather than line
+    endings.
+
+    Args:
+        handle: An open binary handle positioned at the start.
+
+    Returns:
+        The hex digest of the bytes.
+    """
+    digest = hashlib.sha256()
+    for chunk in iter(lambda: handle.read(1 << 20), b""):
+        digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _digest_normalised(handle: IO[bytes]) -> str:
@@ -149,10 +185,14 @@ def _digest_normalised(handle: IO[bytes]) -> str:
     45 MB million-row file.
 
     Two normalisations, both aimed at the same false refusal: a machine regenerating a catalogue with
-    identical rows must not turn a resume away. ``\r\n`` and a lone ``\r`` both become ``\n``, and any
-    run of trailing newlines is dropped, so "no final newline", "one", and "three blank lines" agree.
+    identical rows must not turn a resume away. ``\r\n`` becomes ``\n``, and any run of trailing newlines
+    -- or a trailing ``\r`` -- is dropped, so "no final newline", "one", and "three blank lines" agree.
+    An *interior* lone ``\r`` is content and stays: inside a quoted field it is data, and collapsing it
+    would let two different catalogues hash alike.
     Nothing else is touched -- a reordered or reformatted catalogue is still a different input, which is
-    the safe direction and has its own test.
+    the safe direction and has its own test. And nothing at all is touched for a binary catalogue: this
+    runs only for the suffixes the loader parses as text, because in an HDF5 dataset `\r` and `\n` are
+    values.
 
     Two ways this was wrong before review caught them: the previous version's carry-byte loop never
     terminated on a file ending in a lone ``\r`` (the byte was re-prepended to an empty read forever,
@@ -181,7 +221,12 @@ def _digest_normalised(handle: IO[bytes]) -> str:
             chunk, split_carriage_return = chunk[:-1], b"\r"
         else:
             split_carriage_return = b""
-        chunk = pending + chunk.replace(b"\r", b"\n")
+        # Interior lone `\r` is left alone, deliberately: inside a quoted CSV field it is content, and
+        # rewriting it would make two different catalogues hash the same -- the false-negative direction,
+        # which is the one that matters. An earlier version of this rewrote every `\r` despite the round-2
+        # note saying it must not, and a reviewer caught the contradiction. The cost is that a
+        # classic-Mac-terminated file no longer matches its LF twin: a false refusal, the safe direction.
+        chunk = pending + chunk
         without_trailing_newlines = chunk.rstrip(b"\n")
         pending = chunk[len(without_trailing_newlines) :]
         digest.update(without_trailing_newlines)

--- a/src/gwmock/cli/utils/checkpoint.py
+++ b/src/gwmock/cli/utils/checkpoint.py
@@ -16,7 +16,12 @@ from gwmock.data.serialize.encoder import Encoder
 logger = logging.getLogger("gwmock")
 
 
-def run_fingerprint(config_hashes: Iterable[str | None], output_directory: Path, metadata_directory: Path) -> str:
+def run_fingerprint(
+    config_hashes: Iterable[str | None],
+    output_directory: Path,
+    metadata_directory: Path,
+    referenced_inputs: Iterable[Path | str] = (),
+) -> str:
     """Identify a run by everything that decides where its outputs go, not just its config file.
 
     The config file hash alone is not the run. Two invocations of the *same* file with different
@@ -38,11 +43,22 @@ def run_fingerprint(config_hashes: Iterable[str | None], output_directory: Path,
     reindenting changes it and a legitimate resume is turned away. Annoying, and the safe direction;
     ``--ignore-checkpoint`` is the way out.
 
-    *External inputs are invisible.* The same config file with a different population CSV behind it
-    fingerprints identically, so a resume can mix the old catalogue's completed batches with the new
-    one's remaining batches. This does not make anything worse than before -- nothing checked it
-    previously either -- but it is the sharp edge left in this guard, and hashing referenced inputs
-    is the fix if it ever bites.
+    **The population file is covered by content, not just by name.** A config names its catalogue by
+    path, so replacing that file's bytes left every part of this identity unchanged: the checkpoint was
+    accepted and the batches it recorded were skipped, giving one run some batches from the old
+    catalogue and the rest from the new one. Measured before fixing -- a 3-batch run interrupted after
+    the first batch and resumed over a rewritten CSV kept mass 30 in batch 0 while batches 1 and 2
+    carried 81 and 82, exit code 0. Hashing it costs 18 ms for a 45 MB million-row catalogue, against a
+    run measured in minutes.
+
+    *Remote inputs still are not covered.* A URL contributes the URL, because hashing it would mean
+    downloading the catalogue a second time purely to identify the run. The examples pin theirs to a
+    commit, which is the practical answer; a server that serves different bytes at one URL is not
+    detected here.
+
+    *Only the population file is covered*, deliberately -- the input this was found through. Other paths
+    a config can name (PSD files, waveform tables) remain invisible, and would need the same treatment
+    if one of them ever bites.
 
     Args:
         config_hashes: Per-batch ``config_sha256`` values, in plan order. ``None`` entries are kept
@@ -50,6 +66,12 @@ def run_fingerprint(config_hashes: Iterable[str | None], output_directory: Path,
             fingerprint the same as one without that batch.
         output_directory: Where this run writes its data.
         metadata_directory: Where this run writes its metadata and index.
+        referenced_inputs: Files whose *content* is part of this run's identity. Duplicates and order
+            are normalised away: every batch carries the population config, so a three-batch plan
+            presents the same path three times, and adding a batch must not change the input part of
+            the identity. A path that cannot be read contributes a marker naming it, which still
+            differs from the same path read successfully -- so a run that could not hash its input is
+            never mistaken for one that did.
 
     Returns:
         A hex digest identifying the run.
@@ -57,7 +79,38 @@ def run_fingerprint(config_hashes: Iterable[str | None], output_directory: Path,
     parts = [hash_value if hash_value is not None else "<none>" for hash_value in config_hashes]
     parts.append(str(Path(output_directory).resolve()))
     parts.append(str(Path(metadata_directory).resolve()))
+    # Sorted and de-duplicated, so the identity depends on which inputs a run reads and not on how many
+    # batches happen to name them.
+    for reference in sorted({str(reference) for reference in referenced_inputs}):
+        parts.append(f"{reference}={_input_digest(reference)}")
     return hashlib.sha256("\x00".join(parts).encode("utf-8")).hexdigest()
+
+
+def _input_digest(reference: str) -> str:
+    """Digest the bytes behind *reference*, or say why not.
+
+    A remote reference is left as a marker rather than fetched: identifying the run is not worth
+    downloading the catalogue twice, and the run's own fetch is where a content check would belong.
+
+    An unreadable one is a marker too, not an exception. This runs before the plan executes, so a
+    population staged later or a path typo has to reach its own error rather than a traceback from the
+    identity check -- and the marker still differs from a successful digest, so "could not hash" is
+    never confused with "hashed".
+    """
+    if "://" in reference:
+        return "<remote>"
+    path = Path(reference)
+    try:
+        with path.open("rb") as handle:
+            digest = hashlib.sha256()
+            # Chunked because a catalogue can be hundreds of megabytes; measured at ~2.5 GB/s, which is
+            # 18 ms for a 45 MB million-row file.
+            for chunk in iter(lambda: handle.read(1 << 20), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError as error:
+        logger.debug("Could not hash the run input %s: %s", path, error)
+        return "<unhashed>"
 
 
 class ForeignCheckpointError(RuntimeError):

--- a/src/gwmock/cli/utils/checkpoint.py
+++ b/src/gwmock/cli/utils/checkpoint.py
@@ -9,6 +9,7 @@ import logging
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from gwmock.data.serialize.decoder import Decoder
 from gwmock.data.serialize.encoder import Encoder
@@ -51,10 +52,15 @@ def run_fingerprint(
     carried 81 and 82, exit code 0. Hashing it costs 18 ms for a 45 MB million-row catalogue, against a
     run measured in minutes.
 
-    *Remote inputs still are not covered.* A URL contributes the URL, because hashing it would mean
-    downloading the catalogue a second time purely to identify the run. The examples pin theirs to a
-    commit, which is the practical answer; a server that serves different bytes at one URL is not
-    detected here.
+    **Remote inputs are not covered at all, and the marker is not coverage.** A URL contributes a fixed
+    marker, which adds nothing the config hash did not already carry: hashing the bytes would mean
+    downloading the catalogue a second time purely to identify the run, and hashing the loader's cache
+    would refuse every legitimate resume, because the first run computes this before any cache exists.
+    So a re-fetch that returns different bytes between an interrupt and a resume -- ``refresh: true``, a
+    cleared cache, a mutable URL -- mixes catalogues exactly as a local swap used to, undetected.
+    :func:`warn_if_inputs_are_unverified` says so at the point it matters instead of leaving the
+    docstring to carry it. Pinning the URL to an immutable revision, as the examples do, is the practical
+    answer.
 
     *Only the population file is covered*, deliberately -- the input this was found through. Other paths
     a config can name (PSD files, waveform tables) remain invisible, and would need the same treatment
@@ -86,31 +92,114 @@ def run_fingerprint(
     return hashlib.sha256("\x00".join(parts).encode("utf-8")).hexdigest()
 
 
+# Schemes the population loader fetches rather than opens. Mirrors `gwmock_pop`'s own predicate
+# (`loaders._fetch.is_population_url`) rather than testing for "://", which disagreed with it in both
+# directions: a relative path under a directory named `data:` is local to the loader and was remote
+# here, so its content went unhashed. Duplicated rather than imported because that helper is private;
+# `test_run_identity_covers_the_population_file.py` compares the two whenever it can be imported, so
+# drift is caught rather than assumed away.
+_REMOTE_SCHEMES = frozenset({"http", "https", "s3", "zenodo"})
+
+
+def _is_remote(reference: str) -> bool:
+    """Whether the population loader would fetch *reference* instead of opening it."""
+    return urlparse(reference).scheme.lower() in _REMOTE_SCHEMES
+
+
 def _input_digest(reference: str) -> str:
-    """Digest the bytes behind *reference*, or say why not.
+    """Digest the content behind *reference*, or say why not.
 
-    A remote reference is left as a marker rather than fetched: identifying the run is not worth
-    downloading the catalogue twice, and the run's own fetch is where a content check would belong.
+    ``~`` is expanded, because the loader expands it before reading. Without that, a config naming
+    ``~/population.csv`` failed to open here and recorded the same "could not hash" marker whatever the
+    file held -- so the guard silently did nothing for exactly the paths people write by hand. Found in
+    review, and the reason this function does not simply take a ``Path``.
 
-    An unreadable one is a marker too, not an exception. This runs before the plan executes, so a
+    Line endings are normalised and trailing blank lines dropped before hashing. The run consumes the
+    *parsed* catalogue, so a regenerated file that differs only in CRLF/LF or a trailing newline yields
+    an identical population -- and refusing that resume costs a long run for no reason. Population files
+    are machine-generated, so same-content regeneration is a normal workflow rather than a rare edit.
+    This is not full parsing: a reordered or reformatted CSV still refuses, which is the safe direction.
+
+    A remote reference is a marker rather than a fetch: identifying the run is not worth downloading the
+    catalogue twice. **This means remote populations get no content coverage at all** -- the marker adds
+    nothing the config hash did not already carry, and a re-fetch that returns different bytes between an
+    interrupt and a resume is undetected. :func:`run_fingerprint` warns about that rather than implying
+    the gap is closed.
+
+    An unreadable reference is a marker too, not an exception. This runs before the plan executes, so a
     population staged later or a path typo has to reach its own error rather than a traceback from the
-    identity check -- and the marker still differs from a successful digest, so "could not hash" is
-    never confused with "hashed".
+    identity check -- and the marker still differs from a successful digest, so "could not hash" is never
+    confused with "hashed".
     """
-    if "://" in reference:
+    if _is_remote(reference):
         return "<remote>"
-    path = Path(reference)
+    path = Path(reference).expanduser()
     try:
         with path.open("rb") as handle:
             digest = hashlib.sha256()
             # Chunked because a catalogue can be hundreds of megabytes; measured at ~2.5 GB/s, which is
-            # 18 ms for a 45 MB million-row file.
-            for chunk in iter(lambda: handle.read(1 << 20), b""):
-                digest.update(chunk)
+            # 18 ms for a 45 MB million-row file. Normalisation is per chunk boundary-safe because it
+            # only rewrites `\r\n` pairs, and a chunk is read at a 1 MiB boundary that can split one --
+            # so the tail byte is carried into the next chunk.
+            carry = b""
+            while True:
+                chunk = carry + handle.read(1 << 20)
+                if not chunk:
+                    break
+                carry = chunk[-1:] if chunk.endswith(b"\r") else b""
+                if carry:
+                    chunk = chunk[:-1]
+                digest.update(chunk.replace(b"\r\n", b"\n"))
+            if carry:
+                digest.update(carry.replace(b"\r", b"\n"))
         return digest.hexdigest()
     except OSError as error:
         logger.debug("Could not hash the run input %s: %s", path, error)
         return "<unhashed>"
+
+
+def warn_if_inputs_are_unverified(referenced_inputs: Iterable[Path | str], resuming: bool) -> None:
+    """Say, on a resume, which populations this run's identity could not actually verify.
+
+    The guard's value is that a resume across two catalogues stops. For a remote or unreadable
+    population it cannot: the digest is a marker, so the fingerprints match whatever the bytes were. That
+    is a gap an operator can act on -- pin the URL, or stage the file locally -- and a gap they cannot see
+    is indistinguishable from a guarantee.
+
+    Only on a resume, and only when something is actually unverified: a first run has nothing to be
+    inconsistent with, and warning on every clean run is how the message that matters gets ignored.
+
+    Args:
+        referenced_inputs: The population sources this run's identity was built from.
+        resuming: Whether a checkpoint is being resumed from.
+    """
+    if not resuming:
+        return
+    # A marker rather than a digest is the definition of "not verified". Comparing two calls of
+    # `_input_digest` would have been circular -- it is the same function, so it always agrees with
+    # itself; the first version of this did exactly that and could never warn.
+    unverified = sorted(
+        {str(reference) for reference in referenced_inputs if _is_marker(_input_digest(str(reference)))}
+    )
+    if not unverified:
+        return
+    logger.warning(
+        "This resume could not verify the population it is continuing from: %s. Their content is not part "
+        "of the run's identity -- a remote catalogue is not fetched to identify a run, and one that cannot "
+        "be read cannot be hashed -- so if those bytes changed since the interrupted run, this resume "
+        "mixes two catalogues and nothing here will refuse it. Pin a remote URL to an immutable revision, "
+        "or stage the catalogue locally, to get the check.",
+        ", ".join(unverified),
+    )
+
+
+def _is_marker(digest: str) -> bool:
+    """Whether :func:`_input_digest` gave up rather than hashing.
+
+    Markers are bracketed and a sha256 hex digest never is, so this cannot mistake one for the other --
+    which is also why the marker's exact spelling is not part of any contract.
+    """
+    return digest.startswith("<")
 
 
 class ForeignCheckpointError(RuntimeError):

--- a/src/gwmock/cli/utils/checkpoint.py
+++ b/src/gwmock/cli/utils/checkpoint.py
@@ -137,8 +137,13 @@ def _input_digest(reference: str) -> str:
     """
     if _is_remote(reference):
         return "<remote>"
-    path = Path(reference).expanduser()
+    path = Path(reference)
     try:
+        # Inside the try, and catching `RuntimeError`: `expanduser` raises that -- not `OSError` -- when
+        # the home directory cannot be resolved at all (no `HOME`, no passwd entry), which a container or
+        # a stripped service account can produce. Outside, it escaped and took the run down instead of
+        # degrading to a marker, which is the opposite of what every other failure here does.
+        path = path.expanduser()
         with path.open("rb") as handle:
             # Text normalisation on a binary catalogue is not harmless, it is a false negative: an HDF5
             # dataset holding int8 13 (`\r`) and one holding 10 (`\n`) normalise to the same bytes, so two
@@ -147,7 +152,7 @@ def _input_digest(reference: str) -> str:
             if _is_text_catalogue(path):
                 return _digest_normalised(handle)
             return _digest_raw(handle)
-    except OSError as error:
+    except (OSError, RuntimeError) as error:
         logger.debug("Could not hash the run input %s: %s", path, error)
         return "<unhashed>"
 

--- a/src/gwmock/cli/utils/checkpoint.py
+++ b/src/gwmock/cli/utils/checkpoint.py
@@ -8,7 +8,7 @@ import json
 import logging
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 from urllib.parse import urlparse
 
 from gwmock.data.serialize.decoder import Decoder
@@ -58,7 +58,7 @@ def run_fingerprint(
     would refuse every legitimate resume, because the first run computes this before any cache exists.
     So a re-fetch that returns different bytes between an interrupt and a resume -- ``refresh: true``, a
     cleared cache, a mutable URL -- mixes catalogues exactly as a local swap used to, undetected.
-    :func:`warn_if_inputs_are_unverified` says so at the point it matters instead of leaving the
+    :func:`report_unverified_inputs` says so at the point it matters instead of leaving the
     docstring to carry it. Pinning the URL to an immutable revision, as the examples do, is the practical
     answer.
 
@@ -136,38 +136,76 @@ def _input_digest(reference: str) -> str:
     path = Path(reference).expanduser()
     try:
         with path.open("rb") as handle:
-            digest = hashlib.sha256()
-            # Chunked because a catalogue can be hundreds of megabytes; measured at ~2.5 GB/s, which is
-            # 18 ms for a 45 MB million-row file. Normalisation is per chunk boundary-safe because it
-            # only rewrites `\r\n` pairs, and a chunk is read at a 1 MiB boundary that can split one --
-            # so the tail byte is carried into the next chunk.
-            carry = b""
-            while True:
-                chunk = carry + handle.read(1 << 20)
-                if not chunk:
-                    break
-                carry = chunk[-1:] if chunk.endswith(b"\r") else b""
-                if carry:
-                    chunk = chunk[:-1]
-                digest.update(chunk.replace(b"\r\n", b"\n"))
-            if carry:
-                digest.update(carry.replace(b"\r", b"\n"))
-        return digest.hexdigest()
+            return _digest_normalised(handle)
     except OSError as error:
         logger.debug("Could not hash the run input %s: %s", path, error)
         return "<unhashed>"
 
 
-def warn_if_inputs_are_unverified(referenced_inputs: Iterable[Path | str], resuming: bool) -> None:
-    """Say, on a resume, which populations this run's identity could not actually verify.
+def _digest_normalised(handle: IO[bytes]) -> str:
+    """sha256 of *handle*'s bytes with line endings unified and trailing newlines dropped.
 
-    The guard's value is that a resume across two catalogues stops. For a remote or unreadable
-    population it cannot: the digest is a marker, so the fingerprints match whatever the bytes were. That
-    is a gap an operator can act on -- pin the URL, or stage the file locally -- and a gap they cannot see
-    is indistinguishable from a guarantee.
+    Chunked because a catalogue can be hundreds of megabytes; measured at ~2.5 GB/s, which is 18 ms for a
+    45 MB million-row file.
 
-    Only on a resume, and only when something is actually unverified: a first run has nothing to be
-    inconsistent with, and warning on every clean run is how the message that matters gets ignored.
+    Two normalisations, both aimed at the same false refusal: a machine regenerating a catalogue with
+    identical rows must not turn a resume away. ``\r\n`` and a lone ``\r`` both become ``\n``, and any
+    run of trailing newlines is dropped, so "no final newline", "one", and "three blank lines" agree.
+    Nothing else is touched -- a reordered or reformatted catalogue is still a different input, which is
+    the safe direction and has its own test.
+
+    Two ways this was wrong before review caught them: the previous version's carry-byte loop never
+    terminated on a file ending in a lone ``\r`` (the byte was re-prepended to an empty read forever,
+    hanging the run), and the docstring claimed trailing blank lines were dropped while nothing dropped
+    them.
+
+    Args:
+        handle: An open binary handle positioned at the start.
+
+    Returns:
+        The hex digest of the normalised bytes.
+    """
+    digest = hashlib.sha256()
+    # Held back rather than hashed: a trailing newline run must vanish, but one in the middle must not,
+    # and only the next read can tell them apart.
+    pending = b""
+    # A `\r` at a chunk boundary may be the first half of a `\r\n`. Kept out of the digest until the next
+    # read resolves it -- and dropped at end of file, where it is a line terminator like any other.
+    split_carriage_return = b""
+    while True:
+        block = handle.read(1 << 20)
+        if not block:
+            break
+        chunk = (split_carriage_return + block).replace(b"\r\n", b"\n")
+        if chunk.endswith(b"\r"):
+            chunk, split_carriage_return = chunk[:-1], b"\r"
+        else:
+            split_carriage_return = b""
+        chunk = pending + chunk.replace(b"\r", b"\n")
+        without_trailing_newlines = chunk.rstrip(b"\n")
+        pending = chunk[len(without_trailing_newlines) :]
+        digest.update(without_trailing_newlines)
+    return digest.hexdigest()
+
+
+def report_unverified_inputs(referenced_inputs: Iterable[Path | str], resuming: bool) -> None:
+    """Say, on a resume, which populations this run's identity could not verify -- at two levels.
+
+    The guard's value is that a resume across two catalogues stops. Where the digest is a marker it
+    cannot: the fingerprints match whatever the bytes were. A gap an operator cannot see is
+    indistinguishable from a guarantee, so it is stated -- but the two kinds of gap deserve different
+    volumes, which a reviewer had to point out.
+
+    *A local file that could not be read* warns. It is specific, actionable, and unexpected: stage the
+    file, or fix its permissions, and the check works.
+
+    *A remote population* is logged at ``INFO``, which the CLI shows by default. This cannot distinguish a
+    commit-pinned URL -- the practical answer, and what the examples use -- from a mutable one, so at
+    ``WARNING`` it would fire on every remote resume including the ones where mixing cannot occur, and
+    following its own advice would not silence it. That is exactly how the message that matters gets
+    ignored, which this module already refuses to do elsewhere.
+
+    Only on a resume: a first run has nothing to be inconsistent with.
 
     Args:
         referenced_inputs: The population sources this run's identity was built from.
@@ -175,22 +213,31 @@ def warn_if_inputs_are_unverified(referenced_inputs: Iterable[Path | str], resum
     """
     if not resuming:
         return
-    # A marker rather than a digest is the definition of "not verified". Comparing two calls of
-    # `_input_digest` would have been circular -- it is the same function, so it always agrees with
-    # itself; the first version of this did exactly that and could never warn.
-    unverified = sorted(
-        {str(reference) for reference in referenced_inputs if _is_marker(_input_digest(str(reference)))}
+    remote = sorted({str(reference) for reference in referenced_inputs if _is_remote(str(reference))})
+    unreadable = sorted(
+        {
+            str(reference)
+            for reference in referenced_inputs
+            if not _is_remote(str(reference)) and _is_marker(_input_digest(str(reference)))
+        }
     )
-    if not unverified:
-        return
-    logger.warning(
-        "This resume could not verify the population it is continuing from: %s. Their content is not part "
-        "of the run's identity -- a remote catalogue is not fetched to identify a run, and one that cannot "
-        "be read cannot be hashed -- so if those bytes changed since the interrupted run, this resume "
-        "mixes two catalogues and nothing here will refuse it. Pin a remote URL to an immutable revision, "
-        "or stage the catalogue locally, to get the check.",
-        ", ".join(unverified),
-    )
+    if unreadable:
+        logger.warning(
+            "This resume could not read the population it is continuing from: %s. Its content is "
+            "therefore not part of the run's identity, so if those bytes changed since the interrupted "
+            "run, this resume mixes two catalogues and nothing here will refuse it. Stage the file, or fix "
+            "its permissions, to get the check.",
+            ", ".join(unreadable),
+        )
+    if remote:
+        logger.info(
+            "The population this run continues from is remote (%s), so its content is not part of the "
+            "run's identity -- identifying a run does not fetch the catalogue again. If that URL can serve "
+            "different bytes than the interrupted run received, this resume mixes two catalogues without "
+            "refusing. Pinning it to an immutable revision, as the examples do, removes the risk; this "
+            "message cannot tell a pinned URL from a mutable one, so it is said once per resume either way.",
+            ", ".join(remote),
+        )
 
 
 def _is_marker(digest: str) -> bool:

--- a/src/gwmock/cli/utils/checkpoint.py
+++ b/src/gwmock/cli/utils/checkpoint.py
@@ -114,11 +114,15 @@ def _input_digest(reference: str) -> str:
     file held -- so the guard silently did nothing for exactly the paths people write by hand. Found in
     review, and the reason this function does not simply take a ``Path``.
 
-    Line endings are normalised and trailing blank lines dropped before hashing. The run consumes the
-    *parsed* catalogue, so a regenerated file that differs only in CRLF/LF or a trailing newline yields
-    an identical population -- and refusing that resume costs a long run for no reason. Population files
-    are machine-generated, so same-content regeneration is a normal workflow rather than a rare edit.
-    This is not full parsing: a reordered or reformatted CSV still refuses, which is the safe direction.
+    **For a CSV**, line endings are normalised and trailing blank lines dropped before hashing. The run
+    consumes the *parsed* catalogue, so a regenerated file differing only in CRLF/LF or a trailing newline
+    yields an identical population -- and refusing that resume costs a long run for no reason. Population
+    files are machine-generated, so same-content regeneration is a normal workflow rather than a rare
+    edit. This is not full parsing: a reordered or reformatted CSV still refuses, the safe direction.
+
+    **For anything else** -- ``.hdf5``, ``.h5`` -- the bytes are hashed exactly as they are. In a binary
+    catalogue ``\r`` and ``\n`` are values, and normalising them made two different populations hash
+    alike, which is the failure this guard exists to prevent.
 
     A remote reference is a marker rather than a fetch: identifying the run is not worth downloading the
     catalogue twice. **This means remote populations get no content coverage at all** -- the marker adds

--- a/tests/cli/test_run_identity_covers_the_population_file.py
+++ b/tests/cli/test_run_identity_covers_the_population_file.py
@@ -513,3 +513,15 @@ class TestTheNormaliser:
         """
         filler = b"x" * ((1 << 20) - 1)
         assert self._digest(filler + b"\r\ntail\n") == self._digest(filler + b"\ntail\n")
+
+    def test_a_lone_carriage_return_at_a_chunk_boundary_is_not_swallowed(self) -> None:
+        """Carrying the boundary `\r` matters only when the next byte is not `\n` -- and then it matters.
+
+        Dropping it instead is invisible before a `\n`, because the pair collapses to one newline either
+        way: the previous test passes under that mutation. Before any other byte it deletes a line ending
+        outright, joining two rows into one, and two catalogues that differ by exactly that then hash the
+        same. Found by mutation, not by reading.
+        """
+        filler = b"x" * ((1 << 20) - 1)
+        assert self._digest(filler + b"\ra,b\n") == self._digest(filler + b"\na,b\n")
+        assert self._digest(filler + b"\ra,b\n") != self._digest(filler + b"a,b\n")

--- a/tests/cli/test_run_identity_covers_the_population_file.py
+++ b/tests/cli/test_run_identity_covers_the_population_file.py
@@ -1,0 +1,221 @@
+# Copyright (C) 2026 Leuven Gravity Institute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+"""A resume must not mix two population catalogues into one run.
+
+``run_fingerprint`` identified a run by its config *bytes* plus the resolved output and metadata
+directories. A config names its population by **path**, so replacing that file's content leaves every
+one of those inputs unchanged: the checkpoint is accepted, the batches it records are skipped, and the
+run ends up holding some batches generated from the old catalogue and the rest from the new one.
+
+**Measured before fixing**, with the CLI rather than this harness: a 3-batch run interrupted after the
+first batch, the population CSV rewritten at the same path, the identical command resumed. Batch 0 kept
+the old catalogue's event (detector-frame mass 30) while batches 1 and 2 carried the new one's (81, 82).
+Exit code 0, no warning. The resume said so in its own log -- "Loaded checkpoint: 1 batches already",
+"Skipping batch 0 (already completed from checkpoint)".
+
+Hashing the referenced file closes it. The cost was measured rather than assumed: 18 ms for a 45 MB
+one-million-row catalogue at ~2.5 GB/s, anchored against ``openssl speed -evp sha256`` reporting
+2.75 GB/s on the same host. Against a run measured in minutes, that is free.
+
+Scope is deliberately the population file alone -- the input this bug was found through -- not every
+path a config can name.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gwmock.cli import simulate_utils
+from gwmock.cli.simulate_utils import execute_plan
+from gwmock.cli.utils.checkpoint import ForeignCheckpointError, run_fingerprint
+from gwmock.cli.utils.config import GlobalsConfig, PopulationConfig, SimulatorConfig, SimulatorOutputConfig
+from gwmock.cli.utils.simulation_plan import SimulationBatch, SimulationPlan
+
+pytestmark = pytest.mark.unit
+
+CATALOGUE_HEADER = "detector_frame_mass_1,detector_frame_mass_2,coa_time,distance\n"
+OLD_CATALOGUE = CATALOGUE_HEADER + "30.0,25.0,1000000100.0,400.0\n"
+NEW_CATALOGUE = CATALOGUE_HEADER + "80.0,75.0,1000000100.0,400.0\n"
+
+
+def _plan(checkpoint_directory: Path, population_file: Path, batches: int = 3) -> SimulationPlan:
+    """A plan whose config names *population_file*, as a real orchestration config does."""
+    plan = SimulationPlan(checkpoint_directory=checkpoint_directory)
+    for index in range(batches):
+        plan.add_batch(
+            SimulationBatch(
+                simulator_name="mock",
+                simulator_config=SimulatorConfig(
+                    class_="tests.cli.test_cli_simulate.MockSimulator",
+                    arguments={"seed": 42},
+                    output=SimulatorOutputConfig(file_name=f"batch_{index}.json"),
+                    population=PopulationConfig(
+                        backend="FilePopulationLoader", arguments={"path": str(population_file)}
+                    ),
+                ),
+                globals_config=GlobalsConfig(),
+                batch_index=index,
+            )
+        )
+    return plan
+
+
+def test_swapping_the_population_behind_a_resume_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole point: a resume across two catalogues must stop rather than mix them.
+
+    The checkpoint is left behind by an **actually interrupted** run rather than hand-written, so the
+    value on disk is whatever the production code computes. Hand-writing it with the new signature made
+    this test fail on the unfixed code for the wrong reason -- a ``TypeError`` from an argument that did
+    not exist yet -- which proves nothing about the defect.
+
+    Fails on the unfixed code by *not raising*: the second run is waved through, batch 0 keeps the first
+    catalogue's output, and the rest are generated from the second.
+    """
+    output_directory, metadata_directory = tmp_path / "output", tmp_path / "metadata"
+    checkpoint_directory = tmp_path / "checkpoints"
+    population = tmp_path / "population.csv"
+    population.write_text(OLD_CATALOGUE)
+
+    # Fail the last batch, so the run stops with a checkpoint on disk instead of cleaning it up.
+    real_save = simulate_utils.save_metadata_record
+
+    def _fail_on_the_last_batch(*args, **kwargs):
+        record = args[0] if args else kwargs.get("record")
+        if "mock-2" in str(kwargs.get("metadata_file", "")) or "mock-2" in str(record):
+            raise RuntimeError("interrupted")
+        return real_save(*args, **kwargs)
+
+    monkeypatch.setattr(simulate_utils, "save_metadata_record", _fail_on_the_last_batch)
+    with pytest.raises(RuntimeError, match="interrupted"):
+        execute_plan(_plan(checkpoint_directory, population), output_directory, metadata_directory, overwrite=True)
+    monkeypatch.undo()
+
+    saved = json.loads((checkpoint_directory / "simulation.checkpoint.json").read_text())
+    assert saved.get("completed_batch_indices"), "the interrupted run left no completed batches to skip"
+
+    population.write_text(NEW_CATALOGUE)  # same path, same config bytes, different catalogue
+
+    with pytest.raises(ForeignCheckpointError):
+        execute_plan(_plan(checkpoint_directory, population), output_directory, metadata_directory, overwrite=True)
+
+
+class TestTheFingerprintItself:
+    """The identity function, at the level a future change is most likely to break it."""
+
+    def test_the_population_content_changes_it(self, tmp_path: Path) -> None:
+        """Same path, same config bytes, different bytes behind it: a different run."""
+        population = tmp_path / "population.csv"
+        population.write_text(OLD_CATALOGUE)
+        before = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [population])
+        population.write_text(NEW_CATALOGUE)
+        after = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [population])
+        assert before != after, "the catalogue behind the config was replaced and the run looked identical"
+
+    def test_identical_content_at_a_different_path_still_differs(self, tmp_path: Path) -> None:
+        """Content is added to the identity, not substituted for the path.
+
+        Two catalogues with the same bytes are still two inputs: the path is part of the config, and a
+        run that reads a different file is a different run even when today's bytes agree. Substituting
+        content for path would also make a *renamed* input invisible, which is caught today.
+        """
+        first, second = tmp_path / "a.csv", tmp_path / "b.csv"
+        first.write_text(OLD_CATALOGUE)
+        second.write_text(OLD_CATALOGUE)
+        assert run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [first]) != run_fingerprint(
+            ["a" * 64], tmp_path / "out", tmp_path / "meta", [second]
+        )
+
+    def test_a_missing_input_does_not_crash_the_run(self, tmp_path: Path) -> None:
+        """An unreadable or absent input is a marker, not an exception.
+
+        The fingerprint is computed before the run reads anything, and a population that does not exist
+        yet -- a remote URL, a path typo, a file staged later -- must reach its own error rather than a
+        traceback from the identity check. It still has to change the fingerprint, so a run that could
+        not hash its input is not mistaken for one that did.
+        """
+        missing = tmp_path / "not-there.csv"
+        unhashed = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [missing])
+        present = tmp_path / "population.csv"
+        present.write_text(OLD_CATALOGUE)
+        hashed = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [present])
+        assert unhashed != hashed
+        assert unhashed != run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [])
+
+    def test_a_remote_input_is_kept_as_its_url(self, tmp_path: Path) -> None:
+        """A URL cannot be hashed without fetching it, and this must not try.
+
+        The examples pin their population to an `https://` URL. Fetching here would download the
+        catalogue a second time purely to identify the run, so a remote input contributes its URL --
+        which the config bytes already cover -- and the gap is documented rather than papered over.
+        """
+        url = "https://example.invalid/bbh_population.csv"
+        assert run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [url]) == run_fingerprint(
+            ["a" * 64], tmp_path / "out", tmp_path / "meta", [url]
+        )
+        assert run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [url]) != run_fingerprint(
+            ["a" * 64], tmp_path / "out", tmp_path / "meta", ["https://example.invalid/other.csv"]
+        )
+
+    def test_the_order_of_inputs_does_not_invent_a_new_run(self, tmp_path: Path) -> None:
+        """Two batches naming the same file must not fingerprint differently from one that does.
+
+        Every batch carries the population config, so a plan of three batches presents the same path
+        three times. Left unnormalised, adding a batch would change the input part of the identity for a
+        reason that has nothing to do with the inputs.
+        """
+        population = tmp_path / "population.csv"
+        population.write_text(OLD_CATALOGUE)
+        once = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [population])
+        thrice = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [population] * 3)
+        assert once == thrice
+
+
+def test_the_recorded_fingerprint_is_what_the_next_run_compares(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The checkpoint stores the fingerprint that includes the input, not the bare config hash.
+
+    Without this the fix is inert in a way no other test here would catch: the identity could cover the
+    catalogue while the value written to disk, and therefore compared on resume, does not.
+
+    The run is interrupted rather than completed, because a successful run deletes its checkpoint -- the
+    first version of this test read a file that had just been cleaned up.
+    """
+    output_directory, metadata_directory = tmp_path / "output", tmp_path / "metadata"
+    checkpoint_directory = tmp_path / "checkpoints"
+    population = tmp_path / "population.csv"
+    population.write_text(OLD_CATALOGUE)
+    plan = _plan(checkpoint_directory, population)
+
+    real_save = simulate_utils.save_metadata_record
+
+    def _fail_on_the_last_batch(*args, **kwargs):
+        if "mock-2" in str(kwargs.get("metadata_file", "")) or "mock-2" in str(args[0] if args else ""):
+            raise RuntimeError("interrupted")
+        return real_save(*args, **kwargs)
+
+    monkeypatch.setattr(simulate_utils, "save_metadata_record", _fail_on_the_last_batch)
+    with pytest.raises(RuntimeError, match="interrupted"):
+        execute_plan(plan, output_directory, metadata_directory, overwrite=True)
+    monkeypatch.undo()
+
+    saved = json.loads((checkpoint_directory / "simulation.checkpoint.json").read_text())
+    with_the_input = run_fingerprint(
+        [batch.config_sha256 for batch in plan.batches], output_directory, metadata_directory, [population]
+    )
+    without_it = run_fingerprint([batch.config_sha256 for batch in plan.batches], output_directory, metadata_directory)
+    assert with_the_input != without_it, "the two fingerprints agree, so this test cannot discriminate"
+    assert saved.get("config_sha256") == with_the_input

--- a/tests/cli/test_run_identity_covers_the_population_file.py
+++ b/tests/cli/test_run_identity_covers_the_population_file.py
@@ -39,6 +39,7 @@ import logging
 import signal
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from gwmock.cli import simulate_utils
@@ -360,10 +361,13 @@ class TestWhatTheLoaderActuallyReads:
         assert run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [population]) != original
 
     def test_a_remote_resume_is_reported_but_not_warned_about(self, caplog: pytest.LogCaptureFixture) -> None:
-        """A remote population gets no content coverage, and the operator has to be told.
+        """A remote population gets no content coverage, and the operator is told at ``INFO``.
 
         The marker adds nothing the config hash already carried, so for a remote catalogue this guard
-        cannot refuse a mixed resume at all. Warning is the honest alternative to a docstring nobody reads.
+        cannot refuse a mixed resume at all. Saying so beats a docstring nobody reads -- but at ``INFO``,
+        not ``WARNING``: the check cannot tell a commit-pinned URL, where mixing cannot occur, from a
+        mutable one, and a warning on every remote resume would be unsilenceable by following its own
+        advice.
         """
         with caplog.at_level(logging.INFO, logger="gwmock"):
             checkpoint_utils.report_unverified_inputs(["https://example.invalid/pop.csv"], resuming=True)
@@ -375,7 +379,10 @@ class TestWhatTheLoaderActuallyReads:
         )
 
     def test_an_unreadable_population_warns_on_resume(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-        """An unreadable catalogue is as unverified as a remote one, and warns the same way.
+        """An unreadable catalogue is as unverified as a remote one, but it warns rather than informs.
+
+        The difference is actionability: staging the file or fixing its mode makes the check work, whereas
+        a remote URL has no local repair. Same reason the levels differ.
 
         This is what makes the marker's shape matter rather than cosmetic: a change that returned some
         other constant for the unreadable branch would leave the fingerprint working and the warning
@@ -399,7 +406,7 @@ class TestWhatTheLoaderActuallyReads:
 def test_a_real_resume_over_a_remote_population_reports_the_gap(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """The warning has to be reached by the resume, not merely exist.
+    """The report has to be reached by the resume, not merely exist.
 
     Every other test of it calls the function directly, so removing its one call site left them all
     passing -- the same way the fingerprint change itself could have been made inert. This drives an
@@ -552,10 +559,18 @@ class TestBinaryCatalogues:
         An HDF5 dataset holding int8 13 (`\r`) and one holding 10 (`\n`) are different populations, and the
         format-blind rewrite mapped them to the same bytes -- so the resume this guard exists to refuse
         went through. Suffixes the loader parses as text are normalised; everything else is hashed raw.
+
+        Written with ``h5py`` rather than a handmade byte string carrying an HDF signature: the first
+        version of this test did the latter, so it pinned suffix-based hashing while its docstring claimed
+        HDF5 datasets, and ``h5py`` could not have read what it produced.
         """
+        h5py = pytest.importorskip("h5py")
         first, second = tmp_path / "pop.h5", tmp_path / "other.h5"
-        first.write_bytes(b"\x89HDF\r\n\x1a\n" + bytes([13]))
-        second.write_bytes(b"\x89HDF\r\n\x1a\n" + bytes([10]))
+        for path, mass in ((first, 13), (second, 10)):
+            with h5py.File(path, "w") as handle:
+                handle.create_dataset("detector_frame_mass_1", data=np.array([mass], dtype=np.int8))
+
+        assert first.read_bytes() != second.read_bytes(), "the two catalogues are byte-identical on disk"
         assert checkpoint_utils._input_digest(str(first)) != checkpoint_utils._input_digest(str(second))
 
     def test_the_text_suffixes_match_what_the_loader_parses_as_text(self) -> None:

--- a/tests/cli/test_run_identity_covers_the_population_file.py
+++ b/tests/cli/test_run_identity_covers_the_population_file.py
@@ -396,7 +396,7 @@ class TestWhatTheLoaderActuallyReads:
         assert not [r for r in caplog.records if "not part of the run's identity" in r.message]
 
 
-def test_a_real_resume_over_a_remote_population_emits_the_warning(
+def test_a_real_resume_over_a_remote_population_reports_the_gap(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """The warning has to be reached by the resume, not merely exist.
@@ -466,7 +466,10 @@ class TestTheNormaliser:
             digest = self._digest(b"header\ra,b\r")
         finally:
             signal.setitimer(signal.ITIMER_REAL, 0)
-        assert digest == self._digest(b"header\na,b\n")
+        # Termination is the property under test. What that trailing `\r` *means* is the next assertion's
+        # business: it is a terminator, so dropping it agrees with the same file written without it --
+        # while the interior one stays content, which is why this is not compared to the all-LF form.
+        assert digest == self._digest(b"header\ra,b")
 
     @pytest.mark.parametrize(
         ("label", "data"),
@@ -475,8 +478,8 @@ class TestTheNormaliser:
             ("no trailing newline", b"header\na,b"),
             ("one trailing blank line", b"header\na,b\n\n"),
             ("three trailing blank lines", b"header\na,b\n\n\n\n"),
-            ("lone carriage returns", b"header\ra,b\r"),
             ("crlf with trailing blanks", b"header\r\na,b\r\n\r\n"),
+            ("a trailing lone carriage return", b"header\na,b\r"),
         ],
     )
     def test_forms_that_parse_alike_hash_alike(self, label: str, data: bytes) -> None:
@@ -495,6 +498,7 @@ class TestTheNormaliser:
             ("a blank line in the middle", b"header\n\na,b\n"),
             ("an added row", b"header\na,b\nc,d\n"),
             ("trailing spaces on a row", b"header\na,b  \n"),
+            ("an interior lone carriage return", b"header\ra,b\n"),
         ],
     )
     def test_content_changes_still_differ(self, label: str, data: bytes) -> None:
@@ -514,6 +518,16 @@ class TestTheNormaliser:
         filler = b"x" * ((1 << 20) - 1)
         assert self._digest(filler + b"\r\ntail\n") == self._digest(filler + b"\ntail\n")
 
+    def test_an_interior_lone_carriage_return_is_content_not_a_line_ending(self) -> None:
+        """Inside a quoted CSV field a `\r` is data, so collapsing it would hide a real difference.
+
+        Round 2's brief said this explicitly and round 3's code did it anyway -- every lone `\r` was
+        rewritten to `\n`, so a catalogue with `"a\rb"` in a field hashed the same as one with `"a\nb"`.
+        A reviewer caught the contradiction. The cost of not rewriting is that a classic-Mac-terminated
+        file no longer matches its LF twin, which refuses a resume rather than accepting a wrong one.
+        """
+        assert self._digest(b'header\n"a\rb",c\n') != self._digest(b'header\n"a\nb",c\n')
+
     def test_a_lone_carriage_return_at_a_chunk_boundary_is_not_swallowed(self) -> None:
         """Carrying the boundary `\r` matters only when the next byte is not `\n` -- and then it matters.
 
@@ -523,5 +537,32 @@ class TestTheNormaliser:
         same. Found by mutation, not by reading.
         """
         filler = b"x" * ((1 << 20) - 1)
-        assert self._digest(filler + b"\ra,b\n") == self._digest(filler + b"\na,b\n")
+        # The `\r` is content now, so it must survive the boundary rather than vanish -- dropping it
+        # would make this file identical to one with no separator there at all.
         assert self._digest(filler + b"\ra,b\n") != self._digest(filler + b"a,b\n")
+        assert self._digest(filler + b"\r\na,b\n") == self._digest(filler + b"\na,b\n")
+
+
+class TestBinaryCatalogues:
+    """Line-ending normalisation must not touch a format where those bytes are values."""
+
+    def test_two_hdf5_catalogues_differing_by_0x0d_versus_0x0a_do_not_hash_alike(self, tmp_path: Path) -> None:
+        """The false negative a reviewer found: text normalisation applied to a binary catalogue.
+
+        An HDF5 dataset holding int8 13 (`\r`) and one holding 10 (`\n`) are different populations, and the
+        format-blind rewrite mapped them to the same bytes -- so the resume this guard exists to refuse
+        went through. Suffixes the loader parses as text are normalised; everything else is hashed raw.
+        """
+        first, second = tmp_path / "pop.h5", tmp_path / "other.h5"
+        first.write_bytes(b"\x89HDF\r\n\x1a\n" + bytes([13]))
+        second.write_bytes(b"\x89HDF\r\n\x1a\n" + bytes([10]))
+        assert checkpoint_utils._input_digest(str(first)) != checkpoint_utils._input_digest(str(second))
+
+    def test_the_text_suffixes_match_what_the_loader_parses_as_text(self) -> None:
+        """Agreement with the loader, asserted rather than assumed -- as for the URL predicate."""
+        infer = pytest.importorskip("gwmock_pop.loaders.file_loader").infer_population_file_format
+        for suffix in (".csv", ".hdf5", ".h5"):
+            loader_treats_as_text = infer(Path(f"pop{suffix}")) == "csv"
+            assert checkpoint_utils._is_text_catalogue(Path(f"pop{suffix}")) is loader_treats_as_text, (
+                f"the identity and the loader disagree about {suffix}"
+            )

--- a/tests/cli/test_run_identity_covers_the_population_file.py
+++ b/tests/cli/test_run_identity_covers_the_population_file.py
@@ -33,8 +33,10 @@ path a config can name.
 
 from __future__ import annotations
 
+import io
 import json
 import logging
+import signal
 from pathlib import Path
 
 import pytest
@@ -166,7 +168,7 @@ class TestTheFingerprintItself:
         The marker's *bracketed shape* is load-bearing since the unverified-input warning was added --
         ``_is_marker`` distinguishes "gave up" from "hashed" by it -- so a mutation that returns some
         other constant now silences that warning rather than being harmless. That is pinned by
-        ``test_a_resume_says_it_could_not_verify_an_unreadable_population`` below. The exact spelling
+        ``test_an_unreadable_population_warns_on_resume`` below. The exact spelling
         still is not asserted, only that it is not mistakable for a digest.
         """
         missing = tmp_path / "not-there.csv"
@@ -357,36 +359,41 @@ class TestWhatTheLoaderActuallyReads:
         population.write_text(CATALOGUE_HEADER + "80.0,75.0,1000000200.0,400.0\n30.0,25.0,1000000100.0,400.0\n")
         assert run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [population]) != original
 
-    def test_a_resume_says_which_populations_it_could_not_verify(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_a_remote_resume_is_reported_but_not_warned_about(self, caplog: pytest.LogCaptureFixture) -> None:
         """A remote population gets no content coverage, and the operator has to be told.
 
         The marker adds nothing the config hash already carried, so for a remote catalogue this guard
         cannot refuse a mixed resume at all. Warning is the honest alternative to a docstring nobody reads.
         """
-        with caplog.at_level(logging.WARNING, logger="gwmock"):
-            checkpoint_utils.warn_if_inputs_are_unverified(["https://example.invalid/pop.csv"], resuming=True)
-        assert [r for r in caplog.records if "could not verify" in r.message], "a remote resume said nothing"
+        with caplog.at_level(logging.INFO, logger="gwmock"):
+            checkpoint_utils.report_unverified_inputs(["https://example.invalid/pop.csv"], resuming=True)
+        remote_notes = [r for r in caplog.records if "population this run continues from is remote" in r.message]
+        assert remote_notes, "a remote resume said nothing"
+        assert remote_notes[0].levelno == logging.INFO, (
+            "a remote population was reported at WARNING, which fires identically for a commit-pinned URL "
+            "where mixing cannot occur -- and following the advice would not silence it"
+        )
 
-    def test_a_resume_says_it_could_not_verify_an_unreadable_population(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_an_unreadable_population_warns_on_resume(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         """An unreadable catalogue is as unverified as a remote one, and warns the same way.
 
         This is what makes the marker's shape matter rather than cosmetic: a change that returned some
         other constant for the unreadable branch would leave the fingerprint working and the warning
         silently off, which no other test here would notice.
         """
-        with caplog.at_level(logging.WARNING, logger="gwmock"):
-            checkpoint_utils.warn_if_inputs_are_unverified([tmp_path / "never-staged.csv"], resuming=True)
-        assert [r for r in caplog.records if "could not verify" in r.message], (
-            "a resume over a population it could not read said nothing"
+        with caplog.at_level(logging.INFO, logger="gwmock"):
+            checkpoint_utils.report_unverified_inputs([tmp_path / "never-staged.csv"], resuming=True)
+        unreadable = [r for r in caplog.records if "could not read the population" in r.message]
+        assert unreadable, "a resume over a population it could not read said nothing"
+        assert unreadable[0].levelno == logging.WARNING, (
+            "an unreadable local file is specific and actionable, so it warns rather than informs"
         )
 
     def test_a_clean_first_run_says_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
         """Not on a first run, and not when everything is verifiable: warnings that always fire are noise."""
-        with caplog.at_level(logging.WARNING, logger="gwmock"):
-            checkpoint_utils.warn_if_inputs_are_unverified(["https://example.invalid/pop.csv"], resuming=False)
-        assert not [r for r in caplog.records if "could not verify" in r.message]
+        with caplog.at_level(logging.INFO, logger="gwmock"):
+            checkpoint_utils.report_unverified_inputs(["https://example.invalid/pop.csv"], resuming=False)
+        assert not [r for r in caplog.records if "not part of the run's identity" in r.message]
 
 
 def test_a_real_resume_over_a_remote_population_emits_the_warning(
@@ -432,9 +439,77 @@ def test_a_real_resume_over_a_remote_population_emits_the_warning(
         execute_plan(_plan_with_remote(), output_directory, metadata_directory, overwrite=True)
     monkeypatch.undo()
 
-    with caplog.at_level(logging.WARNING, logger="gwmock"):
+    with caplog.at_level(logging.INFO, logger="gwmock"):
         execute_plan(_plan_with_remote(), output_directory, metadata_directory, overwrite=True)
 
-    unverified = [r for r in caplog.records if "could not verify" in r.message]
-    assert unverified, "a resume over a remote population said nothing about the gap"
-    assert remote in unverified[0].message
+    reported = [r for r in caplog.records if "not part of the run's identity" in r.message]
+    assert reported, "a resume over a remote population said nothing about the gap"
+    assert remote in reported[0].message
+
+
+class TestTheNormaliser:
+    """The byte-level normalisation, including the two ways it was wrong before review."""
+
+    @staticmethod
+    def _digest(data: bytes) -> str:
+        return checkpoint_utils._digest_normalised(io.BytesIO(data))
+
+    def test_a_file_ending_in_a_lone_carriage_return_terminates(self) -> None:
+        """The first chunked version hung forever here, taking the whole run with it.
+
+        Its carry byte was re-prepended to an empty read on every pass, so the loop never reached its
+        break. A classic-Mac line ending, or a truncated CRLF write, is enough to produce it. The alarm
+        makes a regression fail in seconds instead of hanging the suite.
+        """
+        signal.setitimer(signal.ITIMER_REAL, 10)
+        try:
+            digest = self._digest(b"header\ra,b\r")
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+        assert digest == self._digest(b"header\na,b\n")
+
+    @pytest.mark.parametrize(
+        ("label", "data"),
+        [
+            ("crlf", b"header\r\na,b\r\n"),
+            ("no trailing newline", b"header\na,b"),
+            ("one trailing blank line", b"header\na,b\n\n"),
+            ("three trailing blank lines", b"header\na,b\n\n\n\n"),
+            ("lone carriage returns", b"header\ra,b\r"),
+            ("crlf with trailing blanks", b"header\r\na,b\r\n\r\n"),
+        ],
+    )
+    def test_forms_that_parse_alike_hash_alike(self, label: str, data: bytes) -> None:
+        """Every way a generator can end the same catalogue must resume, not refuse.
+
+        Both reviewers found the docstring claiming trailing blank lines were dropped while nothing
+        dropped them, so only the CRLF case was actually covered -- the "claims more than it does" class,
+        in the fix for it.
+        """
+        assert self._digest(data) == self._digest(b"header\na,b\n"), f"{label} refused a valid resume"
+
+    @pytest.mark.parametrize(
+        ("label", "data"),
+        [
+            ("reordered rows", b"header\nb,a\n"),
+            ("a blank line in the middle", b"header\n\na,b\n"),
+            ("an added row", b"header\na,b\nc,d\n"),
+            ("trailing spaces on a row", b"header\na,b  \n"),
+        ],
+    )
+    def test_content_changes_still_differ(self, label: str, data: bytes) -> None:
+        """The normalisation is line endings and trailing newlines only.
+
+        The boundary matters: widened into "parse and compare" this would stop detecting the swap the
+        whole change exists for. A blank line *inside* the file and trailing spaces on a row are kept
+        significant deliberately -- neither is a line-ending difference.
+        """
+        assert self._digest(data) != self._digest(b"header\na,b\n"), f"{label} was treated as the same input"
+
+    def test_a_split_carriage_return_across_a_chunk_boundary_is_still_one_line_ending(self) -> None:
+        """A `\r\n` straddling the 1 MiB read boundary must not become two line endings.
+
+        Chunked hashing is where this class of bug lives, and no small-file test can reach it.
+        """
+        filler = b"x" * ((1 << 20) - 1)
+        assert self._digest(filler + b"\r\ntail\n") == self._digest(filler + b"\ntail\n")

--- a/tests/cli/test_run_identity_covers_the_population_file.py
+++ b/tests/cli/test_run_identity_covers_the_population_file.py
@@ -40,6 +40,7 @@ import pytest
 
 from gwmock.cli import simulate_utils
 from gwmock.cli.simulate_utils import execute_plan
+from gwmock.cli.utils import checkpoint as checkpoint_utils
 from gwmock.cli.utils.checkpoint import ForeignCheckpointError, run_fingerprint
 from gwmock.cli.utils.config import GlobalsConfig, PopulationConfig, SimulatorConfig, SimulatorOutputConfig
 from gwmock.cli.utils.simulation_plan import SimulationBatch, SimulationPlan
@@ -138,6 +139,21 @@ class TestTheFingerprintItself:
             ["a" * 64], tmp_path / "out", tmp_path / "meta", [second]
         )
 
+    def test_a_remote_input_is_never_read_from_disk(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A URL must not reach the filesystem, which is what "kept as its URL" has to mean.
+
+        Comparing two URLs' fingerprints does not show this: with the remote branch removed, a URL falls
+        through to a failed ``open`` and gets a marker, and because the reference string is part of the
+        key the two fingerprints still differ. The assertion has to be that no file access happens --
+        that mutation survived every other test here.
+        """
+
+        def _explode(*args, **kwargs):
+            raise AssertionError("a remote reference was opened as a local path")
+
+        monkeypatch.setattr(Path, "open", _explode)
+        assert checkpoint_utils._input_digest("https://example.invalid/bbh_population.csv") == "<remote>"
+
     def test_a_missing_input_does_not_crash_the_run(self, tmp_path: Path) -> None:
         """An unreadable or absent input is a marker, not an exception.
 
@@ -145,6 +161,12 @@ class TestTheFingerprintItself:
         yet -- a remote URL, a path typo, a file staged later -- must reach its own error rather than a
         traceback from the identity check. It still has to change the fingerprint, so a run that could
         not hash its input is not mistaken for one that did.
+
+        The marker's literal spelling is deliberately not asserted. Changing ``"<unhashed>"`` to any
+        other non-digest constant is semantically null -- no sha256 output is the empty string, or any
+        other short literal -- so a mutation that swaps it survives on purpose rather than for want of a
+        test. What matters, and is asserted, is that it differs from a real digest and from contributing
+        nothing at all.
         """
         missing = tmp_path / "not-there.csv"
         unhashed = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [missing])
@@ -219,3 +241,46 @@ def test_the_recorded_fingerprint_is_what_the_next_run_compares(
     without_it = run_fingerprint([batch.config_sha256 for batch in plan.batches], output_directory, metadata_directory)
     assert with_the_input != without_it, "the two fingerprints agree, so this test cannot discriminate"
     assert saved.get("config_sha256") == with_the_input
+
+
+def test_every_batch_s_population_counts_not_only_the_first(tmp_path: Path) -> None:
+    """A plan can name more than one catalogue, and each one is part of the run's identity.
+
+    Every batch in the earlier tests names the same file, so a change that hashed only the first batch's
+    population passed all of them. A plan assembled from several metadata records is the real case --
+    the same reasoning the config-hash side already documents.
+    """
+    first, second = tmp_path / "first.csv", tmp_path / "second.csv"
+    first.write_text(OLD_CATALOGUE)
+    second.write_text(OLD_CATALOGUE)
+
+    before = run_fingerprint(["a" * 64, "b" * 64], tmp_path / "out", tmp_path / "meta", [first, second])
+    second.write_text(NEW_CATALOGUE)  # the *second* batch's catalogue changes
+    after = run_fingerprint(["a" * 64, "b" * 64], tmp_path / "out", tmp_path / "meta", [first, second])
+
+    assert before != after, "a later batch's catalogue was replaced and the run looked identical"
+
+
+def test_the_plan_s_populations_are_collected_from_every_batch(tmp_path: Path) -> None:
+    """The collector itself, since the fingerprint cannot see a path the collector dropped."""
+    first, second = tmp_path / "first.csv", tmp_path / "second.csv"
+    first.write_text(OLD_CATALOGUE)
+    second.write_text(NEW_CATALOGUE)
+    plan = _plan(tmp_path / "checkpoints", first, batches=1)
+    plan.add_batch(
+        SimulationBatch(
+            simulator_name="mock",
+            simulator_config=SimulatorConfig(
+                class_="tests.cli.test_cli_simulate.MockSimulator",
+                arguments={"seed": 42},
+                output=SimulatorOutputConfig(file_name="batch_1.json"),
+                population=PopulationConfig(backend="FilePopulationLoader", arguments={"path": str(second)}),
+            ),
+            globals_config=GlobalsConfig(),
+            batch_index=1,
+        )
+    )
+
+    collected = simulate_utils._referenced_population_files(plan)
+
+    assert collected == [str(first), str(second)], f"a batch's population was dropped: {collected}"

--- a/tests/cli/test_run_identity_covers_the_population_file.py
+++ b/tests/cli/test_run_identity_covers_the_population_file.py
@@ -466,13 +466,20 @@ class TestTheNormaliser:
 
         Its carry byte was re-prepended to an empty read on every pass, so the loop never reached its
         break. A classic-Mac line ending, or a truncated CRLF write, is enough to produce it. The alarm
-        makes a regression fail in seconds instead of hanging the suite.
+        makes a regression fail in seconds instead of hanging the suite -- as a reported assertion, via an
+        installed handler, because `SIGALRM`'s default action would kill the session with no report at all.
         """
+
+        def _give_up(signum: int, frame: object) -> None:
+            raise AssertionError("the normaliser did not terminate")
+
+        previous = signal.signal(signal.SIGALRM, _give_up)
         signal.setitimer(signal.ITIMER_REAL, 10)
         try:
             digest = self._digest(b"header\ra,b\r")
         finally:
             signal.setitimer(signal.ITIMER_REAL, 0)
+            signal.signal(signal.SIGALRM, previous)
         # Termination is the property under test. What that trailing `\r` *means* is the next assertion's
         # business: it is a terminator, so dropping it agrees with the same file written without it --
         # while the interior one stays content, which is why this is not compared to the all-LF form.
@@ -581,3 +588,19 @@ class TestBinaryCatalogues:
             assert checkpoint_utils._is_text_catalogue(Path(f"pop{suffix}")) is loader_treats_as_text, (
                 f"the identity and the loader disagree about {suffix}"
             )
+
+
+def test_an_unresolvable_home_directory_degrades_instead_of_crashing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`expanduser` raises `RuntimeError`, which is not an `OSError`, and must not escape.
+
+    A container or a stripped service account with no `HOME` and no passwd entry makes `Path.expanduser`
+    raise. It was called outside the guarded block, so instead of degrading to a marker like every other
+    failure here, it took the whole run down. An automated reviewer caught it.
+    """
+
+    def _no_home(self: Path) -> Path:
+        raise RuntimeError("Could not determine home directory.")
+
+    monkeypatch.setattr(Path, "expanduser", _no_home)
+
+    assert checkpoint_utils._input_digest("~/population.csv") == "<unhashed>"

--- a/tests/cli/test_run_identity_covers_the_population_file.py
+++ b/tests/cli/test_run_identity_covers_the_population_file.py
@@ -34,6 +34,7 @@ path a config can name.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -162,11 +163,11 @@ class TestTheFingerprintItself:
         traceback from the identity check. It still has to change the fingerprint, so a run that could
         not hash its input is not mistaken for one that did.
 
-        The marker's literal spelling is deliberately not asserted. Changing ``"<unhashed>"`` to any
-        other non-digest constant is semantically null -- no sha256 output is the empty string, or any
-        other short literal -- so a mutation that swaps it survives on purpose rather than for want of a
-        test. What matters, and is asserted, is that it differs from a real digest and from contributing
-        nothing at all.
+        The marker's *bracketed shape* is load-bearing since the unverified-input warning was added --
+        ``_is_marker`` distinguishes "gave up" from "hashed" by it -- so a mutation that returns some
+        other constant now silences that warning rather than being harmless. That is pinned by
+        ``test_a_resume_says_it_could_not_verify_an_unreadable_population`` below. The exact spelling
+        still is not asserted, only that it is not mistakable for a digest.
         """
         missing = tmp_path / "not-there.csv"
         unhashed = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [missing])
@@ -284,3 +285,105 @@ def test_the_plan_s_populations_are_collected_from_every_batch(tmp_path: Path) -
     collected = simulate_utils._referenced_population_files(plan)
 
     assert collected == [str(first), str(second)], f"a batch's population was dropped: {collected}"
+
+
+class TestWhatTheLoaderActuallyReads:
+    """Findings from review: the identity has to follow the loader, not a plausible guess at it."""
+
+    def test_a_tilde_path_is_expanded_before_hashing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The live false negative: a hand-written `~/...` path silently verified nothing.
+
+        The loader expands `~` before reading. This did not, so the open failed, the same marker was
+        recorded whatever the file held, and the guard did nothing for exactly the paths people type.
+        """
+        monkeypatch.setenv("HOME", str(tmp_path))
+        population = tmp_path / "population.csv"
+        population.write_text(OLD_CATALOGUE)
+
+        before = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", ["~/population.csv"])
+        population.write_text(NEW_CATALOGUE)
+        after = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", ["~/population.csv"])
+
+        assert before != after, "a `~` path was never opened, so the catalogue behind it was never checked"
+
+    def test_the_remote_predicate_agrees_with_the_loader(self) -> None:
+        """Drift between our scheme test and the loader's is the defect, so compare them directly.
+
+        Skipped rather than replicated if the loader's helper moves: this asserts agreement, and an
+        assertion against an import that no longer exists would fail for the wrong reason.
+        """
+        loader_predicate = pytest.importorskip("gwmock_pop.loaders._fetch").is_population_url
+        for reference in (
+            "https://example.invalid/pop.csv",
+            "http://example.invalid/pop.csv",
+            "s3://bucket/pop.csv",
+            "zenodo://12345/pop.csv",
+            "data://pop.csv",  # a directory literally named `data:` -- local to the loader
+            "file:///tmp/pop.csv",
+            "ftp://example.invalid/pop.csv",
+            "/absolute/pop.csv",
+            "relative/pop.csv",
+            "~/pop.csv",
+        ):
+            assert checkpoint_utils._is_remote(reference) is bool(loader_predicate(reference)), (
+                f"the identity and the loader disagree about {reference!r}"
+            )
+
+    def test_a_regenerated_catalogue_with_different_line_endings_still_resumes(self, tmp_path: Path) -> None:
+        """The run consumes the parsed catalogue, so byte-identical parses must not refuse a resume.
+
+        Verified in review: a trailing newline, a blank line, or CRLF/LF each changed the fingerprint while
+        the parsed catalogue was identical. Population files are machine-generated, so a same-content
+        regeneration is a normal workflow -- and refusing it costs a long run for nothing.
+        """
+        population = tmp_path / "population.csv"
+        population.write_text(OLD_CATALOGUE)
+        original = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [population])
+
+        population.write_bytes(OLD_CATALOGUE.replace("\n", "\r\n").encode())
+        assert run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [population]) == original, (
+            "the same catalogue rewritten with CRLF line endings refused the resume"
+        )
+
+    def test_a_reordered_catalogue_still_refuses(self, tmp_path: Path) -> None:
+        """The normalisation is line endings only, and must not become "parse it and compare".
+
+        A reordered or reformatted catalogue is a different input as far as this guard is concerned --
+        the safe direction, and the boundary the previous test could otherwise be widened past.
+        """
+        population = tmp_path / "population.csv"
+        population.write_text(CATALOGUE_HEADER + "30.0,25.0,1000000100.0,400.0\n80.0,75.0,1000000200.0,400.0\n")
+        original = run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [population])
+        population.write_text(CATALOGUE_HEADER + "80.0,75.0,1000000200.0,400.0\n30.0,25.0,1000000100.0,400.0\n")
+        assert run_fingerprint(["a" * 64], tmp_path / "out", tmp_path / "meta", [population]) != original
+
+    def test_a_resume_says_which_populations_it_could_not_verify(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A remote population gets no content coverage, and the operator has to be told.
+
+        The marker adds nothing the config hash already carried, so for a remote catalogue this guard
+        cannot refuse a mixed resume at all. Warning is the honest alternative to a docstring nobody reads.
+        """
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            checkpoint_utils.warn_if_inputs_are_unverified(["https://example.invalid/pop.csv"], resuming=True)
+        assert [r for r in caplog.records if "could not verify" in r.message], "a remote resume said nothing"
+
+    def test_a_resume_says_it_could_not_verify_an_unreadable_population(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An unreadable catalogue is as unverified as a remote one, and warns the same way.
+
+        This is what makes the marker's shape matter rather than cosmetic: a change that returned some
+        other constant for the unreadable branch would leave the fingerprint working and the warning
+        silently off, which no other test here would notice.
+        """
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            checkpoint_utils.warn_if_inputs_are_unverified([tmp_path / "never-staged.csv"], resuming=True)
+        assert [r for r in caplog.records if "could not verify" in r.message], (
+            "a resume over a population it could not read said nothing"
+        )
+
+    def test_a_clean_first_run_says_nothing(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Not on a first run, and not when everything is verifiable: warnings that always fire are noise."""
+        with caplog.at_level(logging.WARNING, logger="gwmock"):
+            checkpoint_utils.warn_if_inputs_are_unverified(["https://example.invalid/pop.csv"], resuming=False)
+        assert not [r for r in caplog.records if "could not verify" in r.message]

--- a/tests/cli/test_run_identity_covers_the_population_file.py
+++ b/tests/cli/test_run_identity_covers_the_population_file.py
@@ -387,3 +387,54 @@ class TestWhatTheLoaderActuallyReads:
         with caplog.at_level(logging.WARNING, logger="gwmock"):
             checkpoint_utils.warn_if_inputs_are_unverified(["https://example.invalid/pop.csv"], resuming=False)
         assert not [r for r in caplog.records if "could not verify" in r.message]
+
+
+def test_a_real_resume_over_a_remote_population_emits_the_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The warning has to be reached by the resume, not merely exist.
+
+    Every other test of it calls the function directly, so removing its one call site left them all
+    passing -- the same way the fingerprint change itself could have been made inert. This drives an
+    actual interrupted run and resume, with a population the identity cannot verify.
+    """
+    output_directory, metadata_directory = tmp_path / "output", tmp_path / "metadata"
+    checkpoint_directory = tmp_path / "checkpoints"
+    remote = "https://example.invalid/bbh_population.csv"
+
+    def _plan_with_remote() -> SimulationPlan:
+        plan = SimulationPlan(checkpoint_directory=checkpoint_directory)
+        for index in range(3):
+            plan.add_batch(
+                SimulationBatch(
+                    simulator_name="mock",
+                    simulator_config=SimulatorConfig(
+                        class_="tests.cli.test_cli_simulate.MockSimulator",
+                        arguments={"seed": 42},
+                        output=SimulatorOutputConfig(file_name=f"batch_{index}.json"),
+                        population=PopulationConfig(backend="FilePopulationLoader", arguments={"path": remote}),
+                    ),
+                    globals_config=GlobalsConfig(),
+                    batch_index=index,
+                )
+            )
+        return plan
+
+    real_save = simulate_utils.save_metadata_record
+
+    def _fail_on_the_last_batch(*args, **kwargs):
+        if "mock-2" in str(kwargs.get("metadata_file", "")) or "mock-2" in str(args[0] if args else ""):
+            raise RuntimeError("interrupted")
+        return real_save(*args, **kwargs)
+
+    monkeypatch.setattr(simulate_utils, "save_metadata_record", _fail_on_the_last_batch)
+    with pytest.raises(RuntimeError, match="interrupted"):
+        execute_plan(_plan_with_remote(), output_directory, metadata_directory, overwrite=True)
+    monkeypatch.undo()
+
+    with caplog.at_level(logging.WARNING, logger="gwmock"):
+        execute_plan(_plan_with_remote(), output_directory, metadata_directory, overwrite=True)
+
+    unverified = [r for r in caplog.records if "could not verify" in r.message]
+    assert unverified, "a resume over a remote population said nothing about the gap"
+    assert remote in unverified[0].message


### PR DESCRIPTION
## 📝 Summary

`run_fingerprint` identified a run by its config *bytes* plus the resolved output and metadata
directories. A config names its population catalogue by **path**, so rewriting that file changed none of
them: a checkpoint was accepted, the batches it recorded were skipped, and one run ended up holding some
batches generated from the old catalogue and the rest from the new one.

Measured before fixing, through the CLI: a 3-batch run interrupted after the first batch, the CSV
rewritten at the same path, the identical command resumed. Batch 0 kept the old catalogue's event
(detector-frame mass 30) while batches 1 and 2 carried the new one's (81, 82). **Exit code 0, no
warning.** The resume said so in its own log — `Loaded checkpoint: 1 batches already` → `Skipping batch
0`. Against this change the same reproduction refuses with `ForeignCheckpointError` and only the first
catalogue remains on disk.

The fingerprint now includes a digest of each population file the plan's batches name, de-duplicated and
sorted so adding a batch does not change the input part of the identity.

**What is hashed depends on what the loader parses.** For a `.csv`, line endings are unified and trailing
blank lines dropped: the run consumes the *parsed* catalogue, population files are machine-generated, and
a regeneration differing only in CRLF/LF would otherwise refuse a resume whose output is identical. An
interior lone `\r` is left as content — inside a quoted field it is data. For `.hdf5`/`.h5` the bytes are
hashed exactly as they are, because there `\r` and `\n` are values, not line endings. The suffix set
mirrors `gwmock_pop.loaders.file_loader.infer_population_file_format`, and a test asserts agreement with
it whenever that helper can be imported.

**Two gaps are reported rather than closed.** A remote population is not fetched to identify a run, so
its content is not covered; `report_unverified_inputs` says so on a resume at `INFO`, naming the
catalogue and the remedy. It is `INFO` and not `WARNING` deliberately: the check cannot distinguish a
commit-pinned URL — where mixing cannot occur, and what the examples use — from a mutable one, so warning
would fire on every remote resume with no way to silence it by following its own advice. An unreadable
local file *does* warn, because staging it or fixing its mode makes the check work.

Scope is the population file only. Other paths a config can name (PSD files, waveform tables) remain
uncovered, and the docstring says so instead of implying otherwise.

Tier: **T2** (behaviour).

## ✨ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

## 🧪 How Has This Been Tested?

- [x] **Unit tests:** `uv run pytest` — **1176 passed** with the `jax` extra, **1134 passed** without it
      (CI's plain `uv sync --group dev` cell).
- [x] **Regression test confirmed failing on the unfixed code**, for the defect: `DID NOT RAISE
      ForeignCheckpointError`. It derives its checkpoint from a genuinely interrupted run rather than a
      hand-written one — the first version failed with a `TypeError` from an argument that did not exist
      yet, which proves nothing.
- [x] **New tests:** `tests/cli/test_run_identity_covers_the_population_file.py` — 35 tests covering the
      resume refusal, the fingerprint's inputs, `~` expansion, the URL predicate's agreement with the
      loader, the text/binary split, every line-ending form that parses alike, the content changes that
      must still differ, the chunk-boundary cases, and both report levels.
- [x] **Mutation testing:** 17 mutations of the changed logic, all killed.

**Cost, since this is on every run's critical path:** 18 ms for a 45 MB (one-million-row) catalogue,
≈2.5 GB/s, anchored against `openssl speed -evp sha256` reporting 2.75 GB/s on the same host. That is a
local-SSD, CPU-bound figure; on a shared cluster filesystem a cold read of that file is I/O-bound and
plausibly ~1 s. Negligible either way against a run measured in minutes.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation — none needed; the behaviour surfaces as a
      refused resume and two log lines.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Checkpoint resuming now detects changes to referenced population files and prevents unsafe resume operations.
  * Equivalent CSV formatting changes, such as line-ending differences, no longer cause unnecessary checkpoint mismatches.
  * Resume operations now clearly report inputs that cannot be verified, including remote or unreadable files.
  * Run identity tracking now handles multiple population inputs, binary files, and reordered data consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->