### PR TITLE
test(e2e): record the compute device so one reference gates both

### DIFF
--- a/tests/e2e/matrix.py
+++ b/tests/e2e/matrix.py
@@ -73,9 +73,9 @@ E2E_MATRIX: tuple[MatrixEntry, ...] = (
             "`execution: batched` -- a segment's events generated in one call through "
             "gwmock-signal's batched entry point, then converted back to per-event chunks. "
             "Runs on whatever JAX backend is present, so this entry is CPU on a machine without one. "
-            "The references are device-independent by measurement, not by assumption: the whole matrix "
-            "was replayed on a CUDA host (RTX 5060 Ti) against these CPU-written references and every "
-            "entry passed, `argmax` included, which is compared exactly. Needs `ripplegw`"
+            "The references are device-independent by measurement, not by assumption: all eight stored "
+            "references were replayed on a CUDA host (RTX 5060 Ti) and matched, `argmax` included, which "
+            "is compared exactly. Needs `ripplegw`"
         ),
         requires=("ripplegw",),
     ),

--- a/tests/e2e/matrix.py
+++ b/tests/e2e/matrix.py
@@ -72,8 +72,10 @@ E2E_MATRIX: tuple[MatrixEntry, ...] = (
         covers=(
             "`execution: batched` -- a segment's events generated in one call through "
             "gwmock-signal's batched entry point, then converted back to per-event chunks. "
-            "Runs on whatever JAX backend is present, so this entry is CPU here; measured on an "
-            "RTX 2080 Ti, GPU and CPU agree far inside the gate. Needs `ripplegw`"
+            "Runs on whatever JAX backend is present, so this entry is CPU on a machine without one. "
+            "The references are device-independent by measurement, not by assumption: the whole matrix "
+            "was replayed on a CUDA host (RTX 5060 Ti) against these CPU-written references and every "
+            "entry passed, `argmax` included, which is compared exactly. Needs `ripplegw`"
         ),
         requires=("ripplegw",),
     ),

--- a/tests/e2e/reference_values.py
+++ b/tests/e2e/reference_values.py
@@ -233,15 +233,21 @@ def fingerprint() -> dict[str, str]:
 
 
 def _jax_device() -> str:
-    """Return the JAX backend this run will generate on, or why there is none.
+    """Return the device this run generates on.
 
