### PR TITLE
docs(cli): correct two stale comments in the index-durability code

### DIFF
--- a/src/gwmock/cli/simulate_utils.py
+++ b/src/gwmock/cli/simulate_utils.py
@@ -1033,10 +1033,17 @@ def _atomically_write_index(index_file: Path, index: dict[str, Any]) -> _Committ
 # success already covers the case where the new mount works. Accepted, and recorded here rather than
 # left for the next reader to rediscover.
 #
-# Not synchronised. Every production caller holds the index's `flock`, the writer is a sequential
-# batch loop, and the resource-monitor thread never touches it; the check-then-add is formally racy
-# but a 64-thread stress probe produced exactly one warning, and the worst case is a duplicated or
-# missing *warning*, never a correctness path.
+# Not synchronised, and the reason is narrower than this comment used to claim. Callers hold the index's
+# `flock` *when locking is available*: `_exclusive_index_lock` deliberately yields **unlocked** when
+# `fcntl` is missing, and when `flock` fails with a locking-unsupported errno such as `ENOLCK` or
+# `EOPNOTSUPP` -- on those filesystems two hosts reach this set with nothing serialising them. Within one
+# process the writer is still a sequential batch loop and the resource-monitor thread never touches it.
+#
+# The check-then-add is therefore formally racy in more situations than "not at all", and it stays
+# unsynchronised anyway: a 64-thread stress probe produced exactly one warning, and the worst case in
+# every case is a duplicated or missing *warning*, never a correctness path. Stated properly because the
+# false version of it -- "every production caller holds the lock" -- is what a future reader would rely
+# on when deciding whether a lock is needed here.
 _DEGRADED_TARGETS: set[tuple[str, object]] = set()
 
 
@@ -1161,7 +1168,9 @@ def _fsync_directory(directory: Path) -> _DirectoryFlush:
     raising would turn a landed update into an error. But the outcome cannot be *dropped* either: the
     caller records a digest next, and a digest recorded for a rename that never reached the disk is
     precisely the wedge this function exists to prevent. :func:`update_signal_index` decides what to
-    do with each outcome; the two failures are kept distinct because they warrant different answers.
+    do with each outcome; the three failures are kept distinct because they warrant different answers --
+    an unreadable directory names a repair, an unsupported platform names none, and a refusing filesystem
+    names a different one.
 
     Args:
         directory: Directory whose entries should be flushed.


### PR DESCRIPTION
## 📝 Summary

Two stale comments in the index-durability code, both found by a reviewer while reviewing an unrelated
branch and filed separately rather than ridden in on it.

**The `_DEGRADED_TARGETS` note claimed every production caller holds the index's `flock`.** It does not:
`_exclusive_index_lock` deliberately yields **unlocked** when `fcntl` is missing, and when `flock` fails
with a locking-unsupported errno such as `ENOLCK` or `EOPNOTSUPP` — so on those filesystems two hosts
reach that set with nothing serialising them. The conclusion is unchanged (the worst case is a duplicated
or missing *warning*, never a correctness path) but the justification was false, and it is the
justification a future reader would rely on when deciding whether a lock belongs there.

**`_fsync_directory`'s docstring still said "the two failures"** after the unopenable-directory case was
split into a permission failure and everything else. There are three, and each names a different repair.

Tier: **T1** (documentation). No code semantics change — see below.

## ✨ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🎨 Refactoring (no functional changes, no API changes)

## 🧪 How Has This Been Tested?

- [x] **Full suite:** `uv run pytest` — 1177 passed, 23 skipped.
- [x] **Mechanically confirmed prose-only**, rather than asserted: parsing this branch and `main`, then
      stripping comments *and* docstrings from both, yields identical ASTs. A T1 PR whose diff touches
      code semantics is the tier's own red flag, so it is checked instead of claimed.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation — this change *is* the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective — not applicable; a comment cannot be tested, and
      the AST comparison above is the evidence that nothing testable moved.