-    ``"none"`` when JAX is absent, which is a real configuration here: the matrix entries that do not
-    need `ripplegw` run without it, and CI has a cell with no `jax` extra at all.
+    The device, not JAX's availability -- a distinction a reviewer had to draw. With no JAX installed the
+    numerics still run on the CPU, on the same device the references were written on, and the entries
+    that need `ripplegw` are skipped rather than run differently. Reporting "none" there described the
+    library instead of the hardware, so CI's no-`jax` cell read as a foreign environment for every
+    reference and silenced the bit-mismatch note on entries that never touch JAX.
+
+    ``"unavailable"`` stays its own state, because that environment is *broken* rather than CPU-only: a
+    CUDA plugin that raises has JAX-using entries failing, not falling back.
     """
     try:
         import jax
     except ImportError:
-        return "none"
+        return "cpu"
     try:
         return str(jax.default_backend())
     except Exception:  # pragma: no cover - a broken backend must not fail the comparison

--- a/tests/e2e/reference_values.py
+++ b/tests/e2e/reference_values.py
@@ -48,6 +48,39 @@ every machine, rather than one that is green only where the references happened 
 than on the data -- the reason sums were left out of the statistics in the first place, before it was
 added back to catch sign inversions. It stays as a diagnostic, where being sensitive is useful.
 
+**One reference, both devices -- and how that was established.** These references are written on a CPU,
+and the entries that generate through JAX (`execution: batched`, the ripple backend, the CW branch) run
+on a GPU wherever one is present. That makes "does the GPU still match?" a real question, and it is
+answered by replaying the matrix on a CUDA host rather than by argument:
+
+    # on a host with a CUDA-capable GPU and the `cuda` extra installed
+    uv run pytest -m e2e --no-cov tests/e2e/test_reference_values.py
+
+Done on 2026-08-09 against an RTX 5060 Ti (compute capability 12.0): **all nine runnable entries passed**
+against these CPU-written references, `argmax` included -- which is compared exactly, so the device
+difference moved no peak off its sample. An earlier measurement on an RTX 2080 Ti agreed. The delta
+itself was characterised separately as a global time shift of 2.3e-16 s, 3.16e-13 relative end to end.
+
+**Where the gate actually sits.** Two effects were measured against it, and it falls between them:
+
+===========================================================  ==========  =====================
+difference                                                   relative    against a 1e-06 gate
+===========================================================  ==========  =====================
+CPU to GPU, one Linux host                                   3.16e-13    passes, 3e6 to spare
+Linux/x86_64/py3.12 to Darwin/arm64/py3.13                   4.17e-06    **fails, by 4x**
+===========================================================  ==========  =====================
+
+So the tolerance is not simply loose: it admits the device difference and rejects a platform change. What
+it does *not* do is catch a GPU-specific regression smaller than about 1e-06, which is seven orders above
+the device difference -- passing the GPU replay says these references survive the device, not that the
+device is tightly watched.
+
+The macOS row is the reason this suite cannot be run green on an Apple machine against Linux-written
+references; it is a known gap rather than a fault in a particular entry.
+
+This check also cannot run in CI: GitHub-hosted runners have no GPU. Repeat it when the waveform path or
+the JAX dependency changes, rather than expecting it to guard every pull request.
+
 Note what the fingerprint deliberately does *not* include: package versions. A dependency bump
 changing a waveform is precisely what these references exist to surface, so putting versions in the
 gate would silently downgrade the very comparison that is wanted. Versions are recorded, and

--- a/tests/e2e/reference_values.py
+++ b/tests/e2e/reference_values.py
@@ -56,9 +56,11 @@ answered by replaying the matrix on a CUDA host rather than by argument:
     # on a host with a CUDA-capable GPU and the `cuda` extra installed
     uv run pytest -m e2e --no-cov tests/e2e/test_reference_values.py
 
-Done on 2026-08-09 against an RTX 5060 Ti (compute capability 12.0): **all nine runnable entries passed**
-against these CPU-written references, `argmax` included -- which is compared exactly, so the device
-difference moved no peak off its sample. An earlier measurement on an RTX 2080 Ti agreed. The delta
+Done on 2026-08-09 against an RTX 5060 Ti (compute capability 12.0): **all eight stored references
+matched**, `argmax` included -- which is compared exactly, so the device difference moved no peak off its
+sample. (The run reports "9 passed, 1 skipped": eight reference comparisons, plus the separate test that
+every runnable entry has a reference, with the gengli entry skipped. An earlier draft of this paragraph
+read that as nine entries, which a reviewer corrected.) An earlier measurement on an RTX 2080 Ti agreed. The delta
 itself was characterised separately as a global time shift of 2.3e-16 s, 3.16e-13 relative end to end.
 
 **Where the gate actually sits.** Two effects were measured against it, and it falls between them:
@@ -251,22 +253,24 @@ def _jax_device() -> str:
 def same_environment(stored: dict[str, str] | None, produced: dict[str, str] | None) -> bool:
     """Whether two fingerprints describe the same numerical environment.
 
-    Compared over the keys the *stored* record carries, not over both. References written before a
-    fingerprint key existed would otherwise all read as "different environment" the moment one is added,
-    silencing the bit-mismatch note for every one of them until they are regenerated -- and regenerating
-    eight references to teach them a key they will get anyway on their next legitimate update is the
-    wrong trade. A reference that does record `device` is held to it.
+    Every key, in both records. An earlier version compared only the keys the *stored* record carried, so
+    that references written before a key existed would keep behaving as they had -- and that defeated the
+    point of adding one: a CPU reference replayed on a GPU still counted as the same environment, and the
+    bit-mismatch note still blamed "references written somewhere subtly different" for the device. Both
+    reviewers caught it. A note that misattributes is worse than a note that is missing, and the
+    references now carry `device` anyway, so there is nothing to be compatible with.
 
     Args:
         stored: The fingerprint recorded with the reference, if any.
         produced: The fingerprint of this run, if any.
 
     Returns:
-        Whether every key the reference recorded matches this run.
+        Whether the two describe the same environment. A reference with no fingerprint at all is not the
+        same environment as anything, since there is nothing to compare.
     """
     if not stored or not produced:
         return False
-    return all(produced.get(key) == value for key, value in stored.items())
+    return stored == produced
 
 
 def _environment() -> dict[str, str]:

--- a/tests/e2e/reference_values.py
+++ b/tests/e2e/reference_values.py
@@ -187,7 +187,53 @@ def fingerprint() -> dict[str, str]:
         "system": platform.system(),
         "machine": platform.machine(),
         "python": ".".join(str(part) for part in sys.version_info[:2]),
+        # The compute device, because two runs on one machine can differ by it alone. `execution:
+        # batched` generates through JAX, so the same host produces different last bits on its CPU and
+        # its GPU -- measured end to end at 3.16e-13 relative, a global time shift of 2.3e-16 s, which is
+        # benign and far inside `STATISTIC_TOLERANCE`. Without this the two runs fingerprint identically
+        # and the bit-mismatch note below blames "references written somewhere subtly different" for what
+        # is simply the other device.
+        "device": _jax_device(),
     }
+
+
+def _jax_device() -> str:
+    """Return the JAX backend this run will generate on, or why there is none.
+
+    ``"none"`` when JAX is absent, which is a real configuration here: the matrix entries that do not
+    need `ripplegw` run without it, and CI has a cell with no `jax` extra at all.
+    """
+    try:
+        import jax
+    except ImportError:
+        return "none"
+    try:
+        return str(jax.default_backend())
+    except Exception:  # pragma: no cover - a broken backend must not fail the comparison
+        # A CUDA plugin that cannot see a supported GPU raises rather than falling back, and that is
+        # worth recording as its own state instead of crashing a test run that would otherwise pass.
+        return "unavailable"
+
+
+def same_environment(stored: dict[str, str] | None, produced: dict[str, str] | None) -> bool:
+    """Whether two fingerprints describe the same numerical environment.
+
+    Compared over the keys the *stored* record carries, not over both. References written before a
+    fingerprint key existed would otherwise all read as "different environment" the moment one is added,
+    silencing the bit-mismatch note for every one of them until they are regenerated -- and regenerating
+    eight references to teach them a key they will get anyway on their next legitimate update is the
+    wrong trade. A reference that does record `device` is held to it.
+
+    Args:
+        stored: The fingerprint recorded with the reference, if any.
+        produced: The fingerprint of this run, if any.
+
+    Returns:
+        Whether every key the reference recorded matches this run.
+    """
+    if not stored or not produced:
+        return False
+    return all(produced.get(key) == value for key, value in stored.items())
 
 
 def _environment() -> dict[str, str]:

--- a/tests/e2e/references/default_config.json
+++ b/tests/e2e/references/default_config.json
@@ -15,6 +15,7 @@
     "scipy": "1.18.0"
   },
   "fingerprint": {
+    "device": "cpu",
     "machine": "x86_64",
     "python": "3.12",
     "system": "Linux"

--- a/tests/e2e/references/noise__uncorrelated_gaussian__et_triangle_sardinia.json
+++ b/tests/e2e/references/noise__uncorrelated_gaussian__et_triangle_sardinia.json
@@ -15,6 +15,7 @@
     "scipy": "1.18.0"
   },
   "fingerprint": {
+    "device": "cpu",
     "machine": "x86_64",
     "python": "3.12",
     "system": "Linux"

--- a/tests/e2e/references/noise__uncorrelated_gaussian__quick_start.json
+++ b/tests/e2e/references/noise__uncorrelated_gaussian__quick_start.json
@@ -15,6 +15,7 @@
     "scipy": "1.18.0"
   },
   "fingerprint": {
+    "device": "cpu",
     "machine": "x86_64",
     "python": "3.12",
     "system": "Linux"

--- a/tests/e2e/references/signal__bbh__et_triangle_sardinia.json
+++ b/tests/e2e/references/signal__bbh__et_triangle_sardinia.json
@@ -15,6 +15,7 @@
     "scipy": "1.18.0"
   },
   "fingerprint": {
+    "device": "cpu",
     "machine": "x86_64",
     "python": "3.12",
     "system": "Linux"

--- a/tests/e2e/references/signal__cw__et_triangle_sardinia.json
+++ b/tests/e2e/references/signal__cw__et_triangle_sardinia.json
@@ -15,6 +15,7 @@
     "scipy": "1.18.0"
   },
   "fingerprint": {
+    "device": "cpu",
     "machine": "x86_64",
     "python": "3.12",
     "system": "Linux"

--- a/tests/e2e/references/signal__execution__batched.json
+++ b/tests/e2e/references/signal__execution__batched.json
@@ -15,6 +15,7 @@
     "scipy": "1.18.0"
   },
   "fingerprint": {
+    "device": "cpu",
     "machine": "x86_64",
     "python": "3.12",
     "system": "Linux"

--- a/tests/e2e/references/signal__sgwb__et_triangle_sardinia.json
+++ b/tests/e2e/references/signal__sgwb__et_triangle_sardinia.json
@@ -15,6 +15,7 @@
     "scipy": "1.18.0"
   },
   "fingerprint": {
+    "device": "cpu",
     "machine": "x86_64",
     "python": "3.12",
     "system": "Linux"

--- a/tests/e2e/references/signal__waveform_backend__ripple.json
+++ b/tests/e2e/references/signal__waveform_backend__ripple.json
@@ -15,6 +15,7 @@
     "scipy": "1.18.0"
   },
   "fingerprint": {
+    "device": "cpu",
     "machine": "x86_64",
     "python": "3.12",
     "system": "Linux"

--- a/tests/e2e/test_fingerprint.py
+++ b/tests/e2e/test_fingerprint.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import pytest
 
+from . import reference_values
 from .reference_values import fingerprint, same_environment
 
 pytestmark = pytest.mark.unit
@@ -78,14 +79,34 @@ class TestFingerprint:
         assert "device" in fingerprint()
 
     def test_the_device_is_one_of_the_states_the_docstring_names(self) -> None:
-        """`none` and `unavailable` are real states, not defensive decoration.
+        """`unavailable` is a real state, not defensive decoration.
 
         `unavailable` was written for a CUDA plugin that raises rather than falling back, and a real
         host produced exactly that: CUDA jaxlib installed, with cards below the compute capability
         current JAX supports.
         """
         device = fingerprint()["device"]
-        assert device in {"cpu", "gpu", "tpu", "none", "unavailable"}, device
+        assert device in {"cpu", "gpu", "tpu", "unavailable"}, device
+
+    def test_a_jax_less_environment_is_cpu_not_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Absent JAX still means the numerics ran on the CPU.
+
+        Reporting "none" described the library rather than the device, so CI's cell without the `jax`
+        extra read as a foreign environment against these CPU-written references -- silencing the
+        bit-mismatch note for the entries that never touch JAX in the first place. A reviewer drew the
+        distinction.
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _no_jax(name: str, *args: object, **kwargs: object) -> object:
+            if name == "jax":
+                raise ImportError("no jax here")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_jax)
+        assert reference_values._jax_device() == "cpu"
 
     def test_it_still_records_what_it_did_before(self) -> None:
         """The device is an addition; dropping a key would silently widen what compares equal."""

--- a/tests/e2e/test_fingerprint.py
+++ b/tests/e2e/test_fingerprint.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2026 Leuven Gravity Institute
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+"""What the reference fingerprint distinguishes, and what it therefore stops misreporting.
+
+These are plain functions, so they are unit tests rather than part of the ``e2e`` matrix: the matrix
+needs a full generation run, and none of that is required to check which environments compare equal.
+
+The behaviour is worth pinning because the failure it prevents is silent. A CPU-written reference
+replayed on a GPU produces different bytes -- measured on one host, all three output frames differ -- and
+without the device in the fingerprint the two environments compared equal, so the bit-mismatch note
+blamed "references written somewhere subtly different" for what was simply the other device.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .reference_values import fingerprint, same_environment
+
+pytestmark = pytest.mark.unit
+
+LINUX_CPU = {"system": "Linux", "machine": "x86_64", "python": "3.12", "device": "cpu"}
+
+
+class TestSameEnvironment:
+    """The comparison the bit-mismatch note depends on."""
+
+    def test_a_run_matches_itself(self) -> None:
+        assert same_environment(LINUX_CPU, dict(LINUX_CPU))
+
+    def test_a_cpu_reference_does_not_match_a_gpu_run(self) -> None:
+        """The case the device key exists for.
+
+        Both reviewers found this returning ``True`` when the comparison used only the stored record's
+        keys, which left the key inert for every reference in the tree and kept the misleading note.
+        """
+        assert not same_environment(LINUX_CPU, dict(LINUX_CPU, device="gpu"))
+
+    def test_an_unlabelled_reference_does_not_match_a_labelled_run(self) -> None:
+        """A reference predating the device key is not silently treated as matching.
+
+        Suppressing the note for such a reference is the intended cost: a note that misattributes is
+        worse than one that is missing, and every reference in the tree now carries the key anyway.
+        """
+        unlabelled = {key: value for key, value in LINUX_CPU.items() if key != "device"}
+        assert not same_environment(unlabelled, LINUX_CPU)
+
+    @pytest.mark.parametrize("key", ["system", "machine", "python", "device"])
+    def test_every_recorded_key_can_separate_two_environments(self, key: str) -> None:
+        """No key is decorative: each one alone makes the environments differ.
+
+        Without this a key could be added to the record and never consulted -- which is exactly what
+        happened to ``device`` before the comparison was made symmetric.
+        """
+        assert not same_environment(LINUX_CPU, dict(LINUX_CPU, **{key: "something-else"}))
+
+    def test_a_reference_without_a_fingerprint_matches_nothing(self) -> None:
+        """There is nothing to compare, so the honest answer is "not the same environment"."""
+        assert not same_environment(None, LINUX_CPU)
+        assert not same_environment({}, LINUX_CPU)
+        assert not same_environment(LINUX_CPU, None)
+
+
+class TestFingerprint:
+    """What a run records about itself."""
+
+    def test_it_records_the_device(self) -> None:
+        assert "device" in fingerprint()
+
+    def test_the_device_is_one_of_the_states_the_docstring_names(self) -> None:
+        """`none` and `unavailable` are real states, not defensive decoration.
+
+        `unavailable` was written for a CUDA plugin that raises rather than falling back, and a real
+        host produced exactly that: CUDA jaxlib installed, with cards below the compute capability
+        current JAX supports.
+        """
+        device = fingerprint()["device"]
+        assert device in {"cpu", "gpu", "tpu", "none", "unavailable"}, device
+
+    def test_it_still_records_what_it_did_before(self) -> None:
+        """The device is an addition; dropping a key would silently widen what compares equal."""
+        assert set(fingerprint()) >= {"system", "machine", "python"}

--- a/tests/e2e/test_reference_values.py
+++ b/tests/e2e/test_reference_values.py
@@ -24,6 +24,7 @@ from .reference_values import (
     build_reference,
     describe_difference,
     load_reference,
+    same_environment,
     statistic_differences,
     write_reference,
     writing_references,
@@ -99,7 +100,9 @@ def test_the_output_matches_its_stored_reference(entry: MatrixEntry, completed_r
         for name in stored_outputs
         if stored_outputs[name]["content_hash"] == produced_outputs[name]["content_hash"]
     ]
-    if len(identical) != len(stored_outputs) and produced.get("fingerprint") == stored.get("fingerprint"):
+    if len(identical) != len(stored_outputs) and same_environment(
+        stored.get("fingerprint"), produced.get("fingerprint")
+    ):
         # Same environment, statistics agree, bits do not. Worth saying rather than passing in
         # silence: it is the signal that the references were written somewhere subtly different.
         print(


### PR DESCRIPTION
## 📝 Summary

The end-to-end references are written on a CPU, and the entries that generate through JAX
(`execution: batched`, the ripple backend, the CW branch) run on a GPU wherever one is present. Nothing
checked that the same references still hold there, and nothing recorded which device produced them.

**The device is now part of the fingerprint.** Without it a CPU and a GPU run on one host compared as the
same environment, so the bit-mismatch note blamed "references written somewhere subtly different" for
what was simply the other device. `same_environment` compares whole fingerprints, and the eight stored
references record `device: cpu`.

That label is verified rather than assumed: a Linux/x86_64/py3.12 CPU run reproduces all eight
**bit-for-bit**, which a GPU-written reference could not do.

`_jax_device()` reports the *device*, not whether JAX is installed. With JAX absent the numerics still run
on the CPU — the same device these references were written on — so reporting "none" made CI's no-`jax`
cell read as a foreign environment and silenced the note for entries that never touch JAX.
`"unavailable"` remains its own state: a CUDA plugin that raises is a broken environment, not a CPU-only
one, and a real host produced exactly that (CUDA jaxlib installed, cards below the compute capability
current JAX supports).

Tier: **T2** — this decides what the reference comparison accepts.

## ✨ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 Refactoring (no functional changes, no API changes) — test infrastructure and its documentation

## 🧪 How Has This Been Tested?

- [x] **Unit tests:** 1189 passed with the `jax` extra, 1147 without it (the cell the `_jax_device` change
      concerns).
- [x] **New tests:** `tests/e2e/test_fingerprint.py`, 12 unit tests. The inert-key defect this branch
      fixes had no test at all; three mutations are killed — the comparison reverting to
      stored-keys-only, the device dropped from the record, a missing fingerprint counting as a match.
- [x] **On a CUDA host** (RTX 5060 Ti, compute capability 12.0, via HTCondor): all eight stored references
      matched, `argmax` included, which is compared exactly. Zero bit-mismatch notes, which is what
      whole-fingerprint comparison against `device: cpu` references should produce.
- [x] **The device is genuinely in the numerical path**, measured rather than assumed: the same entry
      generated on one host in two fresh processes, `JAX_PLATFORMS=cpu` against the GPU default, produces
      3 of 3 output frames differing.

**Where the gate sits**, measured on both sides:

| difference | relative | against the 1e-06 gate |
| --- | --- | --- |
| CPU to GPU, one Linux host | 3.16e-13 | passes, 3e6 to spare |
| Linux/x86_64/py3.12 to Darwin/arm64/py3.13 | 4.17e-06 | fails, by 4x |

So the tolerance admits a device change and rejects a platform one. **What this does not establish:** that
a GPU-specific regression smaller than ~1e-06 would be caught — seven orders above the device difference.
A direct pairwise comparison would close that; it needs a process per device and cannot run in CI, so it
is tracked separately rather than bolted on here.

## 🏗️ Checklist

- [x] My code follows the style guidelines of this project (PEP 8).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation — the module docstring records the procedure
      and the measurements.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of generated reference results across CPU and GPU environments.
  * Prevented comparisons when environment fingerprints are missing or differ, reducing misleading validation results.
  * Added clearer handling for unsupported or unavailable backend detection, including known macOS and CI limitations.

* **Tests**
  * Expanded coverage for environment fingerprint matching, device detection, and reference-result comparisons.
  * Updated reference metadata to include the execution device for more reliable validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->